### PR TITLE
feat: génération de programme sportif IA personnalisé

### DIFF
--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -334,15 +334,16 @@ export function CreateProgramPage() {
           </fieldset>
 
           <div>
-            <label htmlFor="objectif-detail" className="text-sm font-semibold text-heading mb-2 block">
-              Précise ton objectif (optionnel)
+            <label htmlFor="objectif-detail" className="text-sm font-semibold text-heading mb-1 block">
+              Dis-nous en plus
             </label>
+            <p className="text-xs text-muted mb-2">Plus tu précises, plus ton programme sera adapté.</p>
             <textarea
               id="objectif-detail"
               value={draft.objectif_detail}
               onChange={(e) => update('objectif_detail', e.target.value)}
               maxLength={300}
-              rows={2}
+              rows={3}
               placeholder="Ex : perdre 5kg avant l'été, pré-saison foot, programme en parallèle du basket pour performer le week-end..."
               className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint resize-none focus:outline-none focus:border-brand"
             />

--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -343,7 +343,7 @@ export function CreateProgramPage() {
               onChange={(e) => update('objectif_detail', e.target.value)}
               maxLength={300}
               rows={2}
-              placeholder="Ex : perdre 5kg avant l'été, reprendre après une blessure..."
+              placeholder="Ex : perdre 5kg avant l'été, pré-saison foot, programme en parallèle du basket pour performer le week-end..."
               className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint resize-none focus:outline-none focus:border-brand"
             />
           </div>

--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -1,0 +1,643 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useDocumentHead } from '../hooks/useDocumentHead.ts';
+import { useGenerateProgram } from '../hooks/useGenerateProgram.ts';
+import { useUserPrograms } from '../hooks/useUserPrograms.ts';
+import type {
+  ExperienceDuree,
+  FrequenceActuelle,
+  Materiel,
+  ProgramOnboardingInput,
+} from '../types/custom-program.ts';
+
+const DRAFT_KEY = 'wan-shape-create-program-draft';
+const MAX_ACTIVE = 3;
+
+const OBJECTIF_OPTIONS = [
+  { value: 'perte_poids', label: 'Perte de poids' },
+  { value: 'prise_muscle', label: 'Prise de muscle' },
+  { value: 'remise_forme', label: 'Remise en forme' },
+  { value: 'force', label: 'Force' },
+  { value: 'endurance', label: 'Endurance' },
+  { value: 'performance_sportive', label: 'Performance sportive' },
+  { value: 'bien_etre', label: 'Bien-être' },
+  { value: 'souplesse', label: 'Souplesse' },
+];
+
+const EXPERIENCE_OPTIONS: { value: ExperienceDuree; label: string; desc: string }[] = [
+  { value: 'debutant', label: 'Débutant', desc: 'Moins de 6 mois' },
+  { value: 'six_mois_deux_ans', label: '6 mois - 2 ans', desc: 'Pratique régulière' },
+  { value: 'plus_deux_ans', label: '+2 ans', desc: 'Expérimenté' },
+];
+
+const FREQUENCE_OPTIONS: { value: FrequenceActuelle; label: string }[] = [
+  { value: 'jamais', label: 'Jamais' },
+  { value: 'une_deux', label: '1-2x / sem' },
+  { value: 'trois_quatre', label: '3-4x / sem' },
+  { value: 'cinq_plus', label: '5+ / sem' },
+];
+
+const BLESSURE_OPTIONS = [
+  { value: 'genou', label: 'Genou' },
+  { value: 'dos', label: 'Dos / Lombaires' },
+  { value: 'epaule', label: 'Épaule' },
+  { value: 'cheville', label: 'Cheville' },
+  { value: 'poignet', label: 'Poignet' },
+  { value: 'cervicales', label: 'Cervicales' },
+  { value: 'hanche', label: 'Hanche' },
+  { value: 'autre', label: 'Autre' },
+];
+
+const MATERIEL_OPTIONS: { value: Materiel | 'salle'; label: string }[] = [
+  { value: 'poids_du_corps', label: 'Poids du corps' },
+  { value: 'halteres', label: 'Haltères' },
+  { value: 'barre_disques', label: 'Barre & disques' },
+  { value: 'kettlebell', label: 'Kettlebell' },
+  { value: 'elastiques', label: 'Élastiques' },
+  { value: 'banc', label: 'Banc' },
+  { value: 'barre_traction', label: 'Barre de traction' },
+  { value: 'trx', label: 'TRX / Sangles' },
+  { value: 'corde_a_sauter', label: 'Corde à sauter' },
+  { value: 'medecine_ball', label: 'Medicine ball' },
+  { value: 'salle', label: 'Salle de sport (machines)' },
+];
+
+const DUREE_OPTIONS: { value: 4 | 8 | 12; label: string; recommended?: boolean }[] = [
+  { value: 4, label: '4 semaines' },
+  { value: 8, label: '8 semaines', recommended: true },
+  { value: 12, label: '12 semaines' },
+];
+
+const LOADING_PHASES = [
+  { text: 'Analyse de ton profil...', duration: 5000 },
+  { text: 'Conception des séances...', duration: 20000 },
+  { text: 'Planification du calendrier...', duration: 10000 },
+  { text: 'Dernières vérifications...', duration: 10000 },
+];
+
+interface DraftState {
+  step: number;
+  objectifs: string[];
+  objectif_detail: string;
+  experience_duree: ExperienceDuree | '';
+  frequence_actuelle: FrequenceActuelle | '';
+  blessures: string[];
+  blessure_detail: string;
+  age: string;
+  sexe: string;
+  seances_par_semaine: number;
+  duree_seance_minutes: number;
+  materiel: (Materiel | 'salle')[];
+  materiel_detail: string;
+  duree_semaines: 4 | 8 | 12;
+}
+
+const DEFAULT_DRAFT: DraftState = {
+  step: 1,
+  objectifs: [],
+  objectif_detail: '',
+  experience_duree: '',
+  frequence_actuelle: '',
+  blessures: [],
+  blessure_detail: '',
+  age: '',
+  sexe: '',
+  seances_par_semaine: 3,
+  duree_seance_minutes: 45,
+  materiel: [],
+  materiel_detail: '',
+  duree_semaines: 8,
+};
+
+export function CreateProgramPage() {
+  useDocumentHead({ title: 'Créer mon programme — WAN SHAPE' });
+
+  const navigate = useNavigate();
+  const { generate, loading: generating, error: generateError } = useGenerateProgram();
+  const { programs: userPrograms, loading: programsLoading } = useUserPrograms();
+
+  const [draft, setDraft] = useState<DraftState>({ ...DEFAULT_DRAFT });
+  const [loadingPhase, setLoadingPhase] = useState(0);
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+
+  // Clear any stale draft on mount
+  useEffect(() => {
+    sessionStorage.removeItem(DRAFT_KEY);
+  }, []);
+
+  // Focus heading on step change
+  useEffect(() => {
+    stepHeadingRef.current?.focus();
+  }, [draft.step]);
+
+  // Loading phase animation
+  useEffect(() => {
+    if (!generating) {
+      setLoadingPhase(0);
+      return;
+    }
+
+    let elapsed = 0;
+    let phase = 0;
+    const interval = setInterval(() => {
+      elapsed += 1000;
+      let cumulative = 0;
+      for (let i = 0; i < LOADING_PHASES.length; i++) {
+        cumulative += LOADING_PHASES[i].duration;
+        if (elapsed < cumulative) { phase = i; break; }
+        if (i === LOADING_PHASES.length - 1) phase = i;
+      }
+      setLoadingPhase(phase);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [generating]);
+
+  // Prevent accidental close during generation
+  useEffect(() => {
+    if (!generating) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [generating]);
+
+  const update = useCallback(<K extends keyof DraftState>(key: K, value: DraftState[K]) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const toggleChip = <T extends string>(arr: T[], val: T, key: keyof DraftState) => {
+    const newArr = arr.includes(val) ? arr.filter((v) => v !== val) : [...arr, val];
+    update(key, newArr as DraftState[typeof key]);
+  };
+
+  const goToStep = (step: number) => update('step', step);
+
+  // Validation
+  const isStep1Valid = draft.objectifs.length > 0;
+  const isStep2Valid = draft.experience_duree !== '' && draft.frequence_actuelle !== '';
+  const isStep3Valid = draft.materiel.length > 0;
+
+  // Cap seances for beginners
+  const maxSeances = ['jamais', 'une_deux'].includes(draft.frequence_actuelle) ? 3 : 5;
+  const effectiveSeances = Math.min(draft.seances_par_semaine, maxSeances);
+
+  const handleSubmit = async () => {
+    if (!isStep3Valid) return;
+
+    // Build objectif_detail: append materiel_detail if present
+    let detailParts = draft.objectif_detail || '';
+    if (draft.materiel_detail) {
+      detailParts = detailParts
+        ? `${detailParts}\nMateriel supplementaire : ${draft.materiel_detail}`
+        : `Materiel supplementaire : ${draft.materiel_detail}`;
+    }
+    if (draft.materiel.includes('salle')) {
+      detailParts = detailParts
+        ? `${detailParts}\nAcces a une salle de sport avec machines.`
+        : 'Acces a une salle de sport avec machines.';
+    }
+
+    const input: ProgramOnboardingInput = {
+      objectifs: draft.objectifs,
+      objectif_detail: detailParts || undefined,
+      experience_duree: draft.experience_duree as ExperienceDuree,
+      frequence_actuelle: draft.frequence_actuelle as FrequenceActuelle,
+      blessures: draft.blessures.filter((b) => b !== 'autre'),
+      blessure_detail: draft.blessure_detail || undefined,
+      age: draft.age ? parseInt(draft.age) : undefined,
+      sexe: (draft.sexe as ProgramOnboardingInput['sexe']) || undefined,
+      seances_par_semaine: effectiveSeances,
+      duree_seance_minutes: draft.duree_seance_minutes,
+      materiel: (() => {
+        const filtered = draft.materiel.filter((m): m is Materiel => m !== 'salle');
+        // Si seulement "salle" est selectionne, on envoie l'equipement typique
+        if (filtered.length === 0 && draft.materiel.includes('salle'))
+          return ['halteres', 'barre_disques', 'banc', 'elastiques'] as Materiel[];
+        return filtered;
+      })(),
+      duree_semaines: draft.duree_semaines,
+    };
+
+    const result = await generate(input);
+    if (result) {
+      sessionStorage.removeItem(DRAFT_KEY);
+      navigate(`/programme/${result.slug}`);
+    }
+  };
+
+  // Check active programs limit
+  const atLimit = !programsLoading && userPrograms.length >= MAX_ACTIVE;
+
+  if (atLimit) {
+    return (
+      <div className="max-w-2xl mx-auto px-6 py-12 text-center space-y-6">
+        <div className="text-5xl">📋</div>
+        <h1 className="text-2xl font-bold text-heading">Limite atteinte</h1>
+        <p className="text-muted">
+          Tu as déjà {MAX_ACTIVE} programmes actifs. Supprime un programme existant pour en créer un nouveau.
+        </p>
+        <Link
+          to="/programmes"
+          className="inline-block cta-gradient px-8 py-3.5 rounded-full text-sm font-bold text-white"
+        >
+          Voir mes programmes
+        </Link>
+      </div>
+    );
+  }
+
+  // Loading overlay
+  if (generating) {
+    const progressPct = Math.min(95, ((loadingPhase + 1) / LOADING_PHASES.length) * 100);
+
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface/95 backdrop-blur-sm" role="status" aria-live="polite">
+        <div className="text-center space-y-6 px-6 max-w-sm">
+          <div className="w-12 h-12 border-3 border-divider-strong border-t-brand rounded-full animate-spin mx-auto" />
+          <p className="text-lg font-semibold text-heading">{LOADING_PHASES[loadingPhase].text}</p>
+          <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-brand to-brand-secondary transition-all duration-1000"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+          <p className="text-xs text-faint">Estimation : 30-60 secondes</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-8 pb-12">
+      {/* Step indicator */}
+      <nav aria-label={`Étape ${draft.step} sur 3`} className="flex items-center gap-1 mb-8">
+        {([
+          { n: 1, label: 'Objectif' },
+          { n: 2, label: 'Profil' },
+          { n: 3, label: 'Programme' },
+        ] as const).map(({ n, label }) => {
+          const canGo =
+            n < draft.step ||
+            (n === 2 && isStep1Valid) ||
+            (n === 3 && isStep1Valid && isStep2Valid);
+          return (
+            <button
+              key={n}
+              type="button"
+              onClick={() => canGo && goToStep(n)}
+              disabled={!canGo && n !== draft.step}
+              className={`flex-1 flex flex-col items-center gap-1 py-2 rounded-lg transition-colors ${
+                canGo || n === draft.step ? 'cursor-pointer' : 'cursor-default opacity-40'
+              }`}
+              aria-label={`Étape ${n} : ${label}`}
+              aria-current={n === draft.step ? 'step' : undefined}
+            >
+              <span className={`text-xs font-semibold ${n <= draft.step ? 'text-brand' : 'text-muted'}`}>
+                {label}
+              </span>
+              <span className={`w-full h-1.5 rounded-full transition-colors ${
+                n <= draft.step ? 'bg-brand' : 'bg-divider'
+              }`} />
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* Step 1 — Objectif */}
+      {draft.step === 1 && (
+        <div className="space-y-6">
+          <h1 ref={stepHeadingRef} tabIndex={-1} className="text-2xl sm:text-3xl font-bold text-heading outline-none">
+            Qu'est-ce qui te motive ?
+          </h1>
+
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Choisis tes objectifs</legend>
+            <div className="flex flex-wrap gap-2" role="group">
+              {OBJECTIF_OPTIONS.map((o) => (
+                <button
+                  key={o.value}
+                  type="button"
+                  onClick={() => toggleChip(draft.objectifs, o.value, 'objectifs')}
+                  aria-pressed={draft.objectifs.includes(o.value)}
+                  className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors cursor-pointer ${
+                    draft.objectifs.includes(o.value)
+                      ? 'border-brand bg-brand/10 text-brand'
+                      : 'border-divider text-muted hover:border-brand/30'
+                  }`}
+                >
+                  {o.label}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <div>
+            <label htmlFor="objectif-detail" className="text-sm font-semibold text-heading mb-2 block">
+              Précise ton objectif (optionnel)
+            </label>
+            <textarea
+              id="objectif-detail"
+              value={draft.objectif_detail}
+              onChange={(e) => update('objectif_detail', e.target.value)}
+              maxLength={300}
+              rows={2}
+              placeholder="Ex : perdre 5kg avant l'été, reprendre après une blessure..."
+              className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint resize-none focus:outline-none focus:border-brand"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={() => goToStep(2)}
+            disabled={!isStep1Valid}
+            className="cta-gradient w-full py-4 rounded-xl text-sm font-bold text-white tracking-wide cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Suivant
+          </button>
+        </div>
+      )}
+
+      {/* Step 2 — Situation */}
+      {draft.step === 2 && (
+        <div className="space-y-6">
+          <h1 ref={stepHeadingRef} tabIndex={-1} className="text-2xl sm:text-3xl font-bold text-heading outline-none">
+            Parle-nous de toi
+          </h1>
+
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Expérience sportive</legend>
+            <div className="grid grid-cols-3 gap-3">
+              {EXPERIENCE_OPTIONS.map((e) => (
+                <button
+                  key={e.value}
+                  type="button"
+                  onClick={() => update('experience_duree', e.value)}
+                  className={`px-3 py-3 rounded-xl border text-center transition-colors cursor-pointer ${
+                    draft.experience_duree === e.value
+                      ? 'border-brand bg-brand/10'
+                      : 'border-divider hover:border-brand/30'
+                  }`}
+                >
+                  <span className="block text-sm font-semibold text-heading">{e.label}</span>
+                  <span className="block text-xs text-muted mt-0.5">{e.desc}</span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Fréquence actuelle</legend>
+            <div className="grid grid-cols-2 gap-3">
+              {FREQUENCE_OPTIONS.map((f) => (
+                <button
+                  key={f.value}
+                  type="button"
+                  onClick={() => update('frequence_actuelle', f.value)}
+                  className={`px-3 py-3 rounded-xl border text-center transition-colors cursor-pointer ${
+                    draft.frequence_actuelle === f.value
+                      ? 'border-brand bg-brand/10'
+                      : 'border-divider hover:border-brand/30'
+                  }`}
+                >
+                  <span className="text-sm font-semibold text-heading">{f.label}</span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Blessures / sensibilités</legend>
+            <div className="flex flex-wrap gap-2" role="group">
+              {BLESSURE_OPTIONS.map((b) => (
+                <button
+                  key={b.value}
+                  type="button"
+                  onClick={() => toggleChip(draft.blessures, b.value, 'blessures')}
+                  aria-pressed={draft.blessures.includes(b.value)}
+                  className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors cursor-pointer ${
+                    draft.blessures.includes(b.value)
+                      ? 'border-brand bg-brand/10 text-brand'
+                      : 'border-divider text-muted hover:border-brand/30'
+                  }`}
+                >
+                  {b.label}
+                </button>
+              ))}
+            </div>
+            {draft.blessures.includes('autre') && (
+              <input
+                type="text"
+                value={draft.blessure_detail}
+                onChange={(e) => update('blessure_detail', e.target.value)}
+                maxLength={300}
+                placeholder="Précise ta blessure..."
+                className="mt-3 w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint focus:outline-none focus:border-brand"
+              />
+            )}
+          </fieldset>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="age" className="text-sm font-semibold text-heading mb-2 block">
+                Age (optionnel)
+              </label>
+              <input
+                id="age"
+                type="number"
+                min={14}
+                max={99}
+                value={draft.age}
+                onChange={(e) => update('age', e.target.value)}
+                placeholder="Ex : 30"
+                className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint focus:outline-none focus:border-brand"
+              />
+            </div>
+            <div>
+              <label htmlFor="sexe" className="text-sm font-semibold text-heading mb-2 block">
+                Sexe (optionnel)
+              </label>
+              <select
+                id="sexe"
+                value={draft.sexe}
+                onChange={(e) => update('sexe', e.target.value)}
+                className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading focus:outline-none focus:border-brand"
+              >
+                <option value="">-</option>
+                <option value="homme">Homme</option>
+                <option value="femme">Femme</option>
+                <option value="autre">Autre</option>
+              </select>
+            </div>
+          </div>
+
+          <p className="text-xs text-faint">
+            Ces infos permettent d'affiner le programme — elles restent privées.
+          </p>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => goToStep(1)}
+              className="flex-1 py-4 rounded-xl text-sm font-bold border border-divider text-muted hover:text-heading transition-colors cursor-pointer"
+            >
+              Retour
+            </button>
+            <button
+              type="button"
+              onClick={() => goToStep(3)}
+              disabled={!isStep2Valid}
+              className="flex-1 cta-gradient py-4 rounded-xl text-sm font-bold text-white tracking-wide cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Suivant
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3 — Programme */}
+      {draft.step === 3 && (
+        <div className="space-y-6">
+          <h1 ref={stepHeadingRef} tabIndex={-1} className="text-2xl sm:text-3xl font-bold text-heading outline-none">
+            Configure ton programme
+          </h1>
+
+          {/* Seances par semaine */}
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-2">Séances par semaine</legend>
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => update('seances_par_semaine', Math.max(2, effectiveSeances - 1))}
+                disabled={effectiveSeances <= 2}
+                className="w-10 h-10 rounded-full border border-divider text-heading font-bold text-lg flex items-center justify-center cursor-pointer hover:border-brand/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                &minus;
+              </button>
+              <span className="text-2xl font-bold text-heading tabular-nums min-w-[3rem] text-center">
+                {effectiveSeances}
+              </span>
+              <button
+                type="button"
+                onClick={() => update('seances_par_semaine', Math.min(maxSeances, effectiveSeances + 1))}
+                disabled={effectiveSeances >= maxSeances}
+                className="w-10 h-10 rounded-full border border-divider text-heading font-bold text-lg flex items-center justify-center cursor-pointer hover:border-brand/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                +
+              </button>
+            </div>
+            {maxSeances < 5 && (
+              <p className="text-xs text-faint mt-1">Adapté à ton rythme actuel</p>
+            )}
+          </fieldset>
+
+          {/* Duree par seance */}
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-2">Durée par séance</legend>
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => update('duree_seance_minutes', Math.max(30, draft.duree_seance_minutes - 5))}
+                disabled={draft.duree_seance_minutes <= 30}
+                className="w-10 h-10 rounded-full border border-divider text-heading font-bold text-lg flex items-center justify-center cursor-pointer hover:border-brand/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                &minus;
+              </button>
+              <span className="text-2xl font-bold text-heading tabular-nums min-w-[5rem] text-center">
+                {draft.duree_seance_minutes}<span className="text-sm font-medium text-muted ml-1">min</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => update('duree_seance_minutes', Math.min(75, draft.duree_seance_minutes + 5))}
+                disabled={draft.duree_seance_minutes >= 75}
+                className="w-10 h-10 rounded-full border border-divider text-heading font-bold text-lg flex items-center justify-center cursor-pointer hover:border-brand/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                +
+              </button>
+            </div>
+          </fieldset>
+
+          {/* Materiel */}
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Matériel disponible</legend>
+            <div className="flex flex-wrap gap-2" role="group">
+              {MATERIEL_OPTIONS.map((m) => (
+                <button
+                  key={m.value}
+                  type="button"
+                  onClick={() => toggleChip(draft.materiel, m.value, 'materiel')}
+                  aria-pressed={draft.materiel.includes(m.value)}
+                  className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors cursor-pointer ${
+                    draft.materiel.includes(m.value)
+                      ? 'border-brand bg-brand/10 text-brand'
+                      : 'border-divider text-muted hover:border-brand/30'
+                  }`}
+                >
+                  {m.label}
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={draft.materiel_detail}
+              onChange={(e) => update('materiel_detail', e.target.value)}
+              maxLength={100}
+              placeholder="Autre matériel ? (optionnel)"
+              className="mt-3 w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint focus:outline-none focus:border-brand"
+            />
+          </fieldset>
+
+          {/* Duree programme */}
+          <fieldset>
+            <legend className="text-sm font-semibold text-heading mb-3">Durée du programme</legend>
+            <div className="grid grid-cols-3 gap-3">
+              {DUREE_OPTIONS.map((d) => (
+                <button
+                  key={d.value}
+                  type="button"
+                  onClick={() => update('duree_semaines', d.value)}
+                  className={`px-3 py-3 rounded-xl border text-center transition-colors cursor-pointer relative ${
+                    draft.duree_semaines === d.value
+                      ? 'border-brand bg-brand/10'
+                      : 'border-divider hover:border-brand/30'
+                  }`}
+                >
+                  <span className="text-sm font-semibold text-heading">{d.label}</span>
+                  {d.recommended && (
+                    <span className="block text-xs text-brand mt-0.5">Recommandé</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Error */}
+          {generateError && (
+            <div className="p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+              {generateError}
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => goToStep(2)}
+              className="flex-1 py-4 rounded-xl text-sm font-bold border border-divider text-muted hover:text-heading transition-colors cursor-pointer"
+            >
+              Retour
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!isStep3Valid || generating}
+              className="flex-1 cta-gradient py-4 rounded-xl text-sm font-bold text-white tracking-wide cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Générer mon programme
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -246,6 +246,34 @@ function ConnectedContent({
         </Link>
       )}
 
+      {/* Custom program CTA */}
+      {FEATURE_CUSTOM_SESSION && (
+        <Link
+          to="/programme/creer"
+          className="flex items-center gap-3 glass-card rounded-xl px-4 py-3 group transition-colors hover:border-brand/30 cursor-pointer"
+        >
+          <span className="text-lg shrink-0" role="img" aria-label="Programme personnalisé">
+            🏋️
+          </span>
+          <span className="text-sm text-subtle group-hover:text-heading transition-colors">
+            Crée un programme sur-mesure avec l'IA
+          </span>
+          <svg
+            aria-hidden="true"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="text-muted ml-auto shrink-0"
+          >
+            <path d="M9 18l6-6-6-6" />
+          </svg>
+        </Link>
+      )}
+
       {/* Today */}
       <SessionCard
         session={session}

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -1,13 +1,18 @@
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
+import { FEATURE_CUSTOM_SESSION } from '../config/features.ts';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { usePrograms } from '../hooks/useProgram.ts';
+import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import { supabase } from '../lib/supabase.ts';
 import { ProgramCard } from './ProgramCard.tsx';
 
 export function ProgramList() {
   const { user } = useAuth();
   const { programs, loading } = usePrograms();
+  const { programs: userPrograms, loading: userLoading } = useUserPrograms();
+  const [searchParams] = useSearchParams();
+  const justDeleted = searchParams.get('deleted') === '1';
 
   useDocumentHead({
     title: 'Programmes',
@@ -28,27 +33,109 @@ export function ProgramList() {
         </p>
       </section>
 
-      {loading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="w-6 h-6 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+      {/* Deleted confirmation */}
+      {justDeleted && (
+        <div className="p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm text-center">
+          Programme supprimé. Ton historique de séances est conservé.
         </div>
       )}
 
-      {!loading && programs.length === 0 && (
-        <div className="text-center py-12">
-          <p className="text-muted">
-            {supabase ? 'Aucun programme disponible pour le moment.' : 'Service temporairement indisponible.'}
-          </p>
-        </div>
+      {/* My AI programs (feature-flagged, logged-in) */}
+      {FEATURE_CUSTOM_SESSION && user && (
+        <section className="space-y-4">
+          <h2 className="text-lg font-bold text-heading">Mes programmes</h2>
+
+          <Link
+            to="/programme/creer"
+            className="block w-full cta-gradient py-3.5 rounded-xl text-sm font-bold text-white text-center cursor-pointer"
+          >
+            Créer mon programme
+          </Link>
+
+          {userLoading && (
+            <div className="flex items-center justify-center py-6">
+              <div className="w-5 h-5 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+            </div>
+          )}
+
+          {!userLoading && userPrograms.length === 0 && (
+            <p className="text-sm text-muted text-center py-4">
+              Tu n'as pas encore de programme personnalisé.
+            </p>
+          )}
+
+          {!userLoading && userPrograms.length > 0 && (
+            <div className="space-y-3">
+              {userPrograms.map((p) => {
+                const goalLabel = p.goals?.[0] ?? '';
+                return (
+                  <Link
+                    key={p.id}
+                    to={`/programme/${p.slug}`}
+                    className="glass-card rounded-xl px-4 py-3 flex items-center gap-3 group transition-colors hover:border-brand/30 cursor-pointer"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-brand/15 flex items-center justify-center shrink-0">
+                      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+                        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+                      </svg>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-heading group-hover:text-brand transition-colors truncate">
+                        {p.title}
+                      </p>
+                      <p className="text-xs text-muted truncate">
+                        {goalLabel} · {p.duration_weeks} sem · {p.frequency_per_week}x/sem
+                      </p>
+                    </div>
+                    <svg
+                      aria-hidden="true"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      className="text-muted shrink-0"
+                    >
+                      <path d="M9 18l6-6-6-6" />
+                    </svg>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </section>
       )}
 
-      {!loading && programs.length > 0 && (
-        <div className="grid grid-cols-1 gap-5">
-          {programs.map((p) => (
-            <ProgramCard key={p.id} program={p} />
-          ))}
-        </div>
-      )}
+      {/* Fixed programs */}
+      <section className="space-y-4">
+        {FEATURE_CUSTOM_SESSION && user && (
+          <h2 className="text-lg font-bold text-heading">Programmes guidés</h2>
+        )}
+
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="w-6 h-6 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+          </div>
+        )}
+
+        {!loading && programs.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-muted">
+              {supabase ? 'Aucun programme disponible pour le moment.' : 'Service temporairement indisponible.'}
+            </p>
+          </div>
+        )}
+
+        {!loading && programs.length > 0 && (
+          <div className="grid grid-cols-1 gap-5">
+            {programs.map((p) => (
+              <ProgramCard key={p.id} program={p} />
+            ))}
+          </div>
+        )}
+      </section>
 
       {/* CTA for visitors */}
       {!user && supabase && !loading && programs.length > 0 && (

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -1,8 +1,10 @@
-import { Link, Navigate, useParams } from 'react-router';
+import { useEffect, useRef, useState } from 'react';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useHealthCheck } from '../hooks/useHealthCheck.ts';
 import { useProgram } from '../hooks/useProgram.ts';
+import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import type { Session } from '../types/session.ts';
 import { getProgramImage } from '../utils/programImage.ts';
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
@@ -20,16 +22,78 @@ const FITNESS_COLORS: Record<string, string> = {
   advanced: 'bg-red-500/30 text-red-200 border-red-400/40',
 };
 
+function getConsigneForWeek(consignes: Record<string, string> | null, week: number): string | null {
+  if (!consignes) return null;
+  for (const [range, text] of Object.entries(consignes)) {
+    const parts = range.split('-').map(Number);
+    if (parts.length === 1 && parts[0] === week) return text;
+    if (parts.length === 2 && week >= parts[0] && week <= parts[1]) return text;
+  }
+  return null;
+}
+
 export function ProgramPage() {
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
+  const navigate = useNavigate();
   const { program, loading } = useProgram(slug);
+  const { deleteProgram } = useUserPrograms();
   const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [collapsedWeeks, setCollapsedWeeks] = useState<Set<number>>(new Set());
+  const deleteDialogRef = useRef<HTMLDivElement>(null);
 
   useDocumentHead({
     title: program ? `${program.title} — Programme` : 'Programme',
     description: program?.description ?? undefined,
   });
+
+  const isCustom = program && !program.is_fixed;
+
+  // Determine current week based on completion progress
+  const totalSessions = program?.sessions.length ?? 0;
+  const completedCount = program?.sessions.filter((s) => program.completedSessionIds.has(s.id)).length ?? 0;
+  const progressPct = totalSessions > 0 ? Math.round((completedCount / totalSessions) * 100) : 0;
+  const nextSessionOrder = program?.sessions.find((s) => !program.completedSessionIds.has(s.id))?.session_order;
+
+  // Group sessions by week
+  const byWeek = new Map<number, NonNullable<typeof program>['sessions']>();
+  if (program) {
+    for (const s of program.sessions) {
+      if (!byWeek.has(s.week_number)) byWeek.set(s.week_number, []);
+      byWeek.get(s.week_number)!.push(s);
+    }
+  }
+
+  // Find current week (week containing next uncompleted session)
+  const currentWeek = program?.sessions.find((s) => s.session_order === nextSessionOrder)?.week_number ?? 1;
+
+  // Initialize collapsed weeks: future weeks collapsed by default for custom programs
+  useEffect(() => {
+    if (!program || !isCustom) return;
+    const weeks = [...byWeek.keys()];
+    const collapsed = new Set<number>();
+    for (const w of weeks) {
+      if (w > currentWeek) collapsed.add(w);
+    }
+    setCollapsedWeeks(collapsed);
+  }, [program?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Focus trap for delete modal
+  useEffect(() => {
+    if (!showDeleteModal) return;
+    const dialog = deleteDialogRef.current;
+    if (!dialog) return;
+    const focusable = dialog.querySelectorAll<HTMLElement>('button:not(:disabled)');
+    if (focusable.length > 0) focusable[0].focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setShowDeleteModal(false);
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [showDeleteModal]);
 
   if (!slug) return <Navigate to="/programmes" replace />;
 
@@ -52,52 +116,106 @@ export function ProgramPage() {
     );
   }
 
-  const totalSessions = program.sessions.length;
-  const completedCount = program.sessions.filter((s) => program.completedSessionIds.has(s.id)).length;
-  const progressPct = totalSessions > 0 ? Math.round((completedCount / totalSessions) * 100) : 0;
-
-  const nextSessionOrder = program.sessions.find((s) => !program.completedSessionIds.has(s.id))?.session_order;
-
-  // Group sessions by week
-  const byWeek = new Map<number, typeof program.sessions>();
-  for (const s of program.sessions) {
-    const week = s.week_number;
-    if (!byWeek.has(week)) byWeek.set(week, []);
-    byWeek.get(week)!.push(s);
-  }
-
   const handleStartSession = (order: number) => {
     guardNavigation(`/programme/${slug}/seance/${order}/play`);
+  };
+
+  const toggleWeek = (week: number) => {
+    setCollapsedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(week)) next.delete(week);
+      else next.add(week);
+      return next;
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!program) return;
+    setDeleting(true);
+    const ok = await deleteProgram(program.id);
+    setDeleting(false);
+    if (ok) {
+      navigate('/programmes?deleted=1');
+    }
   };
 
   return (
     <>
       {showDisclaimer && <HealthDisclaimer onAccept={acceptAndNavigate} onCancel={cancelDisclaimer} />}
 
+      {/* Delete modal */}
+      {showDeleteModal && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center p-4 pb-20 sm:pb-4 bg-black/50 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-program-title"
+          onClick={(e) => { if (e.target === e.currentTarget) setShowDeleteModal(false); }}
+        >
+          <div ref={deleteDialogRef} className="bg-white w-full max-w-sm rounded-2xl shadow-2xl p-6 space-y-4">
+            <h2 id="delete-program-title" className="text-lg font-bold text-gray-900">
+              Supprimer ce programme ?
+            </h2>
+            <p className="text-sm text-gray-600">
+              Ton historique de séances sera conservé. Cette action est irréversible.
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteModal(false)}
+                className="flex-1 py-3 rounded-xl text-sm font-semibold border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex-1 py-3 rounded-xl text-sm font-semibold bg-red-500 text-white hover:bg-red-600 transition-colors cursor-pointer disabled:opacity-50"
+              >
+                {deleting ? 'Suppression...' : 'Supprimer'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="max-w-3xl mx-auto px-6 py-8 space-y-8">
-        {/* Hero image */}
+        {/* Hero */}
         <section className="space-y-5 -mx-6 -mt-8 md:mx-0 md:mt-0">
           <div className="relative min-h-[220px] sm:min-h-[280px] md:rounded-2xl overflow-hidden">
-            <img
-              src={getProgramImage(program.slug)}
-              alt=""
-              className="absolute inset-0 w-full h-full object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/75" />
+            {isCustom ? (
+              <div className="absolute inset-0 bg-gradient-to-br from-brand/30 via-surface to-brand-secondary/20" />
+            ) : (
+              <>
+                <img
+                  src={getProgramImage(program.slug)}
+                  alt=""
+                  className="absolute inset-0 w-full h-full object-cover"
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/75" />
+              </>
+            )}
 
             <div className="relative z-10 flex flex-col justify-between min-h-[220px] sm:min-h-[280px] p-6">
-              {/* Back link */}
-              <Link
-                to="/programmes"
-                className="inline-flex items-center gap-1.5 text-sm text-white/60 hover:text-white transition-colors cursor-pointer w-fit"
-              >
-                <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M15 18l-6-6 6-6" />
-                </svg>
-                Programmes
-              </Link>
+              <div className="flex items-start justify-between">
+                <Link
+                  to="/programmes"
+                  className="inline-flex items-center gap-1.5 text-sm text-white/60 hover:text-white transition-colors cursor-pointer w-fit"
+                >
+                  <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <path d="M15 18l-6-6 6-6" />
+                  </svg>
+                  Programmes
+                </Link>
 
-              {/* Info */}
+                {isCustom && (
+                  <span className="text-xs font-bold px-3 py-1.5 rounded-full bg-brand/20 border border-brand/30 text-brand backdrop-blur-sm">
+                    Programme IA
+                  </span>
+                )}
+              </div>
+
               <div className="space-y-3">
                 <span
                   className={`text-xs font-bold px-3 py-1.5 rounded-full border inline-block backdrop-blur-sm ${
@@ -107,15 +225,15 @@ export function ProgramPage() {
                   {FITNESS_LABELS[program.fitness_level] ?? program.fitness_level}
                 </span>
 
-                <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-white">
+                <h1 className={`text-3xl md:text-4xl font-extrabold tracking-tight ${isCustom ? 'text-heading' : 'text-white'}`}>
                   {program.title}
                 </h1>
 
                 {program.description && (
-                  <p className="text-sm text-white/70 leading-relaxed">{program.description}</p>
+                  <p className={`text-sm leading-relaxed ${isCustom ? 'text-muted' : 'text-white/70'}`}>{program.description}</p>
                 )}
 
-                <div className="flex items-center gap-3 text-xs text-white/50">
+                <div className={`flex items-center gap-3 text-xs ${isCustom ? 'text-faint' : 'text-white/50'}`}>
                   <span className="flex items-center gap-1.5">
                     <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
@@ -138,7 +256,11 @@ export function ProgramPage() {
                     {program.goals.map((goal) => (
                       <li
                         key={goal}
-                        className="text-xs font-medium px-2.5 py-1 rounded-full bg-white/10 border border-white/15 text-white/70"
+                        className={`text-xs font-medium px-2.5 py-1 rounded-full border ${
+                          isCustom
+                            ? 'bg-white/5 border-divider text-muted'
+                            : 'bg-white/10 border-white/15 text-white/70'
+                        }`}
                       >
                         {goal}
                       </li>
@@ -150,11 +272,11 @@ export function ProgramPage() {
           </div>
         </section>
 
-        {/* Auth gate for non-connected users */}
+        {/* Auth gate */}
         {!user && (
           <div className="glass-card rounded-2xl p-6 text-center space-y-4">
             <p className="text-sm text-subtle">
-              Connectez-vous pour suivre ce programme et enregistrer votre progression.
+              Connecte-toi pour suivre ce programme et enregistrer ta progression.
             </p>
             <Link to="/login" className="inline-block cta-gradient px-8 py-3.5 rounded-full text-sm font-bold text-white cursor-pointer">
               Se connecter
@@ -162,7 +284,7 @@ export function ProgramPage() {
           </div>
         )}
 
-        {/* Progress bar (logged-in only) */}
+        {/* Progress bar */}
         {user && totalSessions > 0 && (
           <div className="glass-card rounded-2xl p-5 space-y-3">
             <div className="flex items-center justify-between text-sm">
@@ -180,95 +302,162 @@ export function ProgramPage() {
           </div>
         )}
 
+        {/* Note coach */}
+        {isCustom && program.note_coach && (
+          <div className="glass-card rounded-2xl p-5 border-l-4 border-l-brand space-y-2">
+            <h2 className="text-sm font-bold text-heading">Note du coach</h2>
+            <p className="text-sm text-subtle leading-relaxed">{program.note_coach}</p>
+          </div>
+        )}
+
         {/* Sessions by week */}
-        {[...byWeek.entries()].map(([week, sessions]) => (
-          <section key={week} className="space-y-3">
-            <h2 className="text-sm font-bold uppercase tracking-wider text-subtle">Semaine {week}</h2>
-            <div className="space-y-3">
-              {sessions.map((ps) => {
-                const data = ps.session_data as unknown as Session;
-                const isDone = user ? program.completedSessionIds.has(ps.id) : false;
-                const isSuggested = user && ps.session_order === nextSessionOrder;
+        {[...byWeek.entries()].map(([week, sessions]) => {
+          const isCollapsed = collapsedWeeks.has(week);
+          const consigne = isCustom ? getConsigneForWeek(program.consignes_semaine, week) : null;
 
-                return (
-                  <div
-                    key={ps.id}
-                    className={`glass-card rounded-2xl overflow-hidden transition-all ${
-                      isSuggested ? 'border-brand/30 ring-1 ring-brand/10' : ''
-                    } ${isDone ? 'opacity-60' : ''}`}
+          return (
+            <section key={week} className="space-y-3">
+              <button
+                type="button"
+                onClick={() => isCustom && toggleWeek(week)}
+                className={`flex items-center gap-2 w-full text-left ${isCustom ? 'cursor-pointer' : ''}`}
+              >
+                <h2 className="text-sm font-bold uppercase tracking-wider text-subtle">Semaine {week}</h2>
+                {isCustom && (
+                  <svg
+                    aria-hidden="true"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    className={`text-faint transition-transform ${isCollapsed ? '' : 'rotate-180'}`}
                   >
-                    {/* Session header */}
-                    <div className="p-5 flex items-center gap-4">
-                      {/* Status indicator */}
+                    <path d="M6 9l6 6 6-6" />
+                  </svg>
+                )}
+              </button>
+
+              {consigne && !isCollapsed && (
+                <p className="text-xs text-muted italic">{consigne}</p>
+              )}
+
+              {!isCollapsed && (
+                <div className="space-y-3">
+                  {sessions.map((ps) => {
+                    const data = ps.session_data as unknown as Session;
+                    const isDone = user ? program.completedSessionIds.has(ps.id) : false;
+                    const isSuggested = user && ps.session_order === nextSessionOrder;
+
+                    return (
                       <div
-                        className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold shrink-0 ${
-                          isDone
-                            ? 'bg-emerald-500/20 text-emerald-400'
-                            : isSuggested
-                              ? 'bg-brand/20 text-brand'
-                              : 'bg-white/5 text-muted'
-                        }`}
+                        key={ps.id}
+                        className={`glass-card rounded-2xl overflow-hidden transition-all ${
+                          isSuggested ? 'border-brand/30 ring-1 ring-brand/10' : ''
+                        } ${isDone ? 'opacity-60' : ''}`}
                       >
-                        {isDone ? (
-                          <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="20 6 9 17 4 12" />
-                          </svg>
-                        ) : (
-                          ps.session_order
-                        )}
-                      </div>
+                        <div className="p-5 flex items-center gap-4">
+                          <div
+                            className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold shrink-0 ${
+                              isDone
+                                ? 'bg-emerald-500/20 text-emerald-400'
+                                : isSuggested
+                                  ? 'bg-brand/20 text-brand'
+                                  : 'bg-white/5 text-muted'
+                            }`}
+                          >
+                            {isDone ? (
+                              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                                <polyline points="20 6 9 17 4 12" />
+                              </svg>
+                            ) : (
+                              ps.session_order
+                            )}
+                          </div>
 
-                      {/* Session info */}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="text-sm font-bold truncate text-heading">
-                          {data.title}
-                        </h3>
-                        <p className="text-xs text-muted truncate mt-0.5">{data.description}</p>
-                        <div className="flex items-center gap-2 mt-1.5 text-xs text-faint">
-                          <span>~{data.estimatedDuration} min</span>
-                          <span>·</span>
-                          <span>{data.blocks.length} blocs</span>
+                          <div className="flex-1 min-w-0">
+                            <h3 className="text-sm font-bold truncate text-heading">{data.title}</h3>
+                            <p className="text-xs text-muted truncate mt-0.5">{data.description}</p>
+                            <div className="flex items-center gap-2 mt-1.5 text-xs text-faint">
+                              <span>~{data.estimatedDuration} min</span>
+                              <span>·</span>
+                              <span>{data.blocks.length} blocs</span>
+                            </div>
+                          </div>
+
+                          {user && isSuggested && (
+                            <button
+                              type="button"
+                              onClick={() => handleStartSession(ps.session_order)}
+                              className="shrink-0 px-5 py-2.5 rounded-full text-sm font-bold cta-gradient text-white cursor-pointer"
+                            >
+                              {completedCount === 0 ? 'Commencer' : 'Continuer'}
+                            </button>
+                          )}
+                          {user && isDone && (
+                            <button
+                              type="button"
+                              onClick={() => handleStartSession(ps.session_order)}
+                              className="shrink-0 px-4 py-2 rounded-full text-xs font-bold bg-white/5 text-subtle hover:bg-white/10 transition-colors cursor-pointer"
+                            >
+                              Refaire
+                            </button>
+                          )}
+                          {user && !isSuggested && !isDone && (
+                            <button
+                              type="button"
+                              onClick={() => handleStartSession(ps.session_order)}
+                              className="shrink-0 px-4 py-2 rounded-full text-xs font-medium text-muted hover:text-subtle hover:bg-white/5 transition-colors cursor-pointer"
+                            >
+                              Lancer
+                            </button>
+                          )}
                         </div>
+
+                        <SessionAccordion session={data} />
                       </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+          );
+        })}
 
-                      {/* CTA */}
-                      {user && isSuggested && (
-                        <button
-                          type="button"
-                          onClick={() => handleStartSession(ps.session_order)}
-                          className="shrink-0 px-5 py-2.5 rounded-full text-sm font-bold cta-gradient text-white cursor-pointer"
-                        >
-                          {completedCount === 0 ? 'Commencer' : 'Continuer'}
-                        </button>
-                      )}
-                      {user && isDone && (
-                        <button
-                          type="button"
-                          onClick={() => handleStartSession(ps.session_order)}
-                          className="shrink-0 px-4 py-2 rounded-full text-xs font-bold bg-white/5 text-subtle hover:bg-white/10 transition-colors cursor-pointer"
-                        >
-                          Refaire
-                        </button>
-                      )}
-                      {user && !isSuggested && !isDone && (
-                        <button
-                          type="button"
-                          onClick={() => handleStartSession(ps.session_order)}
-                          className="shrink-0 px-4 py-2 rounded-full text-xs font-medium text-muted hover:text-subtle hover:bg-white/5 transition-colors cursor-pointer"
-                        >
-                          Lancer
-                        </button>
-                      )}
-                    </div>
+        {/* Progression info */}
+        {isCustom && program.progression && (
+          <div className="glass-card rounded-2xl p-5 space-y-3">
+            <h2 className="text-sm font-bold text-heading">Logique de progression</h2>
+            <p className="text-sm text-subtle leading-relaxed">{program.progression.logique}</p>
+            {program.progression.cible_semaine_3 && (
+              <p className="text-xs text-muted">Semaine 3 : {program.progression.cible_semaine_3}</p>
+            )}
+            {program.progression.cible_semaine_6 && (
+              <p className="text-xs text-muted">Semaine 6 : {program.progression.cible_semaine_6}</p>
+            )}
+            {program.progression.cible_semaine_8 && (
+              <p className="text-xs text-muted">Semaine 8 : {program.progression.cible_semaine_8}</p>
+            )}
+            {program.progression.cible_semaine_12 && (
+              <p className="text-xs text-muted">Semaine 12 : {program.progression.cible_semaine_12}</p>
+            )}
+          </div>
+        )}
 
-                    {/* Accordion details */}
-                    <SessionAccordion session={data} />
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-        ))}
+        {/* Delete button for custom programs */}
+        {isCustom && user && program.user_id === user.id && (
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={() => setShowDeleteModal(true)}
+              className="text-xs text-faint hover:text-red-400 transition-colors cursor-pointer"
+            >
+              Supprimer ce programme
+            </button>
+          </div>
+        )}
 
         {/* Back link */}
         <div className="pt-4 border-t border-divider">

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -152,18 +152,18 @@ export function ProgramPage() {
           aria-labelledby="delete-program-title"
           onClick={(e) => { if (e.target === e.currentTarget) setShowDeleteModal(false); }}
         >
-          <div ref={deleteDialogRef} className="bg-white w-full max-w-sm rounded-2xl shadow-2xl p-6 space-y-4">
-            <h2 id="delete-program-title" className="text-lg font-bold text-gray-900">
+          <div ref={deleteDialogRef} className="bg-surface-card w-full max-w-sm rounded-2xl shadow-2xl border border-card-border p-6 space-y-4">
+            <h2 id="delete-program-title" className="text-lg font-bold text-heading">
               Supprimer ce programme ?
             </h2>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-muted">
               Ton historique de séances sera conservé. Cette action est irréversible.
             </p>
             <div className="flex gap-3">
               <button
                 type="button"
                 onClick={() => setShowDeleteModal(false)}
-                className="flex-1 py-3 rounded-xl text-sm font-semibold border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                className="flex-1 py-3 rounded-xl text-sm font-semibold border border-divider text-muted hover:text-heading transition-colors cursor-pointer"
               >
                 Annuler
               </button>
@@ -321,6 +321,7 @@ export function ProgramPage() {
                 type="button"
                 onClick={() => isCustom && toggleWeek(week)}
                 className={`flex items-center gap-2 w-full text-left ${isCustom ? 'cursor-pointer' : ''}`}
+                aria-expanded={isCustom ? !isCollapsed : undefined}
               >
                 <h2 className="text-sm font-bold uppercase tracking-wider text-subtle">Semaine {week}</h2>
                 {isCustom && (

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import { supabase } from '../lib/supabase.ts';
+import type { ProgramOnboardingInput, GenerateProgramResponse } from '../types/custom-program.ts';
+
+export function useGenerateProgram() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generate = useCallback(async (input: ProgramOnboardingInput): Promise<GenerateProgramResponse | null> => {
+    if (!supabase) {
+      setError('Service indisponible');
+      return null;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data, error: fnError } = await supabase.functions.invoke('generate-program', {
+        body: input,
+      });
+
+      if (fnError) {
+        let message = 'Une erreur est survenue. Reessaye.';
+        try {
+          const ctx = (fnError as Record<string, unknown>).context;
+          if (ctx && typeof (ctx as Response).json === 'function') {
+            const body = await (ctx as Response).json();
+            if (body?.error && typeof body.error === 'string') {
+              message = body.error;
+            }
+          }
+        } catch {
+          // Ignore parsing errors
+        }
+        setError(message);
+        return null;
+      }
+
+      if (data?.error) {
+        setError(data.error);
+        return null;
+      }
+
+      return data as GenerateProgramResponse;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inattendue');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { generate, loading, error };
+}

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -172,11 +172,11 @@ export function useProgram(slug: string | undefined) {
     (async () => {
       try {
         // Fetch program
+        // RLS handles access control (fixed programs + own programs)
         const { data: pgm } = await supabase
           .from('programs')
           .select('*')
           .eq('slug', slug)
-          .eq('is_fixed', true)
           .single();
 
         if (cancelled || !pgm) {
@@ -251,12 +251,11 @@ export function useProgramSession(slug: string | undefined, order: number | unde
 
     (async () => {
       try {
-        // Find program by slug
+        // Find program by slug (RLS handles access control)
         const { data: pgm } = await supabase
           .from('programs')
           .select('id')
           .eq('slug', slug)
-          .eq('is_fixed', true)
           .single();
 
         if (cancelled || !pgm) {

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import type { Program } from '../types/completion.ts';
+
+export function useUserPrograms() {
+  const { user } = useAuth();
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPrograms = useCallback(async () => {
+    if (!user || !supabase) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { data } = await supabase
+        .from('programs')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('is_fixed', false)
+        .order('created_at', { ascending: false });
+
+      setPrograms((data as Program[]) ?? []);
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchPrograms();
+  }, [fetchPrograms]);
+
+  const deleteProgram = useCallback(async (id: string) => {
+    if (!supabase) return false;
+
+    try {
+      const { error } = await supabase.from('programs').delete().eq('id', id);
+      if (error) {
+        console.error('Delete program error:', error);
+        return false;
+      }
+      setPrograms((prev) => prev.filter((p) => p.id !== id));
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  return { programs, loading, deleteProgram, refresh: fetchPrograms };
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -37,6 +37,9 @@ const LazyUpdatePasswordPage = lazy(() =>
 const LazyCustomSessionPage = lazy(() =>
   import('./components/CustomSessionPage.tsx').then((m) => ({ default: m.CustomSessionPage })),
 );
+const LazyCreateProgramPage = lazy(() =>
+  import('./components/CreateProgramPage.tsx').then((m) => ({ default: m.CreateProgramPage })),
+);
 const LazyCustomSessionPreviewPage = lazy(() =>
   import('./components/CustomSessionPreviewPage.tsx').then((m) => ({ default: m.CustomSessionPreviewPage })),
 );
@@ -175,6 +178,16 @@ export const router = createBrowserRouter([
                 <Lazy>
                   <RequireAuth>
                     <LazyCustomSessionPreviewPage />
+                  </RequireAuth>
+                </Lazy>
+              ),
+            },
+            {
+              path: 'programme/creer',
+              element: (
+                <Lazy>
+                  <RequireAuth>
+                    <LazyCreateProgramPage />
                   </RequireAuth>
                 </Lazy>
               ),

--- a/src/types/completion.ts
+++ b/src/types/completion.ts
@@ -20,6 +20,11 @@ export interface Program {
   fitness_level: 'beginner' | 'intermediate' | 'advanced';
   is_fixed: boolean;
   created_at: string;
+  user_id: string | null;
+  note_coach: string | null;
+  progression: import('./custom-program.ts').ProgramProgression | null;
+  consignes_semaine: Record<string, string> | null;
+  onboarding_data: import('./custom-program.ts').ProgramOnboardingInput | null;
 }
 
 export interface ProgramSession {

--- a/src/types/custom-program.ts
+++ b/src/types/custom-program.ts
@@ -1,0 +1,37 @@
+export type Materiel =
+  | 'poids_du_corps' | 'halteres' | 'barre_disques' | 'kettlebell'
+  | 'elastiques' | 'banc' | 'barre_traction' | 'trx'
+  | 'corde_a_sauter' | 'medecine_ball';
+
+export type ExperienceDuree = 'debutant' | 'six_mois_deux_ans' | 'plus_deux_ans';
+export type FrequenceActuelle = 'jamais' | 'une_deux' | 'trois_quatre' | 'cinq_plus';
+
+export interface ProgramOnboardingInput {
+  objectifs: string[];
+  objectif_detail?: string;
+  sport?: string;
+  jour_match?: string;
+  experience_duree: ExperienceDuree;
+  frequence_actuelle: FrequenceActuelle;
+  blessures: string[];
+  blessure_detail?: string;
+  age?: number;
+  sexe?: 'homme' | 'femme' | 'autre';
+  seances_par_semaine: number;
+  duree_seance_minutes: number;
+  materiel: Materiel[];
+  duree_semaines: 4 | 8 | 12;
+}
+
+export interface ProgramProgression {
+  logique: string;
+  cible_semaine_3?: string;
+  cible_semaine_6?: string;
+  cible_semaine_8?: string;
+  cible_semaine_12?: string;
+}
+
+export interface GenerateProgramResponse {
+  programId: string;
+  slug: string;
+}

--- a/src/types/custom-program.ts
+++ b/src/types/custom-program.ts
@@ -9,8 +9,6 @@ export type FrequenceActuelle = 'jamais' | 'une_deux' | 'trois_quatre' | 'cinq_p
 export interface ProgramOnboardingInput {
   objectifs: string[];
   objectif_detail?: string;
-  sport?: string;
-  jour_match?: string;
   experience_duree: ExperienceDuree;
   frequence_actuelle: FrequenceActuelle;
   blessures: string[];

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -39,11 +39,14 @@ function errorResponse(message: string, status = 400) {
   return jsonResponse({ error: message }, status);
 }
 
+const VALID_BLESSURES = [
+  'genou', 'dos', 'epaule', 'cheville', 'poignet', 'cervicales', 'hanche',
+];
+const VALID_SEXE = ['homme', 'femme', 'autre'];
+
 interface RequestInput {
   objectifs: string[];
   objectif_detail?: string;
-  sport?: string;
-  jour_match?: string;
   experience_duree: string;
   frequence_actuelle: string;
   blessures: string[];
@@ -85,6 +88,20 @@ function validateInput(body: RequestInput): string | null {
 
   if (body.blessures && !Array.isArray(body.blessures))
     return "blessures doit etre un tableau";
+  if (Array.isArray(body.blessures)) {
+    for (const b of body.blessures) {
+      if (!VALID_BLESSURES.includes(b)) return `Blessure invalide: ${b}`;
+    }
+  }
+
+  if (body.age !== undefined && body.age !== null) {
+    if (typeof body.age !== 'number' || body.age < 14 || body.age > 99)
+      return "age doit etre un nombre entre 14 et 99";
+  }
+
+  if (body.sexe !== undefined && body.sexe !== null && body.sexe !== '') {
+    if (!VALID_SEXE.includes(body.sexe)) return "sexe invalide";
+  }
 
   if (body.objectif_detail && typeof body.objectif_detail !== "string")
     return "objectif_detail doit etre une chaine";

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -1,0 +1,385 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
+import { validateProgram } from "./validate.ts";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const MAX_ACTIVE_PROGRAMS = 3;
+const MAX_DAILY_GENERATIONS = 3;
+const MODEL = "claude-sonnet-4-6";
+const MAX_TOKENS = 12288;
+
+const VALID_OBJECTIFS = [
+  'perte_poids', 'prise_muscle', 'remise_forme', 'force',
+  'endurance', 'performance_sportive', 'bien_etre', 'souplesse',
+];
+const VALID_EXPERIENCE = ['debutant', 'six_mois_deux_ans', 'plus_deux_ans'];
+const VALID_FREQUENCE = ['jamais', 'une_deux', 'trois_quatre', 'cinq_plus'];
+const VALID_MATERIEL = [
+  'poids_du_corps', 'halteres', 'barre_disques', 'kettlebell',
+  'elastiques', 'banc', 'barre_traction', 'trx',
+  'corde_a_sauter', 'medecine_ball',
+];
+const VALID_DUREES = [4, 8, 12];
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(message: string, status = 400) {
+  return jsonResponse({ error: message }, status);
+}
+
+interface RequestInput {
+  objectifs: string[];
+  objectif_detail?: string;
+  sport?: string;
+  jour_match?: string;
+  experience_duree: string;
+  frequence_actuelle: string;
+  blessures: string[];
+  blessure_detail?: string;
+  age?: number;
+  sexe?: string;
+  seances_par_semaine: number;
+  duree_seance_minutes: number;
+  materiel: string[];
+  duree_semaines: number;
+}
+
+function validateInput(body: RequestInput): string | null {
+  if (!Array.isArray(body.objectifs) || body.objectifs.length === 0)
+    return "Au moins un objectif requis";
+  for (const o of body.objectifs) {
+    if (!VALID_OBJECTIFS.includes(o)) return `Objectif invalide: ${o}`;
+  }
+
+  if (!VALID_EXPERIENCE.includes(body.experience_duree))
+    return "experience_duree invalide";
+  if (!VALID_FREQUENCE.includes(body.frequence_actuelle))
+    return "frequence_actuelle invalide";
+
+  if (!Array.isArray(body.materiel) || body.materiel.length === 0)
+    return "Au moins un type de materiel requis";
+  for (const m of body.materiel) {
+    if (!VALID_MATERIEL.includes(m)) return `Materiel invalide: ${m}`;
+  }
+
+  if (!body.seances_par_semaine || body.seances_par_semaine < 2 || body.seances_par_semaine > 5)
+    return "seances_par_semaine doit etre entre 2 et 5";
+
+  if (!body.duree_seance_minutes || body.duree_seance_minutes < 30 || body.duree_seance_minutes > 75)
+    return "duree_seance_minutes doit etre entre 30 et 75";
+
+  if (!VALID_DUREES.includes(body.duree_semaines))
+    return "duree_semaines doit etre 4, 8 ou 12";
+
+  if (body.blessures && !Array.isArray(body.blessures))
+    return "blessures doit etre un tableau";
+
+  if (body.objectif_detail && typeof body.objectif_detail !== "string")
+    return "objectif_detail doit etre une chaine";
+  if (body.objectif_detail && body.objectif_detail.length > 300)
+    return "objectif_detail: 300 caracteres max";
+
+  if (body.blessure_detail && typeof body.blessure_detail !== "string")
+    return "blessure_detail doit etre une chaine";
+  if (body.blessure_detail && body.blessure_detail.length > 300)
+    return "blessure_detail: 300 caracteres max";
+
+  return null;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function nanoid(size: number): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const bytes = crypto.getRandomValues(new Uint8Array(size));
+  return Array.from(bytes, (b) => chars[b % chars.length]).join('');
+}
+
+interface CalendrierEntry {
+  semaines: number[];
+  sequence: string[];
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  if (req.method !== "POST") {
+    return errorResponse("Method not allowed", 405);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return errorResponse("Missing authorization", 401);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const anthropicApiKey = Deno.env.get("ANTHROPIC_API_KEY");
+
+  if (!anthropicApiKey) {
+    return errorResponse("ANTHROPIC_API_KEY not configured", 500);
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  const supabaseAuth = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY")!, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+
+  if (authError || !user) {
+    return errorResponse("Non autorise", 401);
+  }
+
+  // Parse body
+  let body: RequestInput;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("JSON invalide");
+  }
+
+  // Validate input
+  const inputError = validateInput(body);
+  if (inputError) {
+    return errorResponse(inputError);
+  }
+
+  // Business rule: cap seances_par_semaine for beginners
+  if (['jamais', 'une_deux'].includes(body.frequence_actuelle) && body.seances_par_semaine > 3) {
+    body.seances_par_semaine = 3;
+  }
+
+  // Check active programs limit
+  const { count: activeCount, error: activeError } = await supabaseAdmin
+    .from("programs")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("is_fixed", false);
+
+  if (activeError) {
+    return errorResponse("Erreur serveur", 500);
+  }
+
+  if ((activeCount ?? 0) >= MAX_ACTIVE_PROGRAMS) {
+    return errorResponse(
+      `Limite atteinte : ${MAX_ACTIVE_PROGRAMS} programmes actifs maximum. Supprime un programme existant pour en creer un nouveau.`,
+      429,
+    );
+  }
+
+  // Rate limit: 3 generations / 24h
+  const { count: dailyCount, error: dailyError } = await supabaseAdmin
+    .from("programs")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("is_fixed", false)
+    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  if (dailyError) {
+    return errorResponse("Erreur serveur", 500);
+  }
+
+  if ((dailyCount ?? 0) >= MAX_DAILY_GENERATIONS) {
+    return errorResponse(
+      `Limite atteinte : ${MAX_DAILY_GENERATIONS} programmes par 24h. Reessaye plus tard.`,
+      429,
+    );
+  }
+
+  // Build prompt
+  const userPrompt = buildUserPrompt(body);
+
+  // Call Anthropic API
+  async function callAnthropic(extraMessages: { role: string; content: string }[] = []): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
+    const messages = [
+      { role: "user", content: userPrompt },
+      ...extraMessages,
+    ];
+
+    const aiResponse = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": anthropicApiKey!,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        messages,
+      }),
+    });
+
+    if (!aiResponse.ok) {
+      const errText = await aiResponse.text().catch(() => "Unknown error");
+      console.error("Anthropic API error:", aiResponse.status, errText);
+      throw new Error("Erreur de generation");
+    }
+
+    const aiData = await aiResponse.json();
+    const rawContent = aiData.content?.[0]?.text ?? "";
+
+    // Parse JSON (handle potential markdown wrapper)
+    const cleaned = rawContent
+      .replace(/^```json\s*/i, "")
+      .replace(/```\s*$/, "")
+      .trim();
+
+    const parsed = JSON.parse(cleaned);
+
+    return {
+      data: parsed,
+      inputTokens: aiData.usage?.input_tokens ?? 0,
+      outputTokens: aiData.usage?.output_tokens ?? 0,
+    };
+  }
+
+  let programJson: unknown;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+
+  // First attempt
+  try {
+    const result = await callAnthropic();
+    programJson = result.data;
+    totalInputTokens = result.inputTokens;
+    totalOutputTokens = result.outputTokens;
+  } catch {
+    return errorResponse("Erreur de communication avec l'IA", 502);
+  }
+
+  // Validate
+  let validation = validateProgram(programJson, body.duree_semaines, body.seances_par_semaine);
+
+  // Retry once if invalid
+  if (!validation.valid) {
+    console.error("First attempt validation failed:", validation.error);
+    try {
+      const retryResult = await callAnthropic([
+        { role: "assistant", content: JSON.stringify(programJson) },
+        { role: "user", content: `Ta reponse precedente etait invalide: ${validation.error}. Corrige et renvoie le JSON complet.` },
+      ]);
+      programJson = retryResult.data;
+      totalInputTokens += retryResult.inputTokens;
+      totalOutputTokens += retryResult.outputTokens;
+      validation = validateProgram(programJson, body.duree_semaines, body.seances_par_semaine);
+    } catch {
+      return errorResponse("La generation a echoue apres retry, reessayez", 502);
+    }
+
+    if (!validation.valid) {
+      console.error("Retry validation failed:", validation.error);
+      return errorResponse("Le programme genere est invalide, reessayez", 502);
+    }
+  }
+
+  const pgm = programJson as Record<string, unknown>;
+  const sessions = pgm.sessions as Record<string, Record<string, unknown>>;
+  const calendrier = pgm.calendrier as CalendrierEntry[];
+
+  // Generate slug
+  const baseSlug = slugify(pgm.titre as string) || 'programme';
+  const slug = `${baseSlug}-${nanoid(6)}`;
+
+  // Map niveau to fitness_level
+  const niveauMap: Record<string, string> = {
+    debutant: 'beginner',
+    intermediaire: 'intermediate',
+    avance: 'advanced',
+  };
+
+  // INSERT program
+  const { data: insertedProgram, error: insertError } = await supabaseAdmin
+    .from("programs")
+    .insert({
+      slug,
+      title: pgm.titre,
+      description: pgm.description,
+      goals: body.objectifs,
+      duration_weeks: body.duree_semaines,
+      frequency_per_week: body.seances_par_semaine,
+      fitness_level: niveauMap[pgm.niveau as string] ?? 'intermediate',
+      is_fixed: false,
+      user_id: user.id,
+      note_coach: pgm.note_coach,
+      progression: pgm.progression,
+      consignes_semaine: pgm.consignes_semaine,
+      onboarding_data: body,
+      generation_metadata: pgm,
+      input_tokens: totalInputTokens,
+      output_tokens: totalOutputTokens,
+      model: MODEL,
+    })
+    .select("id")
+    .single();
+
+  if (insertError || !insertedProgram) {
+    console.error("Program insert error:", insertError);
+    return errorResponse("Erreur de sauvegarde du programme", 500);
+  }
+
+  // Build program_sessions rows
+  const sessionRows: {
+    program_id: string;
+    week_number: number;
+    session_order: number;
+    session_data: Record<string, unknown>;
+  }[] = [];
+
+  let globalOrder = 1;
+  for (const entry of calendrier) {
+    for (const week of entry.semaines) {
+      for (const sessionId of entry.sequence) {
+        sessionRows.push({
+          program_id: insertedProgram.id,
+          week_number: week,
+          session_order: globalOrder,
+          session_data: sessions[sessionId],
+        });
+        globalOrder++;
+      }
+    }
+  }
+
+  // INSERT program_sessions
+  const { error: sessionsError } = await supabaseAdmin
+    .from("program_sessions")
+    .insert(sessionRows);
+
+  if (sessionsError) {
+    console.error("Program sessions insert error:", sessionsError);
+    // Rollback: delete the program
+    await supabaseAdmin.from("programs").delete().eq("id", insertedProgram.id);
+    return errorResponse("Erreur de sauvegarde des seances", 502);
+  }
+
+  return jsonResponse({ programId: insertedProgram.id, slug });
+});

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -1,0 +1,359 @@
+interface ProgramInput {
+  objectifs: string[];
+  objectif_detail?: string;
+  sport?: string;
+  jour_match?: string;
+  experience_duree: string;
+  frequence_actuelle: string;
+  blessures: string[];
+  blessure_detail?: string;
+  age?: number;
+  sexe?: string;
+  seances_par_semaine: number;
+  duree_seance_minutes: number;
+  materiel: string[];
+  duree_semaines: number;
+}
+
+export const SYSTEM_PROMPT = `Tu es un preparateur physique expert. Tu generes des programmes d'entrainement multi-semaines au format JSON uniquement.
+
+REGLE ABSOLUE : Reponds UNIQUEMENT avec du JSON valide. Pas de texte avant, pas de texte apres, pas de markdown.
+
+SCHEMA JSON DE SORTIE :
+{
+  "titre": "string (nom court et motivant)",
+  "description": "string (1-2 phrases)",
+  "niveau": "debutant" | "intermediaire" | "avance",
+  "note_coach": "string (3-5 phrases, tutoiement, personnalise selon le profil)",
+  "progression": {
+    "logique": "string (explication de la logique de progression)",
+    "cible_semaine_3": "string (optionnel)",
+    "cible_semaine_6": "string (optionnel)",
+    "cible_semaine_8": "string (optionnel)",
+    "cible_semaine_12": "string (optionnel)"
+  },
+  "sessions": {
+    "A": Session,
+    "B": Session,
+    "C": Session (optionnel, max 5 sessions uniques A-E)
+  },
+  "calendrier": [
+    { "semaines": [1, 2], "sequence": ["A", "B"] },
+    { "semaines": [3, 4], "sequence": ["A", "B", "C"] }
+  ],
+  "consignes_semaine": {
+    "1-2": "string (consigne de progression pour ces semaines)",
+    "3-4": "string"
+  }
+}
+
+SCHEMA D'UNE SESSION :
+{
+  "title": "string (nom court)",
+  "description": "string (1 phrase)",
+  "estimatedDuration": number (minutes),
+  "focus": ["string"] (1-3 tags),
+  "blocks": [Block]
+}
+
+TYPES DE BLOCS DISPONIBLES :
+
+1. warmup — { "type": "warmup", "name": "string", "exercises": [{ "name": "string", "duration": number (sec), "instructions": "string", "bilateral?": boolean }] }
+2. cooldown — { "type": "cooldown", "name": "string", "exercises": [{ "name": "string", "duration": number (sec), "instructions": "string", "bilateral?": boolean }] }
+3. classic — { "type": "classic", "name": "string", "restBetweenExercises": number (sec), "exercises": [{ "name": "string", "sets": number, "reps": number, "restBetweenSets": number (sec), "instructions": "string", "bilateral?": boolean }] }
+4. circuit — { "type": "circuit", "name": "string", "rounds": number, "restBetweenExercises": number (sec), "restBetweenRounds": number (sec), "exercises": [{ "name": "string", "mode": "timed"|"reps", "duration?": number (sec), "reps?": number, "instructions": "string", "bilateral?": boolean }] }
+5. hiit — { "type": "hiit", "name": "string", "rounds": number, "work": number (sec), "rest": number (sec), "exercises": [{ "name": "string", "instructions": "string" }] }
+6. tabata — { "type": "tabata", "name": "string", "sets?": number, "rounds?": number, "work?": number, "rest?": number, "restBetweenSets?": number (sec), "exercises": [{ "name": "string", "instructions": "string" }] }
+7. emom — { "type": "emom", "name": "string", "minutes": number, "exercises": [{ "name": "string", "reps": number, "instructions": "string" }] }
+8. amrap — { "type": "amrap", "name": "string", "duration": number (sec), "exercises": [{ "name": "string", "reps": number, "instructions": "string" }] }
+9. superset — { "type": "superset", "name": "string", "sets": number, "restBetweenSets": number (sec), "restBetweenPairs?": number (sec), "pairs": [{ "exercises": [{ "name": "string", "reps": number, "instructions": "string" }] }] }
+10. pyramid — { "type": "pyramid", "name": "string", "pattern": [number], "restBetweenSets": number (sec), "restBetweenExercises?": number (sec), "exercises": [{ "name": "string", "instructions": "string" }] }
+
+REGLES DE PROGRAMMATION SPORTIVE :
+
+Echauffement :
+- Toujours commencer chaque session par un bloc warmup (5-8 min)
+- L'echauffement doit etre specifique au focus de la seance (mobilite articulaire des zones travaillees + activation musculaire + montee en cardio progressive)
+- Seance haut du corps → mobilite epaules, coudes, poignets + activation scapulaire
+- Seance bas du corps → mobilite hanches, genoux, chevilles + activation fessiers
+- Seance full body → mobilite generale + activation cardio
+
+Cooldown :
+- Toujours terminer par un bloc cooldown (3-5 min)
+- Etirements specifiques aux groupes musculaires travailles dans la seance
+- Inclure 30-60s de respiration profonde en fin
+
+Progression :
+- Programme 4 sem : progression lineaire simple (volume ou intensite croissante)
+- Programme 8 sem : deload semaine 4, reprise avec intensite plus elevee sem 5
+- Programme 12 sem : deload sem 4 et sem 8, 3 phases progressives (decouverte, montee en puissance, performance)
+- Deload = semaine de recuperation : reduire le nombre de series de 40% et l'effort de 20%, garder les memes exercices
+
+Logique par objectif :
+- Perte de poids : predominance circuits/HIIT, 2-3 blocs cardio par seance, repos courts (15-30s), inclure du renfo pour preserver la masse musculaire
+- Prise de muscle : blocs classic et superset, 3-4 series de 8-12 reps, repos 60-90s, augmenter progressivement le poids ou le nombre de series
+- Force : blocs classic, 4-5 series de 3-6 reps, repos 120-180s, exercices composes (squat, developpe, tractions, rowing)
+- Remise en forme : mix equilibre circuits + classic, progression douce en volume, variete des formats
+- Endurance : blocs HIIT/circuit/EMOM longs, temps de travail croissant, repos decroissant
+- Performance sportive : organisation adaptee au sport, blocs explosifs, travail une jambe/un bras, equilibre et stabilite
+- Mobilite/Bien-etre : blocs warmup etendus, circuits doux, yoga-inspired, respiration, foam rolling
+- Souplesse : etirements dynamiques puis statiques, contracter-relacher, progression en amplitude
+
+Substitutions par blessure :
+- Genou : eviter squat profond, sauts, fentes profondes → remplacer par ponts fessiers, flexion jambe tenue en position, squat partiel, step-up bas
+- Epaule : eviter developpe overhead, dips profonds → remplacer par rotations externes, face pulls, developpe incline partiel
+- Dos/Lombaires : eviter deadlift lourd, abdos crunch → remplacer par bird-dog, pallof press, hip hinge avec elastique, planche
+- Poignet : eviter pompes sur mains plates, clean → remplacer par pompes sur poings/halteres, exercices avec sangles
+- Cheville : eviter sauts, course → remplacer par velo, exercices assis/couche, mobilite cheville progressive
+- Hanche : eviter squats larges, adducteurs sous charge → remplacer par ponts fessiers, clam shells, abduction legere
+- Cervicales : eviter charges sur les epaules (back squat), shrugs lourds → remplacer par goblet squat, exercices avec support dorsal
+
+Regles sport-specifiques :
+- Sports collectifs (hand, basket, foot, rugby) : travail explosif (box jumps, sprints), changements de direction, equilibre, renfo une jambe/un bras
+- Running : renfo bas du corps + core, descentes lentes controlees, petits sauts, mobilite hanches/chevilles
+- Sports de raquette : travail epaule/coude, rotateurs, core anti-rotation, agilite laterale
+- Si jour_match specifie : placer les seances les plus intenses 48-72h avant le match, seance legere J-1
+
+Regles generales :
+- Ne jamais travailler les memes groupes musculaires 2 jours de suite
+- Alterner haut/bas du corps ou push/pull/legs selon la frequence
+- 2 seances/sem : full body A + full body B
+- 3 seances/sem : full body A + B + C ou push/pull/legs
+- 4 seances/sem : upper/lower split ou push/pull x2
+- 5 seances/sem : push/pull/legs + upper/lower
+- Maximum 6-8 exercices par seance (hors warmup/cooldown)
+- Exercices composes en debut de seance, isolation en fin
+- Exercices bilateraux : marquer "bilateral": true
+
+LANGAGE :
+- Utilise un langage simple et accessible, comme si tu parlais a un ami qui debute le sport
+- INTERDIT d'utiliser du jargon technique : pas de "mesocycle", "RPE", "PNF", "excentrique", "concentrique", "TUT", "tempo 3-1-2", "supination/pronation", "activation neuromusculaire", "periostage", "isometrique" etc.
+- Remplace par des expressions parlantes : "semaines d'intensite" au lieu de "mesocycle", "difficulte ressentie" au lieu de "RPE", "phase de descente lente" au lieu de "excentrique", "maintenir la position" au lieu de "isometrique"
+- Les consignes de progression doivent etre concretes : "ajoute 1 serie" ou "augmente le poids legerement" plutot que "RPE 7" ou "progression en charge"
+- Les instructions d'exercices doivent decrire le mouvement simplement, comme si la personne le faisait pour la premiere fois
+
+INTERDICTIONS :
+- Pas de texte hors JSON
+- Pas de HTML, pas d'URLs
+- Pas d'exercices avec machines (salle de gym) sauf si le profil mentionne un acces en salle
+- Pas de references a des poids specifiques en kg (utiliser "charge moderee" ou "charge lourde")
+- Pas de jargon technique (voir section LANGAGE)
+- Ne jamais depasser la duree demandee par seance (tolerance ±3 min)
+- Ne jamais proposer plus de sessions uniques que le nombre de seances/semaine demande
+
+EXEMPLE MINI-PROGRAMME (4 sem, 2 seances/sem, 30 min) :
+{
+  "titre": "Debutant Full Body",
+  "description": "Programme progressif pour reprendre le sport en douceur.",
+  "niveau": "debutant",
+  "note_coach": "Bienvenue ! Ce programme est concu pour toi qui reprends le sport. On va y aller progressivement : les 2 premieres semaines servent a poser les bases et apprendre les mouvements. Semaines 3-4, on augmente un peu le volume. Ecoute ton corps et n'hesite pas a adapter.",
+  "progression": {
+    "logique": "Progression lineaire en volume : +1 serie par exercice toutes les 2 semaines.",
+    "cible_semaine_3": "Augmentation du volume : passage a 3 series sur les exercices principaux."
+  },
+  "sessions": {
+    "A": {
+      "title": "Full Body Fondations",
+      "description": "Seance complete axee mouvements fondamentaux.",
+      "estimatedDuration": 30,
+      "focus": ["Full body", "Renforcement"],
+      "blocks": [
+        { "type": "warmup", "name": "Echauffement", "exercises": [
+          { "name": "Rotation des bras", "duration": 30, "instructions": "Grands cercles, bras tendus." },
+          { "name": "Montees de genoux", "duration": 30, "instructions": "Rythme modere, genoux hauts." },
+          { "name": "Squat sans charge", "duration": 30, "instructions": "Descends doucement, 5 repetitions lentes." }
+        ]},
+        { "type": "classic", "name": "Bloc renforcement", "restBetweenExercises": 45, "exercises": [
+          { "name": "Squats", "sets": 2, "reps": 12, "restBetweenSets": 45, "instructions": "Descends cuisses paralleles au sol, pousse sur les talons." },
+          { "name": "Pompes (genoux si besoin)", "sets": 2, "reps": 8, "restBetweenSets": 45, "instructions": "Corps gaine, descends poitrine pres du sol." },
+          { "name": "Rowing inversé", "sets": 2, "reps": 10, "restBetweenSets": 45, "instructions": "Sous une table ou barre basse, tire la poitrine vers la barre." }
+        ]},
+        { "type": "cooldown", "name": "Retour au calme", "exercises": [
+          { "name": "Etirement quadriceps", "duration": 30, "instructions": "Debout, talon vers fesse.", "bilateral": true },
+          { "name": "Etirement pectoraux", "duration": 30, "instructions": "Bras contre un mur, pivote le buste.", "bilateral": true },
+          { "name": "Respiration profonde", "duration": 30, "instructions": "Inspire 4s, expire 6s." }
+        ]}
+      ]
+    },
+    "B": {
+      "title": "Cardio & Core",
+      "description": "Circuit dynamique avec focus abdominaux.",
+      "estimatedDuration": 30,
+      "focus": ["Cardio", "Core"],
+      "blocks": [
+        { "type": "warmup", "name": "Echauffement", "exercises": [
+          { "name": "Marche sur place", "duration": 30, "instructions": "Bras actifs, monte les genoux." },
+          { "name": "Rotation du bassin", "duration": 30, "instructions": "Cercles amples dans les deux sens." }
+        ]},
+        { "type": "circuit", "name": "Circuit cardio-core", "rounds": 3, "restBetweenExercises": 10, "restBetweenRounds": 60, "exercises": [
+          { "name": "Mountain climbers", "mode": "timed", "duration": 30, "instructions": "Rapide et controle." },
+          { "name": "Planche", "mode": "timed", "duration": 30, "instructions": "Corps aligne, gainage actif." },
+          { "name": "Jumping jacks", "mode": "timed", "duration": 30, "instructions": "Rythme soutenu." }
+        ]},
+        { "type": "cooldown", "name": "Retour au calme", "exercises": [
+          { "name": "Etirement ischio-jambiers", "duration": 30, "instructions": "Assis, tends une jambe devant.", "bilateral": true },
+          { "name": "Respiration profonde", "duration": 30, "instructions": "Inspire 4s, expire 6s. Relache les epaules." }
+        ]}
+      ]
+    }
+  },
+  "calendrier": [
+    { "semaines": [1, 2], "sequence": ["A", "B"] },
+    { "semaines": [3, 4], "sequence": ["A", "B"] }
+  ],
+  "consignes_semaine": {
+    "1-2": "Concentre-toi sur la qualite des mouvements. L'effort doit rester confortable. Prends le temps d'apprendre chaque exercice.",
+    "3-4": "On ajoute 1 serie par exercice dans le bloc renforcement. Tu devrais sentir que ca travaille mais rester en controle."
+  }
+}
+
+RAPPELS CRITIQUES :
+1. Chaque session DOIT commencer par warmup et finir par cooldown
+2. Le nombre de sessions uniques (A, B, C...) doit etre <= seances_par_semaine
+3. Le calendrier doit couvrir TOUTES les semaines du programme (1 a duree_semaines)
+4. Chaque ID dans les sequences du calendrier doit exister dans "sessions"
+5. consignes_semaine doit couvrir toutes les semaines avec des plages (ex: "1-2", "3-4")
+6. Respecte STRICTEMENT la duree par seance demandee (±3 min)
+7. Adapte les exercices au materiel disponible — n'utilise JAMAIS du materiel non liste
+8. En cas de blessure, applique SYSTEMATIQUEMENT les substitutions listees
+9. Deload obligatoire : sem 4 pour 8 sem, sem 4 et 8 pour 12 sem
+10. JSON valide uniquement, aucun texte autour`;
+
+const OBJECTIF_LABELS: Record<string, string> = {
+  'perte_poids': 'Perte de poids',
+  'prise_muscle': 'Prise de muscle',
+  'remise_forme': 'Remise en forme',
+  'force': 'Force',
+  'endurance': 'Endurance',
+  'performance_sportive': 'Performance sportive',
+  'bien_etre': 'Bien-etre et sante',
+  'souplesse': 'Souplesse et mobilite',
+};
+
+const EXPERIENCE_LABELS: Record<string, string> = {
+  'debutant': 'Debutant (moins de 6 mois de pratique)',
+  'six_mois_deux_ans': 'Intermediaire (6 mois a 2 ans)',
+  'plus_deux_ans': 'Experimente (plus de 2 ans)',
+};
+
+const FREQUENCE_LABELS: Record<string, string> = {
+  'jamais': 'Ne fait pas de sport actuellement',
+  'une_deux': 'S\'entraine 1-2 fois par semaine',
+  'trois_quatre': 'S\'entraine 3-4 fois par semaine',
+  'cinq_plus': 'S\'entraine 5+ fois par semaine',
+};
+
+const MATERIEL_LABELS: Record<string, string> = {
+  'poids_du_corps': 'Poids du corps uniquement',
+  'halteres': 'Halteres',
+  'barre_disques': 'Barre et disques',
+  'kettlebell': 'Kettlebell',
+  'elastiques': 'Elastiques/bandes',
+  'banc': 'Banc de musculation',
+  'barre_traction': 'Barre de traction',
+  'trx': 'TRX / sangles de suspension',
+  'corde_a_sauter': 'Corde a sauter',
+  'medecine_ball': 'Medicine ball',
+};
+
+const BLESSURE_LABELS: Record<string, string> = {
+  'genou': 'Genou',
+  'dos': 'Dos / Lombaires',
+  'epaule': 'Epaule',
+  'cheville': 'Cheville',
+  'poignet': 'Poignet',
+  'cervicales': 'Cervicales',
+  'hanche': 'Hanche',
+};
+
+export function buildUserPrompt(input: ProgramInput): string {
+  const parts: string[] = [];
+
+  // Objectifs
+  const objectifsList = input.objectifs
+    .map((o) => OBJECTIF_LABELS[o] ?? o)
+    .join(', ');
+  parts.push(`OBJECTIFS : ${objectifsList}`);
+
+  if (input.objectif_detail) {
+    parts.push(`Detail : ${input.objectif_detail}`);
+  }
+
+  if (input.sport) {
+    parts.push(`Sport pratique : ${input.sport}`);
+    if (input.jour_match) {
+      parts.push(`Jour de match/competition : ${input.jour_match}`);
+    }
+  }
+
+  // Profil
+  parts.push('');
+  parts.push('PROFIL :');
+  parts.push(`- Experience : ${EXPERIENCE_LABELS[input.experience_duree] ?? input.experience_duree}`);
+  parts.push(`- Frequence actuelle : ${FREQUENCE_LABELS[input.frequence_actuelle] ?? input.frequence_actuelle}`);
+
+  if (input.age) parts.push(`- Age : ${input.age} ans`);
+  if (input.sexe) parts.push(`- Sexe : ${input.sexe}`);
+
+  // Blessures
+  if (input.blessures.length > 0) {
+    const blessuresList = input.blessures
+      .map((b) => BLESSURE_LABELS[b] ?? b)
+      .join(', ');
+    parts.push(`- ⚠️ BLESSURES/SENSIBILITES : ${blessuresList}`);
+    if (input.blessure_detail) {
+      parts.push(`  Detail : ${input.blessure_detail}`);
+    }
+  }
+
+  // Programme
+  parts.push('');
+  parts.push('PROGRAMME DEMANDE :');
+  parts.push(`- ${input.seances_par_semaine} seances par semaine`);
+  parts.push(`- ${input.duree_seance_minutes} minutes par seance`);
+  parts.push(`- Duree : ${input.duree_semaines} semaines`);
+
+  // Materiel
+  const materielList = input.materiel
+    .map((m) => MATERIEL_LABELS[m] ?? m)
+    .join(', ');
+  parts.push(`- Materiel disponible : ${materielList}`);
+
+  // Warnings
+  const warnings: string[] = [];
+
+  if (
+    input.experience_duree === 'debutant' &&
+    input.seances_par_semaine >= 5
+  ) {
+    warnings.push('Profil debutant avec 5+ seances/semaine : adapte l\'intensite et prevois une progression tres progressive.');
+  }
+
+  if (
+    input.objectifs.includes('prise_muscle') &&
+    input.materiel.length === 1 &&
+    input.materiel[0] === 'poids_du_corps'
+  ) {
+    warnings.push('Prise de muscle avec poids du corps uniquement : privilegie les exercices a progression (pompes declines, pistol squats, etc.) et les tempos lents.');
+  }
+
+  if (
+    ['jamais', 'une_deux'].includes(input.frequence_actuelle) &&
+    input.seances_par_semaine > 3
+  ) {
+    warnings.push(`Frequence actuelle faible (${FREQUENCE_LABELS[input.frequence_actuelle]}) mais ${input.seances_par_semaine} seances demandees : commence doucement les premieres semaines.`);
+  }
+
+  if (warnings.length > 0) {
+    parts.push('');
+    parts.push('⚠️ POINTS D\'ATTENTION :');
+    for (const w of warnings) {
+      parts.push(`- ${w}`);
+    }
+  }
+
+  parts.push('');
+  parts.push('Genere le programme complet au format JSON.');
+
+  return parts.join('\n');
+}

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -1,8 +1,6 @@
 interface ProgramInput {
   objectifs: string[];
   objectif_detail?: string;
-  sport?: string;
-  jour_match?: string;
   experience_duree: string;
   frequence_actuelle: string;
   blessures: string[];
@@ -112,7 +110,7 @@ Regles sport-specifiques :
 - Sports collectifs (hand, basket, foot, rugby) : travail explosif (box jumps, sprints), changements de direction, equilibre, renfo une jambe/un bras
 - Running : renfo bas du corps + core, descentes lentes controlees, petits sauts, mobilite hanches/chevilles
 - Sports de raquette : travail epaule/coude, rotateurs, core anti-rotation, agilite laterale
-- Si jour_match specifie : placer les seances les plus intenses 48-72h avant le match, seance legere J-1
+- Si le profil mentionne un sport et des jours de competition, placer les seances les plus intenses 48-72h avant, seance legere J-1
 
 Regles generales :
 - Ne jamais travailler les memes groupes musculaires 2 jours de suite
@@ -279,13 +277,6 @@ export function buildUserPrompt(input: ProgramInput): string {
     parts.push(`Detail : ${input.objectif_detail}`);
   }
 
-  if (input.sport) {
-    parts.push(`Sport pratique : ${input.sport}`);
-    if (input.jour_match) {
-      parts.push(`Jour de match/competition : ${input.jour_match}`);
-    }
-  }
-
   // Profil
   parts.push('');
   parts.push('PROFIL :');
@@ -301,9 +292,9 @@ export function buildUserPrompt(input: ProgramInput): string {
       .map((b) => BLESSURE_LABELS[b] ?? b)
       .join(', ');
     parts.push(`- ⚠️ BLESSURES/SENSIBILITES : ${blessuresList}`);
-    if (input.blessure_detail) {
-      parts.push(`  Detail : ${input.blessure_detail}`);
-    }
+  }
+  if (input.blessure_detail) {
+    parts.push(`- ⚠️ Detail blessure : ${input.blessure_detail}`);
   }
 
   // Programme

--- a/supabase/functions/generate-program/validate.ts
+++ b/supabase/functions/generate-program/validate.ts
@@ -1,0 +1,335 @@
+// Re-use session validation from generate-session
+// We import the logic inline since Deno edge functions can't share across directories easily
+
+const VALID_BLOCK_TYPES = [
+  'warmup', 'cooldown', 'classic', 'circuit', 'hiit',
+  'tabata', 'emom', 'amrap', 'superset', 'pyramid',
+] as const;
+
+type BlockType = (typeof VALID_BLOCK_TYPES)[number];
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+function isNumber(v: unknown): v is number {
+  return typeof v === 'number' && !Number.isNaN(v);
+}
+
+function isArray(v: unknown): v is unknown[] {
+  return Array.isArray(v);
+}
+
+const MAX_STRING_LENGTH = 500;
+
+function sanitizeString(s: string): string {
+  return s
+    .replace(/<[^>]*>/g, '')
+    .replace(/https?:\/\/\S+/gi, '')
+    .slice(0, MAX_STRING_LENGTH);
+}
+
+function sanitizeSession(session: Record<string, unknown>): void {
+  if (isString(session.title)) session.title = sanitizeString(session.title);
+  if (isString(session.description)) session.description = sanitizeString(session.description);
+  if (isArray(session.focus)) {
+    session.focus = (session.focus as string[]).map(sanitizeString);
+  }
+  if (isArray(session.blocks)) {
+    for (const block of session.blocks as Record<string, unknown>[]) {
+      if (isString(block.name)) block.name = sanitizeString(block.name);
+      if (isArray(block.exercises)) {
+        for (const ex of block.exercises as Record<string, unknown>[]) {
+          if (isString(ex.name)) ex.name = sanitizeString(ex.name);
+          if (isString(ex.instructions)) ex.instructions = sanitizeString(ex.instructions);
+        }
+      }
+      if (isArray(block.pairs)) {
+        for (const pair of block.pairs as Record<string, unknown>[]) {
+          if (isArray(pair.exercises)) {
+            for (const ex of pair.exercises as Record<string, unknown>[]) {
+              if (isString(ex.name)) ex.name = sanitizeString(ex.name);
+              if (isString(ex.instructions)) ex.instructions = sanitizeString(ex.instructions);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function validateBlockExercises(
+  block: Record<string, unknown>,
+  blockType: BlockType,
+): ValidationResult {
+  switch (blockType) {
+    case 'warmup':
+    case 'cooldown': {
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: `${blockType}: exercises required` };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: `${blockType}: exercise name required` };
+        if (!isNumber(ex.duration)) return { valid: false, error: `${blockType}: exercise duration required` };
+        if (!isString(ex.instructions)) return { valid: false, error: `${blockType}: exercise instructions required` };
+      }
+      return { valid: true };
+    }
+    case 'classic': {
+      if (!isNumber(block.restBetweenExercises))
+        return { valid: false, error: 'classic: restBetweenExercises required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'classic: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'classic: exercise name required' };
+        if (!isNumber(ex.sets)) return { valid: false, error: 'classic: exercise sets required' };
+        if (!isNumber(ex.reps) && ex.reps !== 'max')
+          return { valid: false, error: 'classic: exercise reps required' };
+        if (!isNumber(ex.restBetweenSets)) return { valid: false, error: 'classic: exercise restBetweenSets required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'classic: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'circuit': {
+      if (!isNumber(block.rounds)) return { valid: false, error: 'circuit: rounds required' };
+      if (!isNumber(block.restBetweenExercises)) return { valid: false, error: 'circuit: restBetweenExercises required' };
+      if (!isNumber(block.restBetweenRounds)) return { valid: false, error: 'circuit: restBetweenRounds required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'circuit: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'circuit: exercise name required' };
+        if (ex.mode !== 'timed' && ex.mode !== 'reps')
+          return { valid: false, error: 'circuit: exercise mode must be timed or reps' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'circuit: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'hiit': {
+      if (!isNumber(block.rounds)) return { valid: false, error: 'hiit: rounds required' };
+      if (!isNumber(block.work)) return { valid: false, error: 'hiit: work required' };
+      if (!isNumber(block.rest)) return { valid: false, error: 'hiit: rest required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'hiit: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'hiit: exercise name required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'hiit: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'tabata': {
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'tabata: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'tabata: exercise name required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'tabata: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'emom': {
+      if (!isNumber(block.minutes)) return { valid: false, error: 'emom: minutes required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'emom: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'emom: exercise name required' };
+        if (!isNumber(ex.reps)) return { valid: false, error: 'emom: exercise reps required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'emom: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'amrap': {
+      if (!isNumber(block.duration)) return { valid: false, error: 'amrap: duration required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'amrap: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'amrap: exercise name required' };
+        if (!isNumber(ex.reps)) return { valid: false, error: 'amrap: exercise reps required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'amrap: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    case 'superset': {
+      if (!isNumber(block.sets)) return { valid: false, error: 'superset: sets required' };
+      if (!isNumber(block.restBetweenSets)) return { valid: false, error: 'superset: restBetweenSets required' };
+      const pairs = block.pairs;
+      if (!isArray(pairs) || pairs.length === 0)
+        return { valid: false, error: 'superset: pairs required' };
+      for (const pair of pairs as Record<string, unknown>[]) {
+        if (!isArray(pair.exercises) || pair.exercises.length === 0)
+          return { valid: false, error: 'superset: pair exercises required' };
+        for (const ex of pair.exercises as Record<string, unknown>[]) {
+          if (!isString(ex.name)) return { valid: false, error: 'superset: exercise name required' };
+          if (!isNumber(ex.reps)) return { valid: false, error: 'superset: exercise reps required' };
+          if (!isString(ex.instructions)) return { valid: false, error: 'superset: exercise instructions required' };
+        }
+      }
+      return { valid: true };
+    }
+    case 'pyramid': {
+      if (!isArray(block.pattern) || block.pattern.length === 0)
+        return { valid: false, error: 'pyramid: pattern required' };
+      if (!isNumber(block.restBetweenSets)) return { valid: false, error: 'pyramid: restBetweenSets required' };
+      const exercises = block.exercises;
+      if (!isArray(exercises) || exercises.length === 0)
+        return { valid: false, error: 'pyramid: exercises required' };
+      for (const ex of exercises as Record<string, unknown>[]) {
+        if (!isString(ex.name)) return { valid: false, error: 'pyramid: exercise name required' };
+        if (!isString(ex.instructions)) return { valid: false, error: 'pyramid: exercise instructions required' };
+      }
+      return { valid: true };
+    }
+    default:
+      return { valid: false, error: `Unknown block type: ${blockType}` };
+  }
+}
+
+export function validateSession(data: unknown): ValidationResult {
+  if (!data || typeof data !== 'object')
+    return { valid: false, error: 'Session must be an object' };
+
+  const session = data as Record<string, unknown>;
+
+  if (!isString(session.title)) return { valid: false, error: 'title is required' };
+  if (!isString(session.description)) return { valid: false, error: 'description is required' };
+  if (!isNumber(session.estimatedDuration)) return { valid: false, error: 'estimatedDuration is required' };
+  if (!isArray(session.focus) || session.focus.length === 0)
+    return { valid: false, error: 'focus array is required' };
+  if (!isArray(session.blocks) || session.blocks.length < 2)
+    return { valid: false, error: 'At least 2 blocks required (warmup + cooldown)' };
+
+  const blocks = session.blocks as Record<string, unknown>[];
+
+  if (blocks[0].type !== 'warmup')
+    return { valid: false, error: 'First block must be warmup' };
+  if (blocks[blocks.length - 1].type !== 'cooldown')
+    return { valid: false, error: 'Last block must be cooldown' };
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    const blockType = block.type as string;
+    if (!VALID_BLOCK_TYPES.includes(blockType as BlockType))
+      return { valid: false, error: `Block ${i}: invalid type "${blockType}"` };
+    if (!isString(block.name))
+      return { valid: false, error: `Block ${i}: name required` };
+    const result = validateBlockExercises(block, blockType as BlockType);
+    if (!result.valid) return { valid: false, error: `Block ${i}: ${result.error}` };
+  }
+
+  sanitizeSession(session);
+  return { valid: true };
+}
+
+interface CalendrierEntry {
+  semaines: number[];
+  sequence: string[];
+}
+
+export function validateProgram(
+  data: unknown,
+  expectedWeeks: number,
+  maxSessionsPerWeek: number,
+): ValidationResult {
+  if (!data || typeof data !== 'object')
+    return { valid: false, error: 'Program must be an object' };
+
+  const program = data as Record<string, unknown>;
+
+  // Top-level fields
+  if (!isString(program.titre)) return { valid: false, error: 'titre is required' };
+  if (!isString(program.description)) return { valid: false, error: 'description is required' };
+  if (!isString(program.niveau)) return { valid: false, error: 'niveau is required' };
+  if (!['debutant', 'intermediaire', 'avance'].includes(program.niveau as string))
+    return { valid: false, error: 'niveau must be debutant, intermediaire or avance' };
+  if (!isString(program.note_coach) || (program.note_coach as string).length === 0)
+    return { valid: false, error: 'note_coach is required' };
+
+  // Progression
+  if (!program.progression || typeof program.progression !== 'object')
+    return { valid: false, error: 'progression is required' };
+  const progression = program.progression as Record<string, unknown>;
+  if (!isString(progression.logique))
+    return { valid: false, error: 'progression.logique is required' };
+
+  // Sessions
+  if (!program.sessions || typeof program.sessions !== 'object')
+    return { valid: false, error: 'sessions object is required' };
+  const sessions = program.sessions as Record<string, unknown>;
+  const sessionKeys = Object.keys(sessions);
+
+  if (sessionKeys.length < 2 || sessionKeys.length > 5)
+    return { valid: false, error: `sessions must have 2-5 entries, got ${sessionKeys.length}` };
+  if (sessionKeys.length > maxSessionsPerWeek)
+    return { valid: false, error: `sessions count (${sessionKeys.length}) exceeds seances_par_semaine (${maxSessionsPerWeek})` };
+
+  // Validate each session
+  for (const key of sessionKeys) {
+    const sessionValidation = validateSession(sessions[key]);
+    if (!sessionValidation.valid)
+      return { valid: false, error: `Session "${key}": ${sessionValidation.error}` };
+  }
+
+  // Calendrier
+  if (!isArray(program.calendrier) || program.calendrier.length === 0)
+    return { valid: false, error: 'calendrier array is required' };
+
+  const coveredWeeks = new Set<number>();
+  for (const entry of program.calendrier as CalendrierEntry[]) {
+    if (!isArray(entry.semaines) || entry.semaines.length === 0)
+      return { valid: false, error: 'calendrier entry: semaines required' };
+    if (!isArray(entry.sequence) || entry.sequence.length === 0)
+      return { valid: false, error: 'calendrier entry: sequence required' };
+
+    for (const week of entry.semaines) {
+      if (!isNumber(week)) return { valid: false, error: 'calendrier: semaine must be a number' };
+      coveredWeeks.add(week);
+    }
+
+    for (const sessionId of entry.sequence) {
+      if (!isString(sessionId))
+        return { valid: false, error: 'calendrier: sequence item must be a string' };
+      if (!sessionKeys.includes(sessionId))
+        return { valid: false, error: `calendrier: session "${sessionId}" not found in sessions` };
+    }
+  }
+
+  // Check all weeks covered
+  for (let w = 1; w <= expectedWeeks; w++) {
+    if (!coveredWeeks.has(w))
+      return { valid: false, error: `calendrier: week ${w} not covered` };
+  }
+
+  // Consignes semaine
+  if (!program.consignes_semaine || typeof program.consignes_semaine !== 'object')
+    return { valid: false, error: 'consignes_semaine is required' };
+  const consignes = program.consignes_semaine as Record<string, unknown>;
+  const consigneKeys = Object.keys(consignes);
+  if (consigneKeys.length === 0)
+    return { valid: false, error: 'consignes_semaine must have at least one entry' };
+
+  // Verify all consignes are strings
+  for (const key of consigneKeys) {
+    if (!isString(consignes[key]))
+      return { valid: false, error: `consignes_semaine["${key}"] must be a string` };
+  }
+
+  // Sanitize top-level strings
+  program.titre = sanitizeString(program.titre as string);
+  program.description = sanitizeString(program.description as string);
+  // note_coach is longer (3-5 sentences), allow up to 2000 chars
+  program.note_coach = (program.note_coach as string)
+    .replace(/<[^>]*>/g, '')
+    .replace(/https?:\/\/\S+/gi, '')
+    .slice(0, 2000);
+
+  return { valid: true };
+}

--- a/supabase/functions/generate-program/validate.ts
+++ b/supabase/functions/generate-program/validate.ts
@@ -331,5 +331,16 @@ export function validateProgram(
     .replace(/https?:\/\/\S+/gi, '')
     .slice(0, 2000);
 
+  // Sanitize progression strings
+  if (isString(progression.logique)) progression.logique = sanitizeString(progression.logique);
+  for (const key of ['cible_semaine_3', 'cible_semaine_6', 'cible_semaine_8', 'cible_semaine_12']) {
+    if (isString(progression[key])) progression[key] = sanitizeString(progression[key] as string);
+  }
+
+  // Sanitize consignes_semaine values
+  for (const key of consigneKeys) {
+    consignes[key] = sanitizeString(consignes[key] as string);
+  }
+
   return { valid: true };
 }

--- a/supabase/migrations/004_custom_programs.sql
+++ b/supabase/migrations/004_custom_programs.sql
@@ -1,0 +1,53 @@
+-- Phase 4: Custom AI-generated programs
+
+-- Extend programs table for user-generated programs
+ALTER TABLE public.programs
+  ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS onboarding_data jsonb,
+  ADD COLUMN IF NOT EXISTS note_coach text,
+  ADD COLUMN IF NOT EXISTS progression jsonb,
+  ADD COLUMN IF NOT EXISTS consignes_semaine jsonb,
+  ADD COLUMN IF NOT EXISTS generation_metadata jsonb,
+  ADD COLUMN IF NOT EXISTS input_tokens integer,
+  ADD COLUMN IF NOT EXISTS output_tokens integer,
+  ADD COLUMN IF NOT EXISTS model text;
+
+-- Fix FK: session_completions.program_session_id should SET NULL on delete
+-- so completion history is preserved when a custom program is deleted
+ALTER TABLE session_completions
+  DROP CONSTRAINT IF EXISTS fk_completions_program_session;
+ALTER TABLE session_completions
+  DROP CONSTRAINT IF EXISTS session_completions_program_session_id_fkey;
+ALTER TABLE session_completions
+  ADD CONSTRAINT session_completions_program_session_id_fkey
+  FOREIGN KEY (program_session_id) REFERENCES program_sessions(id)
+  ON DELETE SET NULL;
+
+-- RLS: programs — users can read fixed programs OR their own
+DROP POLICY IF EXISTS "read fixed programs" ON programs;
+CREATE POLICY "read programs" ON programs FOR SELECT USING (
+  is_fixed = true OR (user_id IS NOT NULL AND auth.uid() = user_id)
+);
+CREATE POLICY "insert own programs" ON programs FOR INSERT
+  WITH CHECK (auth.uid() = user_id AND is_fixed = false);
+CREATE POLICY "update own programs" ON programs FOR UPDATE
+  USING (auth.uid() = user_id AND is_fixed = false);
+CREATE POLICY "delete own programs" ON programs FOR DELETE
+  USING (auth.uid() = user_id AND is_fixed = false);
+
+-- RLS: program_sessions — read if fixed program OR own program
+DROP POLICY IF EXISTS "read fixed program sessions" ON program_sessions;
+CREATE POLICY "read program sessions" ON program_sessions FOR SELECT USING (
+  EXISTS (SELECT 1 FROM programs WHERE id = program_id
+    AND (is_fixed = true OR (user_id IS NOT NULL AND auth.uid() = user_id)))
+);
+CREATE POLICY "insert own program sessions" ON program_sessions FOR INSERT
+  WITH CHECK (EXISTS (SELECT 1 FROM programs WHERE id = program_id
+    AND user_id = auth.uid() AND is_fixed = false));
+CREATE POLICY "delete own program sessions" ON program_sessions FOR DELETE
+  USING (EXISTS (SELECT 1 FROM programs WHERE id = program_id
+    AND user_id = auth.uid() AND is_fixed = false));
+
+-- Index for fast user program lookups
+CREATE INDEX IF NOT EXISTS idx_programs_user ON programs(user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Onboarding 3 étapes** : objectifs, profil sportif, configuration du programme
- **Edge Function `generate-program`** : appel Claude Sonnet 4.6, validation + retry, insertion atomique (programs + program_sessions)
- **Affichage programme IA** : note coach, consignes par semaine, semaines collapsables, progression, suppression avec modal
- **Section "Mes programmes"** dans ProgramList + CTA sur Home
- Validation input (allowlists blessures/sexe/objectifs/matériel, bounds âge), sanitisation des strings AI
- Rate limit 3/24h, max 3 programmes actifs, cap séances pour débutants

## Fichiers clés

| Fichier | Description |
|---------|-------------|
| `supabase/migrations/004_custom_programs.sql` | ALTER programs + fix FK SET NULL + RLS |
| `supabase/functions/generate-program/` | Edge function (index, prompt, validate) |
| `src/components/CreateProgramPage.tsx` | Wizard onboarding 3 étapes |
| `src/components/ProgramPage.tsx` | Adaptations programmes IA (note, consignes, collapse, delete) |
| `src/types/custom-program.ts` | Types TypeScript |
| `src/hooks/useGenerateProgram.ts` | Hook génération |
| `src/hooks/useUserPrograms.ts` | Hook liste programmes user |

## Test plan

- [ ] Feature flag off → aucun CTA/route programme custom visible
- [ ] Feature flag on → CTA visible sur Home et ProgramList
- [ ] Avec 3 programmes actifs → message bloquant sur `/programme/creer`
- [ ] Onboarding : validation par étape, cap 3 séances si fréquence faible
- [ ] Génération retourne un programme valide, redirige vers `/programme/:slug`
- [ ] ProgramPage affiche note_coach, consignes, progression, gradient hero
- [ ] Semaines futures collapsées, semaine courante expandue
- [ ] Séances AI jouables via le Player existant
- [ ] Suppression programme → historique conservé, redirect `/programmes?deleted=1`
- [ ] Rate limit : 4e génération en 24h refusée
- [ ] Programmes fixes : aucune régression
- [ ] Modal suppression : thème dark/light correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)