### PR TITLE
fix: gestion session Supabase expirée + footer global

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -4,7 +4,7 @@ import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useHealthCheck } from '../hooks/useHealthCheck.ts';
 import { useSession } from '../hooks/useSession.ts';
 import { getTodayKey, getTomorrowKey, parseDDMMYYYY } from '../utils/date.ts';
-import { Footer } from './Footer.tsx';
+
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 import { WelcomeModal, useShowWelcome } from './WelcomeModal.tsx';
 import { ConnectedContent } from './home/ConnectedContent.tsx';
@@ -67,7 +67,6 @@ export function Home() {
         />
       )}
 
-      <Footer />
     </>
   );
 }

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
+import { Footer } from './Footer.tsx';
+import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
   const { pathname } = useLocation();
@@ -17,11 +19,13 @@ export function PublicLayout() {
         Aller au contenu principal
       </a>
       <BrandHeader />
+      <SessionExpiredBanner />
       <main id="main-content" className="flex-1 pb-16 md:pb-0" key={pathname}>
         <div className="animate-fade-in">
           <Outlet />
         </div>
       </main>
+      <Footer />
       <BottomNav />
     </div>
   );

--- a/src/components/SessionExpiredBanner.tsx
+++ b/src/components/SessionExpiredBanner.tsx
@@ -1,0 +1,24 @@
+import { RefreshCw } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+
+export function SessionExpiredBanner() {
+  const { sessionExpired, user } = useAuth();
+
+  if (!sessionExpired || !user) return null;
+
+  return (
+    <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-3 text-center">
+      <p className="text-sm text-amber-200 inline-flex items-center gap-2 flex-wrap justify-center">
+        <RefreshCw className="w-4 h-4" />
+        Votre session a expiré.
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="underline font-medium hover:text-amber-100 transition-colors"
+        >
+          Rafraîchir la page
+        </button>
+      </p>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,12 +1,14 @@
 import type { User } from '@supabase/supabase-js';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
+import { sessionEvents } from '../lib/supabaseQuery.ts';
 import type { Profile } from '../types/auth.ts';
 
 interface AuthContextValue {
   user: User | null;
   profile: Profile | null;
   loading: boolean;
+  sessionExpired: boolean;
   refreshProfile: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string, displayName: string) => Promise<{ error: string | null }>;
@@ -47,6 +49,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(!!supabase);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const mounted = useRef(true);
 
   useEffect(() => {
@@ -80,6 +83,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, session) => {
       if (!mounted.current || event === 'INITIAL_SESSION') return;
+
+      // Session successfully refreshed — clear expired state
+      if (event === 'TOKEN_REFRESHED') {
+        setSessionExpired(false);
+      }
+
       const currentUser = session?.user ?? null;
       setUser(currentUser);
       if (currentUser) {
@@ -94,9 +103,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     });
 
+    // Listen for session-expired events from supabaseQuery helper
+    const onSessionExpired = () => {
+      if (mounted.current) setSessionExpired(true);
+    };
+    sessionEvents.addEventListener('session-expired', onSessionExpired);
+
     return () => {
       mounted.current = false;
       subscription.unsubscribe();
+      sessionEvents.removeEventListener('session-expired', onSessionExpired);
     };
   }, []);
 
@@ -151,7 +167,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, profile, loading, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }}
+      value={{ user, profile, loading, sessionExpired, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/hooks/useCustomSessions.ts
+++ b/src/hooks/useCustomSessions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { CustomSessionRecord } from '../types/custom-session.ts';
 
 export function useCustomSessions() {
@@ -20,15 +21,20 @@ export function useCustomSessions() {
         return;
       }
 
-      const { data, error: fetchError } = await supabase
-        .from('custom_sessions')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('status', 'confirmed')
-        .order('created_at', { ascending: false })
-        .limit(20);
+      const { data, error: fetchError, sessionExpired } = await supabaseQuery(() =>
+        supabase!
+          .from('custom_sessions')
+          .select('*')
+          .eq('user_id', user.id)
+          .eq('status', 'confirmed')
+          .order('created_at', { ascending: false })
+          .limit(20),
+      );
 
-      if (fetchError) {
+      if (sessionExpired) {
+        notifySessionExpired();
+        setError('Session expirée. Veuillez rafraîchir la page.');
+      } else if (fetchError) {
         setError('Impossible de charger l\u2019historique.');
       } else {
         setSessions(data as CustomSessionRecord[]);

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { SessionCompletion } from '../types/completion.ts';
 
 export interface CompletionWithTitle extends SessionCompletion {
@@ -118,18 +119,18 @@ export function useHistory(userId: string | undefined): HistoryStats {
 
     (async () => {
       try {
-        const { data } = await supabase
-          .from('session_completions')
-          .select('*, program_sessions(session_data)')
-          .eq('user_id', userId)
-          .order('completed_at', { ascending: false })
-          .limit(200);
+        const { data, sessionExpired } = await supabaseQuery(() =>
+          supabase!
+            .from('session_completions')
+            .select('*, program_sessions(session_data)')
+            .eq('user_id', userId!)
+            .order('completed_at', { ascending: false })
+            .limit(200),
+        );
 
         if (cancelled) return;
+        if (sessionExpired) { notifySessionExpired(); setLoading(false); return; }
 
-        // Supabase returns joined data (with program_sessions) as a generic shape.
-        // We cast via unknown because the joined row type doesn't directly overlap
-        // with SessionCompletion (which excludes the join field).
         const rows = (data ?? []) as unknown as (SessionCompletion & {
           program_sessions: { session_data?: { title?: string } } | null;
         })[];

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program, ProgramSession, SessionCompletion } from '../types/completion.ts';
 import type { Session } from '../types/session.ts';
 
@@ -36,19 +37,20 @@ export function useActiveProgram(userId: string | undefined) {
 
     (async () => {
       try {
-        const { data, error } = await supabase.rpc('get_active_program', {
-          p_user_id: userId,
-        });
+        const { data, error, sessionExpired } = await supabaseQuery(() =>
+          supabase!.rpc('get_active_program', { p_user_id: userId }),
+        );
 
         if (cancelled) return;
 
-        if (error) {
-          console.error('Active program RPC error:', error);
+        if (sessionExpired) {
+          notifySessionExpired();
           setLoading(false);
           return;
         }
 
-        if (!data) {
+        if (error || !data) {
+          if (error) console.error('Active program RPC error:', error);
           setLoading(false);
           return;
         }
@@ -100,9 +102,12 @@ export function usePrograms() {
 
     (async () => {
       try {
-        const { data, error } = await supabase.from('programs').select('*').eq('is_fixed', true).order('created_at');
+        const { data, error, sessionExpired } = await supabaseQuery(() =>
+          supabase!.from('programs').select('*').eq('is_fixed', true).order('created_at'),
+        );
 
         if (cancelled) return;
+        if (sessionExpired) { notifySessionExpired(); return; }
         if (error) throw error;
         setPrograms((data as Program[]) ?? []);
       } catch (err) {
@@ -135,25 +140,22 @@ export function useProgram(slug: string | undefined) {
 
     (async () => {
       try {
-        // Fetch program
-        // RLS handles access control (fixed programs + own programs)
-        const { data: pgm } = await supabase
-          .from('programs')
-          .select('*')
-          .eq('slug', slug)
-          .single();
+        // Fetch program (RLS handles access control)
+        const { data: pgm, sessionExpired } = await supabaseQuery(() =>
+          supabase!.from('programs').select('*').eq('slug', slug!).single(),
+        );
 
-        if (cancelled || !pgm) {
-          if (!cancelled) setLoading(false);
-          return;
-        }
+        if (cancelled) return;
+        if (sessionExpired) { notifySessionExpired(); setLoading(false); return; }
+        if (!pgm) { setLoading(false); return; }
 
         // Fetch program sessions
-        const { data: sessions } = await supabase
-          .from('program_sessions')
-          .select('*')
-          .eq('program_id', pgm.id)
-          .order('session_order');
+        const { data: sessions, sessionExpired: sessExp } = await supabaseQuery(() =>
+          supabase!.from('program_sessions').select('*').eq('program_id', (pgm as Program).id).order('session_order'),
+        );
+
+        if (cancelled) return;
+        if (sessExp) { notifySessionExpired(); setLoading(false); return; }
 
         // Fetch user's completions for this program's sessions
         const sessionIds = (sessions ?? []).map((s: ProgramSession) => s.id);
@@ -162,14 +164,18 @@ export function useProgram(slug: string | undefined) {
         if (sessionIds.length > 0) {
           const {
             data: { user },
-          } = await supabase.auth.getUser();
+          } = await supabase!.auth.getUser();
 
           if (user) {
-            const { data: completions } = await supabase
-              .from('session_completions')
-              .select('program_session_id')
-              .eq('user_id', user.id)
-              .in('program_session_id', sessionIds);
+            const { data: completions, sessionExpired: compExp } = await supabaseQuery(() =>
+              supabase!
+                .from('session_completions')
+                .select('program_session_id')
+                .eq('user_id', user.id)
+                .in('program_session_id', sessionIds),
+            );
+
+            if (compExp) { notifySessionExpired(); setLoading(false); return; }
 
             completedIds = new Set(
               (completions as Pick<SessionCompletion, 'program_session_id'>[] | null)
@@ -216,27 +222,20 @@ export function useProgramSession(slug: string | undefined, order: number | unde
 
     (async () => {
       try {
-        // Find program by slug (RLS handles access control)
-        const { data: pgm } = await supabase
-          .from('programs')
-          .select('id')
-          .eq('slug', slug)
-          .single();
-
-        if (cancelled || !pgm) {
-          if (!cancelled) setLoading(false);
-          return;
-        }
-
-        // Find session by order
-        const { data: ps } = await supabase
-          .from('program_sessions')
-          .select('*')
-          .eq('program_id', pgm.id)
-          .eq('session_order', order)
-          .single();
+        const { data: pgm, sessionExpired } = await supabaseQuery(() =>
+          supabase!.from('programs').select('id').eq('slug', slug!).single(),
+        );
 
         if (cancelled) return;
+        if (sessionExpired) { notifySessionExpired(); setLoading(false); return; }
+        if (!pgm) { setLoading(false); return; }
+
+        const { data: ps, sessionExpired: sessExp } = await supabaseQuery(() =>
+          supabase!.from('program_sessions').select('*').eq('program_id', (pgm as { id: string }).id).eq('session_order', order!).single(),
+        );
+
+        if (cancelled) return;
+        if (sessExp) { notifySessionExpired(); setLoading(false); return; }
         setSession((ps as ProgramSession) ?? null);
         setLoading(false);
       } catch (err) {

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program } from '../types/completion.ts';
 
 export function useUserPrograms() {
@@ -15,13 +16,16 @@ export function useUserPrograms() {
     }
 
     try {
-      const { data } = await supabase
-        .from('programs')
-        .select('*')
-        .eq('user_id', user.id)
-        .eq('is_fixed', false)
-        .order('created_at', { ascending: false });
+      const { data, sessionExpired } = await supabaseQuery(() =>
+        supabase!
+          .from('programs')
+          .select('*')
+          .eq('user_id', user.id)
+          .eq('is_fixed', false)
+          .order('created_at', { ascending: false }),
+      );
 
+      if (sessionExpired) { notifySessionExpired(); return; }
       setPrograms((data as Program[]) ?? []);
     } catch (err) {
       console.error('User programs fetch error:', err);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,6 +44,9 @@ function getClient(): SupabaseClient | null {
 
   const client = createClient(supabaseUrl, supabaseKey, {
     auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
       lock: inMemoryLock,
     },
   });

--- a/src/lib/supabaseQuery.ts
+++ b/src/lib/supabaseQuery.ts
@@ -1,0 +1,89 @@
+import { supabase } from './supabase.ts';
+
+/** Error codes / messages that indicate a stale or expired auth session. */
+const AUTH_ERROR_INDICATORS = [
+  'JWT expired',
+  'JWTExpired',
+  'PGRST301', // PostgREST unauthorized
+  '42501', // PostgreSQL insufficient_privilege (RLS denial)
+  'permission denied',
+  'Invalid Refresh Token',
+  'Refresh Token Not Found',
+  'Auth session missing',
+  'not_authenticated',
+];
+
+function isAuthError(error: { message?: string; code?: string } | null): boolean {
+  if (!error) return false;
+  const haystack = `${error.message ?? ''} ${error.code ?? ''}`.toLowerCase();
+  return AUTH_ERROR_INDICATORS.some((indicator) => haystack.includes(indicator.toLowerCase()));
+}
+
+let refreshPromise: Promise<boolean> | null = null;
+
+/** Attempt to refresh the session once (deduped across concurrent callers). */
+async function tryRefreshSession(): Promise<boolean> {
+  if (!supabase) return false;
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    try {
+      const { error } = await supabase.auth.refreshSession();
+      return !error;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+/**
+ * Execute a Supabase query with automatic session recovery.
+ *
+ * If the query fails with an auth-related error, it will attempt to refresh
+ * the session once and retry. If the retry also fails, it returns the error
+ * and sets `sessionExpired` to true so the UI can react.
+ *
+ * Usage:
+ * ```ts
+ * const { data, error, sessionExpired } = await supabaseQuery(() =>
+ *   supabase.from('programs').select('*').eq('slug', slug).single()
+ * );
+ * ```
+ */
+export async function supabaseQuery<T>(
+  queryFn: () => PromiseLike<{ data: T; error: { message?: string; code?: string } | null }>,
+): Promise<{ data: T | null; error: { message?: string; code?: string } | null; sessionExpired: boolean }> {
+  const result = await queryFn();
+
+  if (!isAuthError(result.error)) {
+    return { data: result.data, error: result.error, sessionExpired: false };
+  }
+
+  // Auth error detected — try refreshing the session
+  const refreshed = await tryRefreshSession();
+  if (!refreshed) {
+    return { data: null, error: result.error, sessionExpired: true };
+  }
+
+  // Retry the query once after successful refresh
+  const retry = await queryFn();
+  if (isAuthError(retry.error)) {
+    return { data: null, error: retry.error, sessionExpired: true };
+  }
+
+  return { data: retry.data, error: retry.error, sessionExpired: false };
+}
+
+/**
+ * Event target for session expiry notifications.
+ * Components can subscribe to be notified when a query detects session expiry.
+ */
+export const sessionEvents = new EventTarget();
+
+export function notifySessionExpired() {
+  sessionEvents.dispatchEvent(new Event('session-expired'));
+}


### PR DESCRIPTION
## Summary
- **Session expirée** : les pages restaient en spinner infini quand le token JWT Supabase expirait (~1h sans refresh). Tous les hooks avalaient silencieusement les erreurs RLS.
- **Fix** : nouveau helper `supabaseQuery` qui détecte les erreurs auth, tente un `refreshSession()`, retry 1x, et notifie l'UI si la session est définitivement expirée
- **Banner** : message amber "Session expirée" avec bouton "Rafraîchir la page" sous le header
- **Footer** : déplacé de `Home` vers `PublicLayout` → visible sur toutes les pages (accès mentions légales, CGU, À propos)

## Hooks mis à jour
- `useActiveProgram`, `usePrograms`, `useProgram`, `useProgramSession`
- `useHistory`
- `useUserPrograms`
- `useCustomSessions`

## Test plan
- [ ] Ouvrir le site connecté, attendre >1h sans refresh — vérifier que le contenu charge toujours (token auto-refresh)
- [ ] Simuler un token expiré (vider le localStorage auth) — vérifier que le banner s'affiche
- [ ] Cliquer "Rafraîchir la page" sur le banner → vérifie que ça reload
- [ ] Vérifier le footer sur `/formats`, `/programmes`, `/a-propos` (pas juste Home)
- [ ] Vérifier que le footer n'apparaît pas en double sur Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)