### PR TITLE
feat: refonte UX connectée — dashboard, programmes, navigation

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -82,6 +82,26 @@ function UserIcon() {
   );
 }
 
+function ChartIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="20" x2="18" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </svg>
+  );
+}
+
 function PlayIcon() {
   return (
     <svg
@@ -124,15 +144,17 @@ function NavItem({
 
 export function BottomNav() {
   const { pathname } = useLocation();
-  const { user, profile, loading } = useAuth();
+  const { user, profile } = useAuth();
   const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
 
   const isHome = pathname === '/';
   const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
   const isPrograms = pathname.startsWith('/programme');
-  const isProfile = pathname === '/profil' || pathname === '/login' || pathname === '/signup';
+  const isSuivi = pathname === '/suivi';
+  const isProfile = pathname === '/parametres' || pathname === '/profil' || pathname === '/login' || pathname === '/signup';
 
-  const profileTo = user ? '/profil' : '/login';
+  const suiviTo = user ? '/suivi' : '/login';
+  const profileTo = user ? '/parametres' : '/login';
   const profileLabel = user ? 'Profil' : 'Connexion';
 
   return (
@@ -148,7 +170,7 @@ export function BottomNav() {
           <NavItem to="/" label="Accueil" active={isHome}>
             <HomeIcon />
           </NavItem>
-          <NavItem to="/decouvrir" label="Découvrir" active={isDiscover}>
+          <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
             <DiscoverIcon />
           </NavItem>
 
@@ -167,15 +189,23 @@ export function BottomNav() {
           <NavItem to="/programmes" label="Programmes" active={isPrograms}>
             <ProgramsIcon />
           </NavItem>
+          {user && (
+            <NavItem to={suiviTo} label="Suivi" active={isSuivi}>
+              <ChartIcon />
+            </NavItem>
+          )}
+          {!user && (
           <NavItem to={profileTo} label={profileLabel} active={isProfile}>
-            {!loading && user ? (
-              <div className="w-6 h-6 rounded-full flex items-center justify-center text-xs text-white font-bold bg-brand">
+            <UserIcon />
+          </NavItem>
+          )}
+          {user && (
+            <NavItem to={profileTo} label={profileLabel} active={isProfile}>
+              <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] text-white font-bold bg-brand">
                 {getInitials(profile?.display_name ?? user.user_metadata?.display_name, user.email)}
               </div>
-            ) : (
-              <UserIcon />
-            )}
-          </NavItem>
+            </NavItem>
+          )}
         </div>
       </nav>
     </>

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -1,26 +1,21 @@
 import { Link, useLocation } from 'react-router';
-import { useTheme } from '../hooks/useTheme.ts';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { AuthButton } from './auth/AuthButton.tsx';
-
-const THEME_LABELS = {
-  system: 'Thème automatique (système)',
-  light: 'Mode clair',
-  dark: 'Mode sombre',
-} as const;
 
 const NAV_ITEMS = [
   { to: '/', label: 'Accueil', match: (p: string) => p === '/' },
   {
     to: '/decouvrir',
-    label: 'Découvrir',
+    label: 'Explorer',
     match: (p: string) => p === '/decouvrir' || p.startsWith('/formats') || p.startsWith('/exercices'),
   },
   { to: '/programmes', label: 'Programmes', match: (p: string) => p.startsWith('/programme') },
+  { to: '/suivi', label: 'Suivi', match: (p: string) => p === '/suivi', requiresAuth: true },
 ] as const;
 
 export function BrandHeader() {
-  const { preference, cycleTheme } = useTheme();
   const { pathname } = useLocation();
+  const { user } = useAuth();
 
   return (
     <header className="px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
@@ -37,7 +32,7 @@ export function BrandHeader() {
 
         {/* Nav — desktop only, BottomNav handles mobile */}
         <nav className="hidden md:flex items-center gap-1" aria-label="Navigation principale">
-          {NAV_ITEMS.map((item) => {
+          {NAV_ITEMS.filter((item) => !('requiresAuth' in item && item.requiresAuth) || user).map((item) => {
             const active = item.match(pathname);
             return (
               <Link
@@ -57,84 +52,8 @@ export function BrandHeader() {
         {/* Controls */}
         <div className="flex items-center gap-2">
           <AuthButton />
-          <button
-            type="button"
-            onClick={cycleTheme}
-            className="flex p-2 rounded-xl border border-divider hover:border-divider-strong transition-colors"
-            aria-label={THEME_LABELS[preference]}
-            title={THEME_LABELS[preference]}
-          >
-            {preference === 'dark' ? <MoonIcon /> : preference === 'light' ? <SunIcon /> : <AutoIcon />}
-          </button>
         </div>
       </div>
     </header>
-  );
-}
-
-function SunIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="text-muted"
-    >
-      <circle cx="12" cy="12" r="5" />
-      <line x1="12" y1="1" x2="12" y2="3" />
-      <line x1="12" y1="21" x2="12" y2="23" />
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-      <line x1="1" y1="12" x2="3" y2="12" />
-      <line x1="21" y1="12" x2="23" y2="12" />
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-    </svg>
-  );
-}
-
-function MoonIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="text-muted"
-    >
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-    </svg>
-  );
-}
-
-function AutoIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="text-muted"
-    >
-      <circle cx="12" cy="12" r="9" />
-      <path d="M12 3a9 9 0 0 1 0 18" fill="currentColor" opacity="0.3" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
   );
 }

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -117,13 +117,16 @@ function ConnectedContent({
   tomorrowKey: string;
   onStart: () => void;
 }) {
-  const { user } = useAuth();
+  const { user, profile } = useAuth();
   const { activeProgram, loading: programLoading } = useActiveProgram(user?.id);
 
   const progressPct =
     activeProgram && activeProgram.totalSessions > 0
       ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
       : 0;
+
+  const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '')
+    .split(' ')[0];
 
   return (
     <div className="px-6 md:px-10 lg:px-14 py-8">
@@ -132,6 +135,11 @@ function ConnectedContent({
 
         {/* ── Titre + 3 colonnes d'action ── */}
         <section>
+          {firstName && (
+            <p className="text-sm text-muted mb-1">
+              Salut {firstName}
+            </p>
+          )}
           <h2 className="font-display text-2xl sm:text-3xl font-black text-heading mb-6">
             Aujourd'hui je &hellip;
           </h2>

--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -1,18 +1,7 @@
 import { Link } from 'react-router';
 import type { Program } from '../types/completion.ts';
+import { FITNESS_COLORS, FITNESS_LABELS } from '../utils/labels.ts';
 import { getProgramImage } from '../utils/programImage.ts';
-
-const FITNESS_LABELS: Record<string, string> = {
-  beginner: 'Débutant',
-  intermediate: 'Intermédiaire',
-  advanced: 'Avancé',
-};
-
-const FITNESS_COLORS: Record<string, string> = {
-  beginner: 'bg-emerald-500/30 text-emerald-200 border-emerald-400/40',
-  intermediate: 'bg-amber-500/30 text-amber-200 border-amber-400/40',
-  advanced: 'bg-red-500/30 text-red-200 border-red-400/40',
-};
 
 export function ProgramCard({ program }: { program: Program }) {
   const image = getProgramImage(program.slug);

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -1,18 +1,42 @@
 import { Link, useSearchParams } from 'react-router';
+import { ChevronRight, Play, Plus } from 'lucide-react';
 import { FEATURE_CUSTOM_SESSION } from '../config/features.ts';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
-import { usePrograms } from '../hooks/useProgram.ts';
+import { useActiveProgram, usePrograms } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import { supabase } from '../lib/supabase.ts';
+import { getAIProgramImage, getProgramImage } from '../utils/programImage.ts';
 import { ProgramCard } from './ProgramCard.tsx';
+
+const GOAL_LABELS: Record<string, string> = {
+  perte_poids: 'Perte de poids',
+  prise_muscle: 'Prise de muscle',
+  remise_forme: 'Remise en forme',
+  force: 'Force',
+  endurance: 'Endurance',
+  performance_sportive: 'Performance sportive',
+  bien_etre: 'Bien-être',
+  souplesse: 'Souplesse',
+};
 
 export function ProgramList() {
   const { user } = useAuth();
   const { programs, loading } = usePrograms();
   const { programs: userPrograms, loading: userLoading } = useUserPrograms();
+  const { activeProgram, loading: activeProgramLoading } = useActiveProgram(user?.id);
   const [searchParams] = useSearchParams();
   const justDeleted = searchParams.get('deleted') === '1';
+
+  const progressPct = activeProgram
+    ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
+    : 0;
+
+  // Check if active program is an AI program (not in fixed programs list)
+  const isActiveAI = activeProgram && !programs.find((p) => p.slug === activeProgram.slug);
+  const activeImage = activeProgram
+    ? isActiveAI ? getAIProgramImage() : getProgramImage(activeProgram.slug)
+    : '';
 
   useDocumentHead({
     title: 'Programmes',
@@ -21,17 +45,15 @@ export function ProgramList() {
   });
 
   return (
-    <div className="max-w-3xl mx-auto px-6 py-8 space-y-8">
-      {/* Hero */}
-      <section className="text-center space-y-4 py-4 md:py-8">
-        <h1 className="font-display text-3xl md:text-4xl font-black tracking-tight text-heading">
-          Nos <span className="gradient-text">programmes</span>
-        </h1>
-        <p className="text-base text-muted max-w-md mx-auto leading-relaxed">
+    <div className="max-w-6xl mx-auto px-4 md:px-10 lg:px-14 py-6 md:py-8 space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="font-display text-2xl md:text-3xl font-black text-heading">Programmes</h1>
+        <p className="text-sm text-muted mt-1 max-w-lg">
           Atteins tes objectifs avec des programmes conçus pour des résultats visibles.
           {!user && ' Crée ton compte gratuit pour suivre ton avancement.'}
         </p>
-      </section>
+      </div>
 
       {/* Deleted confirmation */}
       {justDeleted && (
@@ -40,78 +62,146 @@ export function ProgramList() {
         </div>
       )}
 
-      {/* My AI programs (feature-flagged, logged-in) */}
-      {FEATURE_CUSTOM_SESSION && user && (
-        <section className="space-y-4">
-          <h2 className="text-lg font-bold text-heading">Mes programmes</h2>
-
-          <Link
-            to="/programme/creer"
-            className="block w-full cta-gradient py-3.5 rounded-xl text-sm font-bold text-white text-center cursor-pointer"
-          >
-            Créer mon programme
-          </Link>
-
-          {userLoading && (
-            <div className="flex items-center justify-center py-6">
-              <div className="w-5 h-5 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+      {/* ── Active program hero ── */}
+      {user && !activeProgramLoading && activeProgram && (
+        <section className="relative rounded-2xl overflow-hidden">
+          <img
+            src={activeImage}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-black/60 to-black/30" />
+          <div className="relative z-10 flex flex-col md:flex-row md:items-center gap-6 p-6 md:p-8">
+            {/* Donut */}
+            <div className="relative shrink-0 hidden md:block">
+              <svg width="100" height="100" viewBox="0 0 100 100" className="-rotate-90">
+                <circle cx="50" cy="50" r="40" fill="none" stroke="rgba(255,255,255,0.15)" strokeWidth="7" />
+                <circle
+                  cx="50" cy="50" r="40"
+                  fill="none" stroke="white" strokeWidth="7" strokeLinecap="round"
+                  strokeDasharray={2 * Math.PI * 40}
+                  strokeDashoffset={2 * Math.PI * 40 * (1 - progressPct / 100)}
+                  className="transition-all duration-500"
+                />
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="font-display text-xl font-black text-white">{progressPct}%</span>
+              </div>
             </div>
-          )}
 
-          {!userLoading && userPrograms.length === 0 && (
-            <p className="text-sm text-muted text-center py-4">
-              Tu n'as pas encore de programme personnalisé.
-            </p>
-          )}
-
-          {!userLoading && userPrograms.length > 0 && (
-            <div className="space-y-3">
-              {userPrograms.map((p) => {
-                const goalLabel = p.goals?.[0] ?? '';
-                return (
-                  <Link
-                    key={p.id}
-                    to={`/programme/${p.slug}/suivi`}
-                    className="glass-card rounded-xl px-4 py-3 flex items-center gap-3 group transition-colors hover:border-brand/30 cursor-pointer"
-                  >
-                    <div className="w-10 h-10 rounded-full bg-brand/15 flex items-center justify-center shrink-0">
-                      <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
-                        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
-                      </svg>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-semibold text-heading group-hover:text-brand transition-colors truncate">
-                        {p.title}
-                      </p>
-                      <p className="text-xs text-muted truncate">
-                        {goalLabel} · {p.duration_weeks} sem · {p.frequency_per_week}x/sem
-                      </p>
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      width="16"
-                      height="16"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      className="text-muted shrink-0"
-                    >
-                      <path d="M9 18l6-6-6-6" />
-                    </svg>
-                  </Link>
-                );
-              })}
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold uppercase tracking-wider text-brand-secondary mb-1">Programme en cours</p>
+              <h2 className="font-display text-xl md:text-2xl font-black text-white mb-2 truncate">
+                {activeProgram.title}
+              </h2>
+              <div className="flex items-center gap-4 text-sm text-white/60">
+                <span>{activeProgram.completedCount}/{activeProgram.totalSessions} séances</span>
+                {activeProgram.nextSessionTitle && (
+                  <span className="truncate">
+                    Prochaine : <span className="text-white/90 font-semibold">{activeProgram.nextSessionTitle}</span>
+                  </span>
+                )}
+              </div>
+              {/* Progress bar — mobile (replaces donut) */}
+              <div className="md:hidden mt-3">
+                <div className="h-2 rounded-full bg-white/15 overflow-hidden">
+                  <div className="h-full rounded-full bg-white transition-all" style={{ width: `${progressPct}%` }} />
+                </div>
+                <p className="text-xs text-white/50 mt-1">{progressPct}% complété</p>
+              </div>
             </div>
-          )}
+
+            {/* CTA */}
+            <div className="flex gap-3 shrink-0">
+              {activeProgram.nextSessionOrder != null && (
+                <Link
+                  to={`/programme/${activeProgram.slug}/seance/${activeProgram.nextSessionOrder}/play`}
+                  className="flex items-center gap-2 px-5 py-3 rounded-xl bg-white text-black text-sm font-bold hover:bg-white/90 transition-colors"
+                >
+                  <Play className="w-4 h-4" aria-hidden="true" />
+                  Continuer
+                </Link>
+              )}
+              <Link
+                to={`/programme/${activeProgram.slug}/suivi`}
+                className="flex items-center gap-2 px-4 py-3 rounded-xl border border-white/20 text-white text-sm font-semibold hover:bg-white/10 transition-colors"
+              >
+                Voir le suivi
+                <ChevronRight className="w-4 h-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
         </section>
       )}
 
-      {/* Fixed programs */}
+      {/* ── My programs (logged-in, feature-flagged) ── */}
+      {FEATURE_CUSTOM_SESSION && user && (
+        <section className="space-y-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-subtle">Mes programmes</h2>
+
+          {/* CTA */}
+          <Link
+            to="/programme/creer"
+            className="group flex items-center gap-3 rounded-xl border border-dashed border-brand/30 hover:border-brand/60 bg-brand/5 hover:bg-brand/10 px-5 py-3 transition-all cursor-pointer"
+          >
+            <div className="w-10 h-10 rounded-xl bg-brand/15 flex items-center justify-center group-hover:bg-brand/25 transition-colors shrink-0">
+              <Plus className="w-5 h-5 text-brand" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-sm font-bold text-brand">Créer un programme</p>
+              <p className="text-xs text-muted">Généré par IA, adapté à toi</p>
+            </div>
+          </Link>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+            {userLoading && (
+              <div className="rounded-2xl border border-divider bg-surface-card p-6 flex items-center justify-center min-h-[220px]">
+                <div className="w-5 h-5 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+              </div>
+            )}
+
+            {!userLoading && userPrograms.map((p) => {
+              const goalLabel = GOAL_LABELS[p.goals?.[0] ?? ''] ?? p.goals?.[0] ?? '';
+              const image = getAIProgramImage();
+              return (
+                <Link
+                  key={p.id}
+                  to={`/programme/${p.slug}/suivi`}
+                  className="group relative rounded-2xl overflow-hidden cursor-pointer transition-transform hover:scale-[1.01] min-h-[220px] sm:min-h-[260px] flex flex-col"
+                >
+                  <img
+                    src={image}
+                    alt=""
+                    className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
+                    loading="lazy"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/70 transition-opacity group-hover:opacity-70" />
+                  <div className="relative z-10 flex flex-col justify-between flex-1 p-5">
+                    <span className="self-start text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full bg-brand/30 border border-brand/40 text-white backdrop-blur-sm">
+                      IA
+                    </span>
+                    <div className="mt-auto space-y-1.5">
+                      <p className="text-lg font-bold text-white group-hover:text-white/90 transition-colors line-clamp-2">
+                        {p.title}
+                      </p>
+                      <p className="text-xs text-white/50">
+                        {goalLabel && <span>{goalLabel} · </span>}
+                        {p.duration_weeks} sem · {p.frequency_per_week}x/sem
+                      </p>
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* ── Fixed programs ── */}
       <section className="space-y-4">
         {FEATURE_CUSTOM_SESSION && user && (
-          <h2 className="text-lg font-bold text-heading">Programmes guidés</h2>
+          <h2 className="text-xs font-bold uppercase tracking-wider text-subtle">Programmes guidés</h2>
         )}
 
         {loading && (
@@ -129,7 +219,7 @@ export function ProgramList() {
         )}
 
         {!loading && programs.length > 0 && (
-          <div className="grid grid-cols-1 gap-5">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
             {programs.map((p) => (
               <ProgramCard key={p.id} program={p} />
             ))}

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -6,19 +6,9 @@ import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useActiveProgram, usePrograms } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import { supabase } from '../lib/supabase.ts';
+import { GOAL_LABELS } from '../utils/labels.ts';
 import { getAIProgramImage, getProgramImage } from '../utils/programImage.ts';
 import { ProgramCard } from './ProgramCard.tsx';
-
-const GOAL_LABELS: Record<string, string> = {
-  perte_poids: 'Perte de poids',
-  prise_muscle: 'Prise de muscle',
-  remise_forme: 'Remise en forme',
-  force: 'Force',
-  endurance: 'Endurance',
-  performance_sportive: 'Performance sportive',
-  bien_etre: 'Bien-être',
-  souplesse: 'Souplesse',
-};
 
 export function ProgramList() {
   const { user } = useAuth();
@@ -28,7 +18,7 @@ export function ProgramList() {
   const [searchParams] = useSearchParams();
   const justDeleted = searchParams.get('deleted') === '1';
 
-  const progressPct = activeProgram
+  const progressPct = activeProgram && activeProgram.totalSessions > 0
     ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
     : 0;
 

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -6,43 +6,10 @@ import { useHealthCheck } from '../hooks/useHealthCheck.ts';
 import { useProgram } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import type { Session } from '../types/session.ts';
+import { FITNESS_COLORS, FITNESS_LABELS, GOAL_COLORS, GOAL_LABELS } from '../utils/labels.ts';
 import { getAIProgramImage, getProgramImage } from '../utils/programImage.ts';
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 import { SessionAccordion } from './SessionAccordion.tsx';
-
-const FITNESS_LABELS: Record<string, string> = {
-  beginner: 'Débutant',
-  intermediate: 'Intermédiaire',
-  advanced: 'Avancé',
-};
-
-const GOAL_LABELS: Record<string, string> = {
-  perte_poids: 'Perte de poids',
-  prise_muscle: 'Prise de muscle',
-  remise_forme: 'Remise en forme',
-  force: 'Force',
-  endurance: 'Endurance',
-  performance_sportive: 'Performance sportive',
-  bien_etre: 'Bien-être',
-  souplesse: 'Souplesse',
-};
-
-const GOAL_COLORS: Record<string, string> = {
-  perte_poids: 'bg-rose-400/80',
-  prise_muscle: 'bg-orange-400/80',
-  remise_forme: 'bg-amber-400/80',
-  force: 'bg-red-400/80',
-  endurance: 'bg-sky-400/80',
-  performance_sportive: 'bg-pink-400/80',
-  bien_etre: 'bg-teal-400/80',
-  souplesse: 'bg-violet-400/80',
-};
-
-const FITNESS_COLORS: Record<string, string> = {
-  beginner: 'bg-emerald-500/30 text-emerald-200 border-emerald-400/40',
-  intermediate: 'bg-amber-500/30 text-amber-200 border-amber-400/40',
-  advanced: 'bg-red-500/30 text-red-200 border-red-400/40',
-};
 
 function getConsigneForWeek(consignes: Record<string, string> | null, week: number): string | null {
   if (!consignes) return null;

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -6,7 +6,7 @@ import { useHealthCheck } from '../hooks/useHealthCheck.ts';
 import { useProgram } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import type { Session } from '../types/session.ts';
-import { getProgramImage } from '../utils/programImage.ts';
+import { getAIProgramImage, getProgramImage } from '../utils/programImage.ts';
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 import { SessionAccordion } from './SessionAccordion.tsx';
 
@@ -14,6 +14,28 @@ const FITNESS_LABELS: Record<string, string> = {
   beginner: 'Débutant',
   intermediate: 'Intermédiaire',
   advanced: 'Avancé',
+};
+
+const GOAL_LABELS: Record<string, string> = {
+  perte_poids: 'Perte de poids',
+  prise_muscle: 'Prise de muscle',
+  remise_forme: 'Remise en forme',
+  force: 'Force',
+  endurance: 'Endurance',
+  performance_sportive: 'Performance sportive',
+  bien_etre: 'Bien-être',
+  souplesse: 'Souplesse',
+};
+
+const GOAL_COLORS: Record<string, string> = {
+  perte_poids: 'bg-rose-400/80',
+  prise_muscle: 'bg-orange-400/80',
+  remise_forme: 'bg-amber-400/80',
+  force: 'bg-red-400/80',
+  endurance: 'bg-sky-400/80',
+  performance_sportive: 'bg-pink-400/80',
+  bien_etre: 'bg-teal-400/80',
+  souplesse: 'bg-violet-400/80',
 };
 
 const FITNESS_COLORS: Record<string, string> = {
@@ -184,18 +206,12 @@ export function ProgramPage() {
         {/* Hero */}
         <section className="space-y-5 -mx-6 -mt-8 md:mx-0 md:mt-0">
           <div className="relative min-h-[220px] sm:min-h-[280px] md:rounded-2xl overflow-hidden">
-            {isCustom ? (
-              <div className="absolute inset-0 bg-gradient-to-br from-brand/30 via-surface to-brand-secondary/20" />
-            ) : (
-              <>
-                <img
-                  src={getProgramImage(program.slug)}
-                  alt=""
-                  className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
-                />
-                <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/75" />
-              </>
-            )}
+            <img
+              src={isCustom ? getAIProgramImage() : getProgramImage(program.slug)}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
+            />
+            <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/75" />
 
             <div className="relative z-10 flex flex-col justify-between min-h-[220px] sm:min-h-[280px] p-6">
               <div className="flex items-start justify-between">
@@ -225,12 +241,12 @@ export function ProgramPage() {
                   {FITNESS_LABELS[program.fitness_level] ?? program.fitness_level}
                 </span>
 
-                <h1 className={`font-display text-3xl md:text-4xl font-black tracking-tight ${isCustom ? 'text-heading' : 'text-white'}`}>
+                <h1 className="font-display text-3xl md:text-4xl font-black tracking-tight text-white">
                   {program.title}
                 </h1>
 
                 {program.description && (
-                  <p className={`text-sm leading-relaxed ${isCustom ? 'text-muted' : 'text-white/70'}`}>{program.description}</p>
+                  <p className="text-sm leading-relaxed text-white/70">{program.description}</p>
                 )}
 
                 <div className={`flex items-center gap-3 text-xs ${isCustom ? 'text-faint' : 'text-white/50'}`}>
@@ -256,13 +272,9 @@ export function ProgramPage() {
                     {program.goals.map((goal) => (
                       <li
                         key={goal}
-                        className={`text-xs font-medium px-2.5 py-1 rounded-full border ${
-                          isCustom
-                            ? 'bg-white/5 border-divider text-muted'
-                            : 'bg-white/10 border-white/15 text-white/70'
-                        }`}
+                        className={`text-xs font-bold px-2.5 py-1 rounded-full text-white ${GOAL_COLORS[goal] ?? 'bg-rose-400/80'}`}
                       >
-                        {goal}
+                        {GOAL_LABELS[goal] ?? goal}
                       </li>
                     ))}
                   </ul>

--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -22,9 +22,9 @@ export function AuthButton() {
 
   return (
     <Link
-      to="/profil"
+      to="/parametres"
       className="w-8 h-8 rounded-full flex items-center justify-center text-xs text-white font-bold bg-brand shrink-0"
-      aria-label="Mon profil"
+      aria-label="Parametres"
     >
       {initials}
     </Link>

--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -24,7 +24,7 @@ export function AuthButton() {
     <Link
       to="/parametres"
       className="w-8 h-8 rounded-full flex items-center justify-center text-xs text-white font-bold bg-brand shrink-0"
-      aria-label="Parametres"
+      aria-label="Paramètres"
     >
       {initials}
     </Link>

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -1,0 +1,100 @@
+import { Link } from 'react-router';
+import { Moon, Sun, Monitor } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { useTheme } from '../../hooks/useTheme.ts';
+import { getInitials } from '../../utils/getInitials.ts';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+const THEME_OPTIONS = [
+  { value: 'light' as const, label: 'Clair', Icon: Sun },
+  { value: 'dark' as const, label: 'Sombre', Icon: Moon },
+  { value: 'system' as const, label: 'Système', Icon: Monitor },
+];
+
+export function SettingsPage() {
+  const { user, profile, signOut } = useAuth();
+  const { preference, setTheme } = useTheme();
+
+  useDocumentHead({
+    title: 'Paramètres',
+    description: 'Gérez votre compte WanShape.',
+  });
+
+  const displayName = profile?.display_name ?? user?.user_metadata?.display_name;
+  const initials = getInitials(displayName, user?.email);
+
+  return (
+    <div className="px-6 py-8 flex-1 flex items-start justify-center">
+      <div className="w-full max-w-md space-y-8">
+        {/* Identity */}
+        <div className="flex items-center gap-4">
+          <div
+            className="w-14 h-14 rounded-full flex items-center justify-center text-white font-bold text-lg shrink-0 bg-brand"
+            aria-hidden="true"
+          >
+            {initials}
+          </div>
+          <div className="min-w-0 flex-1">
+            {displayName && <h1 className="text-xl font-bold text-heading truncate">{displayName}</h1>}
+            <p className="text-sm text-muted truncate">{user?.email}</p>
+            <p className="text-xs text-faint mt-0.5">
+              Membre depuis {user?.created_at ? formatDate(user.created_at) : '—'}
+            </p>
+          </div>
+        </div>
+
+        {/* Theme */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-bold uppercase tracking-wider text-subtle">Apparence</h2>
+          <div className="flex gap-2">
+            {THEME_OPTIONS.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setTheme(value)}
+                className={`flex-1 flex flex-col items-center gap-2 py-3 rounded-xl border transition-colors cursor-pointer ${
+                  preference === value
+                    ? 'border-brand bg-brand/10 text-brand'
+                    : 'border-divider text-muted hover:border-divider-strong'
+                }`}
+              >
+                <Icon className="w-5 h-5" aria-hidden="true" />
+                <span className="text-xs font-medium">{label}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* Legal */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-bold uppercase tracking-wider text-subtle">Informations</h2>
+          <div className="space-y-1">
+            <Link to="/legal/cgu" className="block py-2.5 text-sm text-body hover:text-heading transition-colors">
+              Conditions d'utilisation
+            </Link>
+            <Link to="/legal/privacy" className="block py-2.5 text-sm text-body hover:text-heading transition-colors">
+              Politique de confidentialité
+            </Link>
+          </div>
+        </section>
+
+        {/* Sign out */}
+        <button
+          type="button"
+          onClick={signOut}
+          className="w-full py-3 rounded-xl text-red-400 font-semibold border border-red-400/30 hover:bg-red-400/10 transition-colors cursor-pointer"
+        >
+          Se déconnecter
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -51,7 +51,7 @@ export function StatsPage() {
   const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '')
     .split(' ')[0];
 
-  const progressPct = activeProgram
+  const progressPct = activeProgram && activeProgram.totalSessions > 0
     ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
     : 0;
 

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -1,0 +1,431 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import { ChevronRight } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { useHistory } from '../../hooks/useHistory.ts';
+import type { CompletionWithTitle, WeeklyData } from '../../hooks/useHistory.ts';
+import { useActiveProgram } from '../../hooks/useProgram.ts';
+
+const DAY_LABELS = ['L', 'M', 'M', 'J', 'V', 'S', 'D'];
+
+type HistoryFilter = 'all' | 'program' | 'free';
+
+function formatDuration(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.round((totalSeconds % 3600) / 60);
+  if (h === 0) return `${m}`;
+  return `${h}h${m > 0 ? String(m).padStart(2, '0') : ''}`;
+}
+
+function formatDurationUnit(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  if (h === 0) return 'min';
+  return '';
+}
+
+function formatShortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function formatMonthYear(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export function StatsPage() {
+  const { user, profile } = useAuth();
+  const { completions, consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading } = useHistory(user?.id);
+  const { activeProgram } = useActiveProgram(user?.id);
+
+  useDocumentHead({
+    title: 'Suivi',
+    description: 'Tableau de bord sportif WanShape.',
+  });
+
+  const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '')
+    .split(' ')[0];
+
+  const progressPct = activeProgram
+    ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
+    : 0;
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center min-h-[60vh]">
+        <div className="w-6 h-6 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (totalSessions === 0) {
+    return (
+      <div className="flex-1 px-6 md:px-10 lg:px-14 py-12">
+        <div className="max-w-md mx-auto text-center space-y-6">
+          <div className="w-20 h-20 rounded-2xl bg-brand/10 flex items-center justify-center mx-auto">
+            <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+          </div>
+          {firstName && <p className="text-muted">Salut {firstName}</p>}
+          <h1 className="font-display text-2xl font-black text-heading">Pas encore de stats</h1>
+          <p className="text-body text-sm">
+            Lance ta première séance pour commencer à suivre ta progression ici.
+          </p>
+          <Link to="/" className="inline-flex items-center gap-2 text-sm font-bold text-brand hover:text-brand/80 transition-colors">
+            Séance du jour
+            <ChevronRight className="w-4 h-4" aria-hidden="true" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 px-4 md:px-10 lg:px-14 py-6 md:py-8">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header */}
+        {firstName && (
+          <div>
+            <p className="text-sm text-muted">Salut {firstName}</p>
+            <h1 className="font-display text-2xl md:text-3xl font-black text-heading">Suivi</h1>
+          </div>
+        )}
+
+        {/* ── Bento Grid ── */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+
+          {/* Metric: Total sessions */}
+          <div className="rounded-2xl bg-brand p-5 text-white">
+            <div className="text-xs font-semibold uppercase tracking-wider opacity-70 mb-3">Séances</div>
+            <div className="font-display text-4xl md:text-5xl font-black leading-none">{totalSessions}</div>
+            <div className="text-xs opacity-60 mt-1">total</div>
+          </div>
+
+          {/* Metric: Total duration */}
+          <div className="rounded-2xl bg-surface-card border border-divider p-5">
+            <div className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Temps</div>
+            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
+              {formatDuration(totalDuration)}
+              <span className="text-lg font-normal text-muted ml-0.5">{formatDurationUnit(totalDuration)}</span>
+            </div>
+            <div className="text-xs text-muted mt-1">cumulé</div>
+          </div>
+
+          {/* Weekly bar chart — spans 2 cols, 2 rows on desktop */}
+          <div className="col-span-2 md:row-span-2 rounded-2xl bg-surface-card border border-divider p-5">
+            <WeeklyBarChart data={weeklyChart} />
+          </div>
+
+          {/* Metric: This week */}
+          <div className="rounded-2xl bg-emerald-500/15 border border-emerald-500/20 p-5">
+            <div className="text-xs font-semibold uppercase tracking-wider text-emerald-400 mb-3">Semaine</div>
+            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
+              {thisWeekSessions}<span className="text-lg font-normal text-muted">/7</span>
+            </div>
+            <div className="text-xs text-muted mt-1">jours actifs</div>
+          </div>
+
+          {/* Metric: Streak */}
+          <div className="rounded-2xl bg-amber-500/15 border border-amber-500/20 p-5">
+            <div className="text-xs font-semibold uppercase tracking-wider text-amber-400 mb-3">Série</div>
+            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
+              {consecutiveDays}
+            </div>
+            <div className="text-xs text-muted mt-1">jour{consecutiveDays > 1 ? 's' : ''} d'affilée</div>
+          </div>
+
+          {/* Week dots — spans 2 cols */}
+          <div className="col-span-2 rounded-2xl bg-surface-card border border-divider p-5">
+            <WeekDots weekDots={weekDots} />
+          </div>
+
+          {/* Programme progress — spans 2 cols */}
+          {activeProgram ? (
+            <Link
+              to={`/programme/${activeProgram.slug}/suivi`}
+              className="col-span-2 rounded-2xl bg-surface-card border border-divider p-5 group hover:border-brand/30 transition-colors"
+            >
+              <ProgramCard activeProgram={activeProgram} progressPct={progressPct} />
+            </Link>
+          ) : (
+            <Link
+              to="/programmes"
+              className="col-span-2 rounded-2xl border border-dashed border-divider-strong p-5 flex items-center gap-4 group hover:border-brand/30 transition-colors"
+            >
+              <div className="w-12 h-12 rounded-xl bg-brand/10 flex items-center justify-center shrink-0">
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+                  <rect x="3" y="3" width="7" height="7" />
+                  <rect x="14" y="3" width="7" height="7" />
+                  <rect x="3" y="14" width="7" height="7" />
+                  <rect x="14" y="14" width="7" height="7" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-bold text-heading group-hover:text-brand transition-colors">Découvrir les programmes</p>
+                <p className="text-xs text-muted mt-0.5">Suis un programme structuré pour progresser</p>
+              </div>
+              <ChevronRight className="w-4 h-4 text-muted ml-auto shrink-0" aria-hidden="true" />
+            </Link>
+          )}
+
+          {/* Recent sessions — full width */}
+          <div className="col-span-2 md:col-span-4 rounded-2xl bg-surface-card border border-divider p-5">
+            <RecentSessions completions={completions} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────────────────────────
+   Sub-components
+   ──────────────────────────────────────────── */
+
+function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
+  const maxMinutes = Math.max(...data.map((d) => d.minutes), 1);
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm font-bold text-heading">Volume hebdo</p>
+        <p className="text-xs text-muted">
+          {activeIdx != null ? (
+            <span className="text-heading font-semibold">
+              {data[activeIdx].minutes} min · {data[activeIdx].sessions} séance{data[activeIdx].sessions > 1 ? 's' : ''}
+            </span>
+          ) : (
+            'min / semaine'
+          )}
+        </p>
+      </div>
+      <div className="flex items-end gap-2 flex-1 min-h-[120px]">
+        {data.map((week, i) => {
+          const heightPct = Math.max((week.minutes / maxMinutes) * 100, 4);
+          const isActive = activeIdx === i;
+          return (
+            <button
+              key={week.label}
+              type="button"
+              onClick={() => setActiveIdx(isActive ? null : i)}
+              className="flex-1 flex flex-col items-center gap-1.5 cursor-pointer group"
+            >
+              <div className="w-full flex items-end" style={{ height: '100px' }}>
+                <div
+                  className={`w-full rounded-lg transition-all duration-200 ${
+                    week.isCurrent
+                      ? 'bg-brand shadow-sm shadow-brand/30'
+                      : isActive
+                        ? 'bg-brand/60'
+                        : 'bg-divider-strong group-hover:bg-brand/30'
+                  }`}
+                  style={{ height: `${heightPct}%` }}
+                />
+              </div>
+              <span className={`text-[10px] font-medium ${week.isCurrent ? 'text-brand font-bold' : 'text-muted'}`}>
+                {week.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function WeekDots({ weekDots }: { weekDots: boolean[] }) {
+  const activeDays = weekDots.filter(Boolean).length;
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm font-bold text-heading">Cette semaine</p>
+        <p className="text-xs text-muted">{activeDays} jour{activeDays > 1 ? 's' : ''} d'activité</p>
+      </div>
+      <div className="flex gap-2">
+        {weekDots.map((done, i) => (
+          <div key={i} className="flex-1 flex flex-col items-center gap-2">
+            <div
+              className={`w-full aspect-square max-w-[44px] rounded-xl flex items-center justify-center transition-colors ${
+                done
+                  ? 'bg-emerald-500/20 border-2 border-emerald-500'
+                  : 'bg-surface-2 border-2 border-transparent'
+              }`}
+            >
+              {done && (
+                <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-emerald-400">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </div>
+            <span className="text-[11px] font-medium text-muted">{DAY_LABELS[i]}</span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function ProgramCard({
+  activeProgram,
+  progressPct,
+}: {
+  activeProgram: NonNullable<ReturnType<typeof useActiveProgram>['activeProgram']>;
+  progressPct: number;
+}) {
+  // SVG donut chart
+  const radius = 32;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - progressPct / 100);
+
+  return (
+    <div className="flex items-center gap-5">
+      {/* Donut */}
+      <div className="relative shrink-0">
+        <svg width="80" height="80" viewBox="0 0 80 80" className="-rotate-90">
+          <circle cx="40" cy="40" r={radius} fill="none" stroke="var(--color-divider-strong)" strokeWidth="6" />
+          <circle
+            cx="40"
+            cy="40"
+            r={radius}
+            fill="none"
+            stroke="var(--color-brand)"
+            strokeWidth="6"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            className="transition-all duration-500"
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="font-display text-lg font-black text-heading">{progressPct}%</span>
+        </div>
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-bold uppercase tracking-wider text-brand mb-1">Programme en cours</p>
+        <p className="text-base font-bold text-heading group-hover:text-brand transition-colors truncate">
+          {activeProgram.title}
+        </p>
+        <p className="text-xs text-muted mt-1">
+          {activeProgram.completedCount}/{activeProgram.totalSessions} séances
+        </p>
+        {activeProgram.nextSessionTitle && (
+          <p className="text-xs text-muted mt-1 flex items-center gap-1">
+            Prochaine : <span className="text-heading font-semibold truncate">{activeProgram.nextSessionTitle}</span>
+            <ChevronRight className="w-3 h-3 text-muted shrink-0" aria-hidden="true" />
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RecentSessions({ completions }: { completions: CompletionWithTitle[] }) {
+  const [filter, setFilter] = useState<HistoryFilter>('all');
+  const [limit, setLimit] = useState(10);
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return completions;
+    if (filter === 'program') return completions.filter((c) => c.program_session_id != null);
+    return completions.filter((c) => c.program_session_id == null);
+  }, [completions, filter]);
+
+  const visible = filtered.slice(0, limit);
+  const hasMore = filtered.length > limit;
+
+  const grouped = useMemo(() => {
+    const groups: { month: string; items: CompletionWithTitle[] }[] = [];
+    for (const c of visible) {
+      const month = formatMonthYear(c.completed_at);
+      const last = groups[groups.length - 1];
+      if (last && last.month === month) {
+        last.items.push(c);
+      } else {
+        groups.push({ month, items: [c] });
+      }
+    }
+    return groups;
+  }, [visible]);
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm font-bold text-heading">Historique</p>
+        {/* Filter pills */}
+        <div className="flex items-center gap-1.5">
+          {([
+            { value: 'all' as const, label: 'Tout' },
+            { value: 'program' as const, label: 'Prog' },
+            { value: 'free' as const, label: 'Libre' },
+          ]).map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => { setFilter(value); setLimit(10); }}
+              className={`px-3 py-1 rounded-full text-[11px] font-semibold transition-colors cursor-pointer ${
+                filter === value
+                  ? 'bg-brand text-white'
+                  : 'bg-surface-2 text-muted hover:text-heading'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {grouped.length === 0 ? (
+        <p className="text-sm text-muted text-center py-4">Aucune séance dans cette catégorie.</p>
+      ) : (
+        <div className="space-y-4">
+          {grouped.map(({ month, items }) => (
+            <section key={month}>
+              <h3 className="text-[11px] font-bold uppercase tracking-wider text-subtle mb-2 capitalize">{month}</h3>
+              <div className="space-y-0.5">
+                {items.map((c) => (
+                  <SessionRow key={c.id} completion={c} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => setLimit((l) => l + 20)}
+          className="w-full py-2.5 mt-3 rounded-xl border border-divider text-xs font-semibold text-muted hover:text-heading hover:border-divider-strong transition-colors cursor-pointer"
+        >
+          Charger plus
+        </button>
+      )}
+    </>
+  );
+}
+
+function SessionRow({ completion: c }: { completion: CompletionWithTitle }) {
+  const minutes = c.duration_seconds ? Math.round(c.duration_seconds / 60) : null;
+  const title = c.session_title ?? 'Séance';
+  const isProgram = c.program_session_id != null;
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl px-3 py-2 hover:bg-surface-2/50 transition-colors">
+      <div className={`w-2 h-2 rounded-full shrink-0 ${isProgram ? 'bg-brand' : 'bg-emerald-500'}`} />
+      <p className="text-sm text-heading truncate flex-1">{title}</p>
+      <div className="flex items-center gap-3 shrink-0 text-right">
+        {minutes != null && <span className="text-xs font-medium text-heading">{minutes} min</span>}
+        <span className="text-[11px] text-muted w-14">{formatShortDate(c.completed_at)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -6,12 +6,21 @@ export interface CompletionWithTitle extends SessionCompletion {
   session_title: string | null;
 }
 
+export interface WeeklyData {
+  label: string;
+  minutes: number;
+  sessions: number;
+  isCurrent: boolean;
+}
+
 export interface HistoryStats {
   completions: CompletionWithTitle[];
   consecutiveDays: number;
   totalSessions: number;
   totalDuration: number;
   weekDots: boolean[];
+  weeklyChart: WeeklyData[];
+  thisWeekSessions: number;
   loading: boolean;
 }
 
@@ -77,6 +86,57 @@ function computeWeekDots(completions: SessionCompletion[]): boolean[] {
   return dots;
 }
 
+function getMonday(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  const day = d.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  d.setDate(d.getDate() - diff);
+  return d;
+}
+
+function computeWeeklyChart(completions: SessionCompletion[]): WeeklyData[] {
+  const today = new Date();
+  const currentMonday = getMonday(today);
+
+  // Build 8 weeks of buckets (current + 7 previous)
+  const weeks: WeeklyData[] = [];
+  for (let i = 7; i >= 0; i--) {
+    const monday = new Date(currentMonday);
+    monday.setDate(monday.getDate() - i * 7);
+    const weekNum = getISOWeekNumber(monday);
+    weeks.push({
+      label: `S${weekNum}`,
+      minutes: 0,
+      sessions: 0,
+      isCurrent: i === 0,
+    });
+  }
+
+  // Fill buckets
+  for (const c of completions) {
+    const d = new Date(c.completed_at);
+    const cMonday = getMonday(d);
+    const diffMs = currentMonday.getTime() - cMonday.getTime();
+    const diffWeeks = Math.round(diffMs / (7 * 24 * 60 * 60 * 1000));
+    if (diffWeeks >= 0 && diffWeeks <= 7) {
+      const idx = 7 - diffWeeks;
+      weeks[idx].minutes += Math.round((c.duration_seconds ?? 0) / 60);
+      weeks[idx].sessions += 1;
+    }
+  }
+
+  return weeks;
+}
+
+function getISOWeekNumber(date: Date): number {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+  const yearStart = new Date(d.getFullYear(), 0, 4);
+  return Math.round(((d.getTime() - yearStart.getTime()) / 86400000 - 3 + ((yearStart.getDay() + 6) % 7)) / 7) + 1;
+}
+
 export function useHistory(userId: string | undefined): HistoryStats {
   const [completions, setCompletions] = useState<CompletionWithTitle[]>([]);
   const [loading, setLoading] = useState(true);
@@ -127,6 +187,8 @@ export function useHistory(userId: string | undefined): HistoryStats {
   const totalSessions = completions.length;
   const totalDuration = completions.reduce((sum, c) => sum + (c.duration_seconds ?? 0), 0);
   const weekDots = computeWeekDots(completions);
+  const weeklyChart = computeWeeklyChart(completions);
+  const thisWeekSessions = weekDots.filter(Boolean).length;
 
-  return { completions, consecutiveDays, totalSessions, totalDuration, weekDots, loading };
+  return { completions, consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading };
 }

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
 import type { SessionCompletion } from '../types/completion.ts';
 
@@ -183,12 +183,15 @@ export function useHistory(userId: string | undefined): HistoryStats {
     };
   }, [userId]);
 
-  const consecutiveDays = computeConsecutiveDays(completions);
-  const totalSessions = completions.length;
-  const totalDuration = completions.reduce((sum, c) => sum + (c.duration_seconds ?? 0), 0);
-  const weekDots = computeWeekDots(completions);
-  const weeklyChart = computeWeeklyChart(completions);
-  const thisWeekSessions = weekDots.filter(Boolean).length;
+  const derived = useMemo(() => {
+    const consecutiveDays = computeConsecutiveDays(completions);
+    const totalSessions = completions.length;
+    const totalDuration = completions.reduce((sum, c) => sum + (c.duration_seconds ?? 0), 0);
+    const weekDots = computeWeekDots(completions);
+    const weeklyChart = computeWeeklyChart(completions);
+    const thisWeekSessions = weekDots.filter(Boolean).length;
+    return { consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions };
+  }, [completions]);
 
-  return { completions, consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading };
+  return { completions, ...derived, loading };
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -62,5 +62,9 @@ export function useTheme() {
     });
   }, []);
 
-  return { preference, theme: resolved, cycleTheme } as const;
+  const setTheme = useCallback((pref: ThemePreference) => {
+    setPreference(pref);
+  }, []);
+
+  return { preference, theme: resolved, cycleTheme, setTheme } as const;
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,8 +19,11 @@ const LazySignupPage = lazy(() => import('./components/auth/SignupPage.tsx').the
 const LazyAuthCallback = lazy(() =>
   import('./components/auth/AuthCallback.tsx').then((m) => ({ default: m.AuthCallback })),
 );
-const LazyProfilePage = lazy(() =>
-  import('./components/auth/ProfilePage.tsx').then((m) => ({ default: m.ProfilePage })),
+const LazyStatsPage = lazy(() =>
+  import('./components/auth/StatsPage.tsx').then((m) => ({ default: m.StatsPage })),
+);
+const LazySettingsPage = lazy(() =>
+  import('./components/auth/SettingsPage.tsx').then((m) => ({ default: m.SettingsPage })),
 );
 const LazyDiscover = lazy(() => import('./components/Discover.tsx').then((m) => ({ default: m.Discover })));
 const LazyProgramList = lazy(() => import('./components/ProgramList.tsx').then((m) => ({ default: m.ProgramList })));
@@ -136,15 +139,28 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: 'profil',
+        path: 'suivi',
         element: (
           <Lazy>
             <RequireAuth>
-              <LazyProfilePage />
+              <LazyStatsPage />
             </RequireAuth>
           </Lazy>
         ),
       },
+      { path: 'stats', element: <Navigate to="/suivi" replace /> },
+      {
+        path: 'parametres',
+        element: (
+          <Lazy>
+            <RequireAuth>
+              <LazySettingsPage />
+            </RequireAuth>
+          </Lazy>
+        ),
+      },
+      // Legacy redirects
+      { path: 'profil', element: <Navigate to="/suivi" replace /> },
       // Programme routes
       {
         path: 'programmes',

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -1,0 +1,33 @@
+export const FITNESS_LABELS: Record<string, string> = {
+  beginner: 'Débutant',
+  intermediate: 'Intermédiaire',
+  advanced: 'Avancé',
+};
+
+export const FITNESS_COLORS: Record<string, string> = {
+  beginner: 'bg-emerald-500/30 text-emerald-200 border-emerald-400/40',
+  intermediate: 'bg-amber-500/30 text-amber-200 border-amber-400/40',
+  advanced: 'bg-red-500/30 text-red-200 border-red-400/40',
+};
+
+export const GOAL_LABELS: Record<string, string> = {
+  perte_poids: 'Perte de poids',
+  prise_muscle: 'Prise de muscle',
+  remise_forme: 'Remise en forme',
+  force: 'Force',
+  endurance: 'Endurance',
+  performance_sportive: 'Performance sportive',
+  bien_etre: 'Bien-être',
+  souplesse: 'Souplesse',
+};
+
+export const GOAL_COLORS: Record<string, string> = {
+  perte_poids: 'bg-rose-400/80',
+  prise_muscle: 'bg-orange-400/80',
+  remise_forme: 'bg-amber-400/80',
+  force: 'bg-red-400/80',
+  endurance: 'bg-sky-400/80',
+  performance_sportive: 'bg-pink-400/80',
+  bien_etre: 'bg-teal-400/80',
+  souplesse: 'bg-violet-400/80',
+};

--- a/src/utils/programImage.ts
+++ b/src/utils/programImage.ts
@@ -5,7 +5,12 @@ const PROGRAM_IMAGES: Record<string, string> = {
 };
 
 const DEFAULT_IMAGE = '/images/fullbody.webp';
+const AI_PROGRAM_IMAGE = '/images/illustration-program.webp';
 
 export function getProgramImage(slug: string): string {
   return PROGRAM_IMAGES[slug] ?? DEFAULT_IMAGE;
+}
+
+export function getAIProgramImage(): string {
+  return AI_PROGRAM_IMAGE;
 }


### PR DESCRIPTION
## Summary
- **Dashboard Suivi** : nouvelle page bento avec métriques (séances, série, durée), bar chart hebdo, donut programme actif, historique filtrable par catégorie/mois
- **Programmes redesign** : hero programme actif en haut, cards uniformisées 2 colonnes, image background pour programmes IA, tags goals traduits avec couleurs pastels
- **Navigation** : onglet "Suivi" dédié (desktop + mobile), profil/avatar → Paramètres, toggle thème retiré du header (conservé en Paramètres)
- **Qualité** : labels partagés (DRY), guard division par zéro, aria-labels corrigés, useMemo sur calculs dérivés

## Fichiers clés
| Fichier | Changement |
|---------|-----------|
| `StatsPage.tsx` | Nouveau dashboard bento |
| `SettingsPage.tsx` | Nouvelle page paramètres (thème, identité, legal) |
| `ProgramList.tsx` | Hero programme actif + layout redesign |
| `ProgramPage.tsx` | Image background IA + tags goals colorés |
| `BottomNav.tsx` | Onglet Suivi + profil → paramètres |
| `BrandHeader.tsx` | Nav Suivi + suppression toggle thème |
| `useHistory.ts` | weeklyChart, weekDots, useMemo |
| `utils/labels.ts` | Labels et couleurs partagés |

## Test plan
- [ ] Vérifier dashboard /suivi connecté (métriques, chart, donut, historique)
- [ ] Vérifier page /programmes (hero actif, cards AI + fixes, tags goals)
- [ ] Vérifier /programme/:slug/suivi pour un programme IA (image, tags colorés)
- [ ] Vérifier navigation desktop + mobile (Suivi, Profil → Paramètres)
- [ ] Vérifier /parametres (thème, déconnexion)
- [ ] Vérifier dark + light mode
- [ ] Vérifier mobile 393px + desktop 1440px
- [ ] Vérifier redirects legacy (/stats → /suivi, /profil → /suivi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)