### PR TITLE
fix: mentions légales, signOut robuste, signup tl;dr

### DIFF
--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -102,21 +102,21 @@ function MentionsLegales() {
           <br />
           SARL (Société à Responsabilité Limitée) au capital de 1 000 €
           <br />
-          Siège social : 8 impasse des Musiciens, 44880 Sautron
+          Siège social : 33 La Baluère, 35220 Châteaubourg
           <br />
-          RCS Nantes 831 188 586
+          RCS Rennes 831 188 586
           <br />
           SIRET : 831 188 586 00026
           <br />
-          TVA intracommunautaire : FR 76 831188586
+          TVA intracommunautaire : FR59831188586
           <br />
           Directeur de la publication : Erwan VIOT
           <br />
           Téléphone : 06 79 08 40 63
           <br />
           Contact :{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
         </p>
       </Section>
@@ -176,8 +176,8 @@ function PolitiqueConfidentialite() {
       <Section title="Responsable du traitement">
         <p>
           Le responsable du traitement des données est WAN SOFT, joignable à l'adresse :{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
         </p>
       </Section>
@@ -331,8 +331,8 @@ function PolitiqueConfidentialite() {
         </ul>
         <p>
           Pour exercer ces droits, contactez-nous à{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
           . Nous nous engageons à répondre dans un délai de 30 jours.
         </p>
@@ -451,8 +451,8 @@ function CGU() {
         </p>
         <p>
           L'utilisateur peut demander la suppression de son compte à tout moment en contactant{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
           . La suppression entraîne l'effacement de l'ensemble des données associées dans un délai de 30 jours.
         </p>
@@ -553,8 +553,8 @@ function CGU() {
       <Section title="Contact">
         <p>
           Pour toute question relative aux présentes CGU, vous pouvez nous contacter à :{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
         </p>
       </Section>
@@ -661,8 +661,8 @@ function CGV() {
         </p>
         <p>
           Pour contacter notre service client préalablement à toute médiation :{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
         </p>
       </Section>
@@ -684,8 +684,8 @@ function CGV() {
       <Section title="Contact">
         <p>
           Pour toute question relative aux présentes CGV ou à votre abonnement :{' '}
-          <a href="mailto:erwan.viot@wan-soft.fr" className="text-link underline">
-            erwan.viot@wan-soft.fr
+          <a href="mailto:contact@wan2fit.fr" className="text-link underline">
+            contact@wan2fit.fr
           </a>
         </p>
       </Section>

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -154,11 +154,10 @@ export function SignupPage() {
             <div className="rounded-xl bg-surface border border-divider p-3.5 text-xs text-muted space-y-1">
               <p className="font-semibold text-subtle">En bref (pour ceux qui ne lisent pas les CGU) 😉</p>
               <ul className="space-y-0.5 list-inside">
-                <li>C'est gratuit, pas de piège.</li>
-                <li>On stocke ton email, ton prénom et tes séances. C'est tout.</li>
+                <li>Le compte est gratuit, sans engagement.</li>
+                <li>On stocke ton email, ton prénom et tes séances.</li>
                 <li>On ne revend pas tes données.</li>
-                <li>Les exercices sont du contenu éditorial, pas du coaching : libre à toi de les suivre ou non.</li>
-                <li>On n'est pas médecins — consulte le tien avant de suer.</li>
+                <li>Les exercices sont des suggestions, pas du coaching médical.</li>
                 <li>Tu peux supprimer ton compte quand tu veux.</li>
               </ul>
             </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -160,9 +160,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = async () => {
     if (!supabase) return;
-    await supabase.auth.signOut();
+    try {
+      await supabase.auth.signOut();
+    } catch {
+      // Force local cleanup even if the API call fails (e.g. expired token)
+    }
     setUser(null);
     setProfile(null);
+    setSessionExpired(false);
   };
 
   return (


### PR DESCRIPTION
## Summary
- **Mentions légales** : adresse corrigée (Châteaubourg), RCS Rennes, TVA FR59831188586, email contact@wan2fit.fr sur toutes les pages légales
- **SignOut** : force le nettoyage local même si l'appel API échoue (token expiré)
- **Signup tl;dr** : texte actualisé (compte gratuit sans engagement, suppression mention "pas de piège")

## Test plan
- [ ] Vérifier `/legal/mentions` — adresse, RCS, TVA, email
- [ ] Vérifier email contact@wan2fit.fr sur confidentialité, CGU, CGV
- [ ] Tester déconnexion avec session expirée
- [ ] Vérifier texte tl;dr sur `/signup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)