### PR TITLE
feat: refonte page suivi + fix race condition Supabase

### DIFF
--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -22,7 +22,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
   const { save, saved } = useSaveCompletion();
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !durationSeconds) return;
     save({
       sessionDate: programSessionId || customSessionId ? undefined : session.date,
       programSessionId,

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -3,7 +3,6 @@ import { ChevronRight, Play, Rocket, Sparkles } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useHealthCheck } from '../hooks/useHealthCheck.ts';
-import { useHistory } from '../hooks/useHistory.ts';
 import { useActiveProgram, usePrograms } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import { supabase } from '../lib/supabase.ts';
@@ -17,7 +16,6 @@ export function ProgramList() {
   const { programs, loading } = usePrograms();
   const { programs: userPrograms, loading: userLoading } = useUserPrograms();
   const { activeProgram, loading: activeProgramLoading } = useActiveProgram(user?.id);
-  useHistory(user?.id);
   const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
   const [searchParams] = useSearchParams();
   const justDeleted = searchParams.get('deleted') === '1';

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -17,13 +17,12 @@ export function ProgramList() {
   const { programs, loading } = usePrograms();
   const { programs: userPrograms, loading: userLoading } = useUserPrograms();
   const { activeProgram, loading: activeProgramLoading } = useActiveProgram(user?.id);
-  const { totalSessions } = useHistory(user?.id);
+  useHistory(user?.id);
   const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
   const [searchParams] = useSearchParams();
   const justDeleted = searchParams.get('deleted') === '1';
 
   const isPremium = profile?.subscription_tier === 'premium';
-  const totalActive = userPrograms.length;
 
   const progressPct = activeProgram && activeProgram.totalSessions > 0
     ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
@@ -51,13 +50,6 @@ export function ProgramList() {
           Suis tes programmes ou génère-en un nouveau adapté à tes objectifs.
           {!user && ' Crée ton compte gratuit pour suivre ton avancement.'}
         </p>
-        {user && (totalActive > 0 || totalSessions > 0) && (
-          <p className="text-xs text-subtle mt-2">
-            {totalActive > 0 && <>{totalActive} programme{totalActive > 1 ? 's' : ''} actif{totalActive > 1 ? 's' : ''}</>}
-            {totalActive > 0 && totalSessions > 0 && ' · '}
-            {totalSessions > 0 && <>{totalSessions} séance{totalSessions > 1 ? 's' : ''} complétée{totalSessions > 1 ? 's' : ''}</>}
-          </p>
-        )}
       </div>
 
       {/* Deleted confirmation */}

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -136,21 +136,21 @@ export function StatsPage() {
           </div>
 
           {/* This week: dots + contextual message */}
-          <div className={`col-span-2 rounded-2xl p-5 border bg-gradient-to-br ${weekCardStyle(thisWeekSessions).bg} ${weekCardStyle(thisWeekSessions).border}`}>
-            <WeekDots weekDots={weekDots} />
-            {(() => {
-              const msg = getWeekMessage(thisWeekSessions);
-              const style = weekCardStyle(thisWeekSessions);
-              return (
+          {(() => {
+            const style = weekCardStyle(thisWeekSessions);
+            const msg = getWeekMessage(thisWeekSessions);
+            return (
+              <div className={`col-span-2 rounded-2xl p-5 border bg-gradient-to-br ${style.bg} ${style.border}`}>
+                <WeekDots weekDots={weekDots} />
                 <div className="mt-4 rounded-xl border border-divider px-4 py-3 shadow-sm bg-surface-0">
                   <p className={`text-sm font-bold ${style.text}`}>
                     {msg.emoji}{'  '}{msg.title}
                   </p>
                   <p className="text-xs text-body mt-0.5">{msg.subtitle}</p>
                 </div>
-              );
-            })()}
-          </div>
+              </div>
+            );
+          })()}
 
           {/* Programme progress */}
           {activeProgram ? (

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -22,18 +22,53 @@ function formatDurationUnit(totalSeconds: number): string {
   return '';
 }
 
+interface WeekMessage { emoji: string; title: string; subtitle: string }
+
+function getWeekMessage(sessions: number): WeekMessage {
+  const dayOfWeek = new Date().getDay(); // 0 = dimanche
+  const isEndOfWeek = dayOfWeek === 0 || dayOfWeek === 6;
+
+  if (sessions === 0) {
+    return isEndOfWeek
+      ? { emoji: '😌', title: 'Week-end mérité', subtitle: 'Recharge les batteries, lundi on envoie du lourd.' }
+      : { emoji: '🚀', title: 'Nouvelle semaine', subtitle: 'Prêt à t\'entraîner ?' };
+  }
+  if (sessions === 1) {
+    return isEndOfWeek
+      ? { emoji: '💪', title: 'Séance validée', subtitle: 'Belle semaine ! Récupère bien, la suite va être énorme.' }
+      : { emoji: '🔥', title: 'Première séance validée', subtitle: 'Le plus dur est fait.' };
+  }
+  if (sessions === 2) return { emoji: '💪', title: 'Bien lancé', subtitle: 'Tu construis quelque chose de solide.' };
+  if (sessions === 3) return { emoji: '🚀', title: 'Rythme parfait', subtitle: 'Tu es sur la bonne lancée.' };
+  if (sessions === 4) return { emoji: '🔥', title: 'Impressionnant', subtitle: 'Tu dépasses tes objectifs.' };
+  return { emoji: '⚠️', title: 'Attention au surmenage', subtitle: 'Ton corps progresse au repos. Souffle un peu !' };
+}
+
+const WEEK_CARD_STYLES: Record<string, { bg: string; border: string; text: string }> = {
+  idle:    { bg: 'from-slate-500/10 to-slate-500/5',     border: 'border-slate-500/20',   text: 'text-body' },
+  start:   { bg: 'from-emerald-500/20 to-emerald-500/5', border: 'border-emerald-500/30', text: 'text-emerald-700 dark:text-emerald-300' },
+  cruise:  { bg: 'from-blue-500/20 to-blue-500/5',       border: 'border-blue-500/30',    text: 'text-blue-700 dark:text-blue-300' },
+  peak:    { bg: 'from-violet-500/25 to-violet-500/5',   border: 'border-violet-500/30',  text: 'text-violet-700 dark:text-violet-300' },
+  warning: { bg: 'from-amber-500/25 to-amber-500/5',     border: 'border-amber-500/30',   text: 'text-amber-700 dark:text-amber-300' },
+};
+
+function weekCardStyle(sessions: number) {
+  if (sessions === 0) return WEEK_CARD_STYLES.idle;
+  if (sessions <= 2) return WEEK_CARD_STYLES.start;
+  if (sessions <= 3) return WEEK_CARD_STYLES.cruise;
+  if (sessions === 4) return WEEK_CARD_STYLES.peak;
+  return WEEK_CARD_STYLES.warning;
+}
+
 export function StatsPage() {
-  const { user, profile } = useAuth();
-  const { completions, consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading } = useHistory(user?.id);
+  const { user } = useAuth();
+  const { completions, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading } = useHistory(user?.id);
   const { activeProgram } = useActiveProgram(user?.id);
 
   useDocumentHead({
     title: 'Suivi',
     description: 'Tableau de bord sportif Wan2Fit.',
   });
-
-  const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '')
-    .split(' ')[0];
 
   const progressPct = activeProgram && activeProgram.totalSessions > 0
     ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
@@ -56,7 +91,6 @@ export function StatsPage() {
               <polygon points="5 3 19 12 5 21 5 3" />
             </svg>
           </div>
-          {firstName && <p className="text-muted">Salut {firstName}</p>}
           <h1 className="font-display text-2xl font-black text-heading">Pas encore de stats</h1>
           <p className="text-body text-sm">
             Lance ta première séance pour commencer à suivre ta progression ici.
@@ -74,12 +108,7 @@ export function StatsPage() {
     <div className="flex-1 px-4 md:px-10 lg:px-14 py-6 md:py-8">
       <div className="max-w-6xl mx-auto space-y-6">
         {/* Header */}
-        {firstName && (
-          <div>
-            <p className="text-sm text-muted">Salut {firstName}</p>
-            <h1 className="font-display text-2xl md:text-3xl font-black text-heading">Suivi</h1>
-          </div>
-        )}
+        <h1 className="font-display text-2xl md:text-3xl font-black text-heading">Chaque effort compte</h1>
 
         {/* Bento Grid */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
@@ -106,27 +135,21 @@ export function StatsPage() {
             <WeeklyBarChart data={weeklyChart} />
           </div>
 
-          {/* Metric: This week */}
-          <div className="rounded-2xl bg-emerald-500/15 border border-emerald-500/20 p-5">
-            <div className="text-xs font-semibold uppercase tracking-wider text-emerald-400 mb-3">Semaine</div>
-            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
-              {thisWeekSessions}<span className="text-lg font-normal text-muted">/7</span>
-            </div>
-            <div className="text-xs text-muted mt-1">jours actifs</div>
-          </div>
-
-          {/* Metric: Streak */}
-          <div className="rounded-2xl bg-amber-500/15 border border-amber-500/20 p-5">
-            <div className="text-xs font-semibold uppercase tracking-wider text-amber-400 mb-3">Série</div>
-            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
-              {consecutiveDays}
-            </div>
-            <div className="text-xs text-muted mt-1">jour{consecutiveDays > 1 ? 's' : ''} d'affilée</div>
-          </div>
-
-          {/* Week dots */}
-          <div className="col-span-2 rounded-2xl bg-surface-card border border-divider p-5">
+          {/* This week: dots + contextual message */}
+          <div className={`col-span-2 rounded-2xl p-5 border bg-gradient-to-br ${weekCardStyle(thisWeekSessions).bg} ${weekCardStyle(thisWeekSessions).border}`}>
             <WeekDots weekDots={weekDots} />
+            {(() => {
+              const msg = getWeekMessage(thisWeekSessions);
+              const style = weekCardStyle(thisWeekSessions);
+              return (
+                <div className="mt-4 rounded-xl border border-divider px-4 py-3 shadow-sm bg-surface-0">
+                  <p className={`text-sm font-bold ${style.text}`}>
+                    {msg.emoji}{'  '}{msg.title}
+                  </p>
+                  <p className="text-xs text-body mt-0.5">{msg.subtitle}</p>
+                </div>
+              );
+            })()}
           </div>
 
           {/* Programme progress */}
@@ -140,21 +163,22 @@ export function StatsPage() {
           ) : (
             <Link
               to="/programmes"
-              className="col-span-2 rounded-2xl border border-dashed border-divider-strong p-5 flex items-center gap-4 group hover:border-brand/30 transition-colors"
+              className="col-span-2 rounded-2xl overflow-hidden relative group hover:ring-2 hover:ring-brand/40 transition-all"
             >
-              <div className="w-12 h-12 rounded-xl bg-brand/10 flex items-center justify-center shrink-0">
-                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
-                  <rect x="3" y="3" width="7" height="7" />
-                  <rect x="14" y="3" width="7" height="7" />
-                  <rect x="3" y="14" width="7" height="7" />
-                  <rect x="14" y="14" width="7" height="7" />
-                </svg>
+              <img
+                src="/images/illustration-program.webp"
+                alt=""
+                className="w-full h-40 md:h-48 object-cover"
+                style={{ objectPosition: '50% 25%' }}
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+              <div className="absolute bottom-0 left-0 right-0 p-5 flex items-end justify-between">
+                <div>
+                  <p className="text-white font-bold text-base md:text-lg">Passe au niveau supérieur</p>
+                  <p className="text-white/60 text-xs mt-0.5">Commence à suivre un programme personnalisé</p>
+                </div>
+                <ChevronRight className="w-5 h-5 text-white/70 shrink-0 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
               </div>
-              <div>
-                <p className="text-sm font-bold text-heading group-hover:text-brand transition-colors">Découvrir les programmes</p>
-                <p className="text-xs text-muted mt-0.5">Suis un programme structuré pour progresser</p>
-              </div>
-              <ChevronRight className="w-4 h-4 text-muted ml-auto shrink-0" aria-hidden="true" />
             </Link>
           )}
 

--- a/src/components/stats/WeekDots.tsx
+++ b/src/components/stats/WeekDots.tsx
@@ -16,7 +16,7 @@ export function WeekDots({ weekDots }: { weekDots: boolean[] }) {
               className={`w-full aspect-square max-w-[44px] rounded-xl flex items-center justify-center transition-colors ${
                 done
                   ? 'bg-emerald-500/20 border-2 border-emerald-500'
-                  : 'bg-surface-2 border-2 border-transparent'
+                  : 'bg-surface-2 border-2 border-divider-strong'
               }`}
             >
               {done && (

--- a/src/components/stats/WeeklyBarChart.tsx
+++ b/src/components/stats/WeeklyBarChart.tsx
@@ -28,6 +28,8 @@ export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
               key={week.label}
               type="button"
               onClick={() => setActiveIdx(isActive ? null : i)}
+              onMouseEnter={() => setActiveIdx(i)}
+              onMouseLeave={() => setActiveIdx(null)}
               aria-label={`${week.label} : ${week.minutes} minutes, ${week.sessions} séance${week.sessions > 1 ? 's' : ''}`}
               className="flex-1 flex flex-col items-center gap-1.5 cursor-pointer group"
             >

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -15,7 +15,6 @@ export interface WeeklyData {
 
 export interface HistoryStats {
   completions: CompletionWithTitle[];
-  consecutiveDays: number;
   totalSessions: number;
   totalDuration: number;
   weekDots: boolean[];
@@ -26,40 +25,6 @@ export interface HistoryStats {
 
 function toDateString(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
-
-function computeConsecutiveDays(completions: SessionCompletion[]): number {
-  if (completions.length === 0) return 0;
-
-  const completionDays = new Set(
-    completions.map((c) => {
-      const d = new Date(c.completed_at);
-      return toDateString(d);
-    }),
-  );
-
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const todayStr = toDateString(today);
-
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = toDateString(yesterday);
-
-  // Must include today or yesterday to be active
-  if (!completionDays.has(todayStr) && !completionDays.has(yesterdayStr)) return 0;
-
-  // Start counting from the most recent day that has a completion
-  const startDate = completionDays.has(todayStr) ? new Date(today) : new Date(yesterday);
-  let count = 0;
-  const cursor = new Date(startDate);
-
-  while (completionDays.has(toDateString(cursor))) {
-    count++;
-    cursor.setDate(cursor.getDate() - 1);
-  }
-
-  return count;
 }
 
 function computeWeekDots(completions: SessionCompletion[]): boolean[] {
@@ -190,13 +155,12 @@ export function useHistory(userId: string | undefined): HistoryStats {
   }, [userId]);
 
   const derived = useMemo(() => {
-    const consecutiveDays = computeConsecutiveDays(completions);
     const totalSessions = completions.length;
     const totalDuration = completions.reduce((sum, c) => sum + (c.duration_seconds ?? 0), 0);
     const weekDots = computeWeekDots(completions);
     const weeklyChart = computeWeeklyChart(completions);
     const thisWeekSessions = weekDots.filter(Boolean).length;
-    return { consecutiveDays, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions };
+    return { totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions };
   }, [completions]);
 
   return { completions, ...derived, loading };

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -100,9 +100,10 @@ export function usePrograms() {
 
     (async () => {
       try {
-        const { data } = await supabase.from('programs').select('*').eq('is_fixed', true).order('created_at');
+        const { data, error } = await supabase.from('programs').select('*').eq('is_fixed', true).order('created_at');
 
         if (cancelled) return;
+        if (error) throw error;
         setPrograms((data as Program[]) ?? []);
       } catch (err) {
         console.error('Programs fetch error:', err);

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import type { Program, ProgramSession, SessionCompletion } from '../types/completion.ts';
 import type { Session } from '../types/session.ts';
@@ -87,14 +88,13 @@ export function useActiveProgram(userId: string | undefined) {
 }
 
 export function usePrograms() {
+  const { loading: authLoading } = useAuth();
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!supabase) {
-      setLoading(false);
-      return;
-    }
+    // Wait for auth to settle so the Supabase client is fully initialized
+    if (!supabase || authLoading) return;
 
     let cancelled = false;
 
@@ -104,9 +104,9 @@ export function usePrograms() {
 
         if (cancelled) return;
         setPrograms((data as Program[]) ?? []);
-        setLoading(false);
       } catch (err) {
         console.error('Programs fetch error:', err);
+      } finally {
         if (!cancelled) setLoading(false);
       }
     })();
@@ -114,7 +114,7 @@ export function usePrograms() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authLoading]);
 
   return { programs, loading };
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,6 +7,31 @@ if (!supabaseUrl || !supabaseKey) {
   console.warn('Supabase env vars missing — auth features disabled');
 }
 
+// In-memory mutex that serializes auth operations without Navigator Locks.
+// Navigator Locks get stuck when a tab/module is disposed without releasing
+// the lock (HMR, crashes, dev reloads). This mutex avoids that while still
+// properly serializing concurrent auth state reads/writes.
+const locks = new Map<string, Promise<unknown>>();
+
+async function inMemoryLock<T>(name: string, _acquireTimeout: number, fn: () => Promise<T>): Promise<T> {
+  const prev = locks.get(name) ?? Promise.resolve();
+  let resolve!: () => void;
+  const next = new Promise<void>((r) => {
+    resolve = r;
+  });
+  locks.set(name, next);
+
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    resolve();
+    if (locks.get(name) === next) {
+      locks.delete(name);
+    }
+  }
+}
+
 function getClient(): SupabaseClient | null {
   if (!supabaseUrl || !supabaseKey) return null;
 
@@ -19,11 +44,7 @@ function getClient(): SupabaseClient | null {
 
   const client = createClient(supabaseUrl, supabaseKey, {
     auth: {
-      // Replace Navigator Lock with a simple no-contention lock.
-      // Navigator Locks coordinate across tabs but get stuck when a tab/module
-      // is disposed without releasing the lock (HMR, crashes, dev reloads).
-      // A simple passthrough is safe for a single-tab PWA.
-      lock: async (_name, _acquireTimeout, fn) => fn(),
+      lock: inMemoryLock,
     },
   });
 


### PR DESCRIPTION
## Summary
- **Refonte page Suivi** : messages coach contextuels (semaine, week-end, surmenage), bento grid stats, philosophie anti-streak
- **Fix race condition Supabase** : remplacement du lock passthrough auth par un mutex in-memory sérialisé — résout le bug où le contenu ne chargeait pas au premier accès SPA
- **Nettoyage review** : suppression dead code (`computeConsecutiveDays`, `useHistory` orphelin), factorisation `weekCardStyle`, ajout error handling

## Test plan
- [ ] Naviguer vers /programmes via SPA (pas de refresh) — le contenu doit charger au premier accès
- [ ] Vérifier la page /suivi — messages coach adaptés au nombre de séances et au jour
- [ ] Vérifier que les programmes fixes s'affichent pour les visiteurs non connectés
- [ ] Vérifier le hover sur le bar chart hebdomadaire (desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)