### PR TITLE
fix: branding Wan2Fit, encart à propos, réorg landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,23 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- SEO -->
-    <title>WAN2FIT — Séance de sport gratuite chaque jour, sans matériel</title>
+    <title>Wan2Fit — Séance de sport gratuite chaque jour, sans matériel</title>
     <meta name="description" content="Ton programme sport gratuit. Chaque jour, une séance complète t'attend : échauffement, exercices, repos, étirements — tout est guidé et timé. 25-40 min, sans matériel." />
     <meta name="keywords" content="sport maison, séance sport gratuite, exercices sans matériel, entraînement guidé gratuit, entraînement quotidien, fitness maison, sport à la maison" />
     <link rel="canonical" href="https://www.wan2fit.fr/" />
 
     <!-- Open Graph (Facebook, WhatsApp, LinkedIn) -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="WAN2FIT — Sport gratuit chaque jour, guidé et sans matériel" />
+    <meta property="og:title" content="Wan2Fit — Sport gratuit chaque jour, guidé et sans matériel" />
     <meta property="og:description" content="Une séance complète chaque jour : échauffement, renforcement, étirements. Gratuit pour commencer, programmes IA personnalisés avec Premium." />
     <meta property="og:image" content="https://www.wan2fit.fr/og-image.png" />
     <meta property="og:url" content="https://www.wan2fit.fr/" />
     <meta property="og:locale" content="fr_FR" />
-    <meta property="og:site_name" content="WAN2FIT" />
+    <meta property="og:site_name" content="Wan2Fit" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="WAN2FIT — Sport gratuit chaque jour, guidé et sans matériel" />
+    <meta name="twitter:title" content="Wan2Fit — Sport gratuit chaque jour, guidé et sans matériel" />
     <meta name="twitter:description" content="Séance de sport complète chaque jour, sans matériel. Gratuit pour commencer, programmes IA personnalisés avec Premium." />
     <meta name="twitter:image" content="https://www.wan2fit.fr/og-image.png" />
 
@@ -76,7 +76,7 @@
     <meta name="theme-color" content="#1a1a22" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="WAN2FIT" />
+    <meta name="apple-mobile-web-app-title" content="Wan2Fit" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -55,7 +55,7 @@ const DEFAULT_DRAFT: DraftState = {
 };
 
 export function CreateProgramPage() {
-  useDocumentHead({ title: 'Créer mon programme — WAN2FIT' });
+  useDocumentHead({ title: 'Créer mon programme — Wan2Fit' });
 
   const navigate = useNavigate();
   const { generate, loading: generating, error: generateError } = useGenerateProgram();

--- a/src/components/CustomSessionPage.tsx
+++ b/src/components/CustomSessionPage.tsx
@@ -43,7 +43,7 @@ const BODY_FOCUS_OPTIONS: { value: BodyFocus; label: string }[] = [
 ];
 
 export function CustomSessionPage() {
-  useDocumentHead({ title: 'Créer ma séance — WAN2FIT' });
+  useDocumentHead({ title: 'Créer ma séance — Wan2Fit' });
 
   const navigate = useNavigate();
   const { generate, loading, error } = useGenerateSession();

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -28,7 +28,7 @@ function groupByCategory(exercises: ExerciseData[]): [ExerciseCategory, Exercise
 
 export function Discover() {
   useDocumentHead({
-    title: 'Découvrir — WAN2FIT',
+    title: 'Découvrir — Wan2Fit',
     description: "Explorez nos 8 formats d'entraînement et notre bibliothèque d'exercices.",
   });
 

--- a/src/components/Exercises.tsx
+++ b/src/components/Exercises.tsx
@@ -18,7 +18,7 @@ export function Exercises() {
   useDocumentHead({
     title: 'Nos exercices',
     description:
-      'Tous les exercices WAN2FIT : fiches détaillées avec exécution, variantes, conseils et erreurs courantes.',
+      'Tous les exercices Wan2Fit : fiches détaillées avec exécution, variantes, conseils et erreurs courantes.',
   });
 
   const grouped = groupByCategory(EXERCISES_DATA);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
   return (
     <footer className="px-6 py-8 border-t border-divider">
       <p className="text-faint text-xs text-center">
-        WAN2FIT par{' '}
+        Wan2Fit par{' '}
         <a
           href="https://www.wan-soft.fr"
           target="_blank"
@@ -14,19 +14,26 @@ export function Footer() {
           WAN SOFT
         </a>
       </p>
-      <div className="flex justify-center gap-4 mt-3">
-        <Link to="/legal/mentions" className="text-xs text-faint hover:text-subtle transition-colors">
-          Mentions légales
-        </Link>
-        <Link to="/legal/privacy" className="text-xs text-faint hover:text-subtle transition-colors">
-          Confidentialité
-        </Link>
-        <Link to="/legal/cgu" className="text-xs text-faint hover:text-subtle transition-colors">
-          CGU
-        </Link>
-        <Link to="/a-propos" className="text-xs text-faint hover:text-subtle transition-colors">
-          À propos
-        </Link>
+      <div className="mt-3 space-y-2">
+        <div className="flex justify-center">
+          <Link to="/a-propos" className="text-xs text-link hover:text-link-hover transition-colors">
+            À propos
+          </Link>
+        </div>
+        <div className="flex justify-center gap-4">
+          <Link to="/legal/mentions" className="text-xs text-faint hover:text-subtle transition-colors">
+            Mentions légales
+          </Link>
+          <Link to="/legal/privacy" className="text-xs text-faint hover:text-subtle transition-colors">
+            Confidentialité
+          </Link>
+          <Link to="/legal/cgu" className="text-xs text-faint hover:text-subtle transition-colors">
+            CGU
+          </Link>
+          <Link to="/legal/cgv" className="text-xs text-faint hover:text-subtle transition-colors">
+            CGV
+          </Link>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/HealthDisclaimer.tsx
+++ b/src/components/HealthDisclaimer.tsx
@@ -75,7 +75,7 @@ export function HealthDisclaimer({ onAccept, onCancel }: Props) {
 
         <div className="px-6 overflow-y-auto flex-1 space-y-3 text-sm text-gray-600 leading-relaxed">
           <p>
-            WAN2FIT propose du <strong>contenu éditorial et informationnel</strong> relatif à l'activité physique. Il
+            Wan2Fit propose du <strong>contenu éditorial et informationnel</strong> relatif à l'activité physique. Il
             ne s'agit pas de coaching sportif personnalisé ni d'encadrement par un éducateur sportif diplômé.
           </p>
           <p>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -28,9 +28,9 @@ export function Home() {
   const [showWelcome, setShowWelcome] = useState(shouldShowWelcome);
 
   useDocumentHead({
-    title: 'WAN2FIT',
+    title: 'Wan2Fit',
     description:
-      "Chaque jour, une séance de sport guidée sans matériel. 8 formats d'entraînement, 25-40 min, 100% gratuit.",
+      "Chaque jour, une séance de sport guidée sans matériel. 8 formats d'entraînement, 25-40 min. Gratuit pour commencer, premium pour aller plus loin.",
   });
 
   const handleStartSession = () => {

--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -24,7 +24,7 @@ export function Legal() {
 
   useDocumentHead({
     title: TAB_TITLES[tab],
-    description: `${TAB_TITLES[tab]} du site WAN2FIT, édité par WAN SOFT.`,
+    description: `${TAB_TITLES[tab]} du site Wan2Fit, édité par WAN SOFT.`,
   });
 
   return (
@@ -95,7 +95,7 @@ function MentionsLegales() {
 
       <Section title="Éditeur du site">
         <p>
-          Le site <strong className="text-strong">WAN2FIT</strong> (ci-après « le Site ») est édité par :
+          Le site <strong className="text-strong">Wan2Fit</strong> (ci-après « le Site ») est édité par :
         </p>
         <p>
           <strong className="text-strong">WAN SOFT</strong>
@@ -367,14 +367,14 @@ function CGU() {
       <Section title="Objet">
         <p>
           Les présentes Conditions Générales d'Utilisation (ci-après « CGU ») définissent les conditions d'accès et
-          d'utilisation du site WAN2FIT, édité par WAN SOFT.
+          d'utilisation du site Wan2Fit, édité par WAN SOFT.
         </p>
         <p>L'utilisation du Site implique l'acceptation pleine et entière des présentes CGU.</p>
       </Section>
 
       <Section title="Description du service">
         <p>
-          WAN2FIT propose une offre gratuite de séances d'exercices physiques quotidiennes et une offre Premium
+          Wan2Fit propose une offre gratuite de séances d'exercices physiques quotidiennes et une offre Premium
           payante donnant accès à des fonctionnalités avancées (séances et programmes personnalisés par IA). Le Site
           met à disposition des suggestions d'exercices guidées avec minuteur intégré, sans équipement nécessaire.
         </p>
@@ -388,7 +388,7 @@ function CGU() {
       <Section title="Nature du contenu">
         <p>
           <strong className="text-strong">
-            WAN2FIT est un service de contenu éditorial et informationnel relatif à l'activité physique.
+            Wan2Fit est un service de contenu éditorial et informationnel relatif à l'activité physique.
           </strong>
         </p>
         <p>
@@ -465,7 +465,7 @@ function CGU() {
             médical ni une prescription d'activité physique.
           </strong>
         </p>
-        <p>Avant d'utiliser WAN2FIT, il est indispensable de :</p>
+        <p>Avant d'utiliser Wan2Fit, il est indispensable de :</p>
         <ul className="list-disc list-inside space-y-1">
           <li>Consulter un médecin pour vérifier votre aptitude à la pratique sportive</li>
           <li>Vous assurer de ne présenter aucune contre-indication médicale</li>
@@ -494,7 +494,7 @@ function CGU() {
             blessure.
           </strong>
         </p>
-        <p>En utilisant WAN2FIT, l'utilisateur déclare :</p>
+        <p>En utilisant Wan2Fit, l'utilisateur déclare :</p>
         <ul className="list-disc list-inside space-y-1">
           <li>Avoir pris connaissance de l'avertissement santé ci-dessus</li>
           <li>Pratiquer sous sa propre responsabilité et à ses propres risques</li>
@@ -572,7 +572,7 @@ function CGV() {
       <Section title="Objet">
         <p>
           Les présentes Conditions Générales de Vente (ci-après « CGV ») régissent les conditions de souscription et
-          d'utilisation de l'abonnement Premium proposé par WAN SOFT sur le site WAN2FIT.
+          d'utilisation de l'abonnement Premium proposé par WAN SOFT sur le site Wan2Fit.
         </p>
         <p>
           Toute souscription à l'offre Premium implique l'acceptation pleine et entière des présentes CGV, ainsi que
@@ -585,7 +585,7 @@ function CGV() {
       </Section>
 
       <Section title="Offres et tarifs">
-        <p>WAN2FIT propose les offres suivantes :</p>
+        <p>Wan2Fit propose les offres suivantes :</p>
         <ul className="list-disc list-inside space-y-1">
           <li>
             <strong className="text-strong">Gratuit</strong> — Séance du jour, bibliothèque exercices et formats, 3
@@ -607,7 +607,7 @@ function CGV() {
 
       <Section title="Souscription et paiement">
         <p>
-          La souscription à l'offre Premium nécessite la création d'un compte sur WAN2FIT. Le paiement est effectué
+          La souscription à l'offre Premium nécessite la création d'un compte sur Wan2Fit. Le paiement est effectué
           en ligne par carte bancaire, Apple Pay, Google Pay ou prélèvement SEPA, via la plateforme de paiement
           sécurisée <strong className="text-strong">Stripe</strong>.
         </p>

--- a/src/components/ProgramContentPage.tsx
+++ b/src/components/ProgramContentPage.tsx
@@ -11,7 +11,7 @@ export function ProgramContentPage() {
   const content = slug ? PROGRAM_CONTENT[slug] : undefined;
 
   useDocumentHead({
-    title: content ? `${content.headline} — Programme WAN2FIT` : 'Programme',
+    title: content ? `${content.headline} — Programme Wan2Fit` : 'Programme',
     description: content?.intro,
   });
 

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -48,7 +48,7 @@ export function ConnectedContent({
   return (
     <div className="px-6 md:px-10 lg:px-14 py-8">
       <div className="max-w-5xl mx-auto space-y-10">
-        <h1 className="sr-only">WAN2FIT — Votre séance de sport quotidienne</h1>
+        <h1 className="sr-only">Wan2Fit — Votre séance de sport quotidienne</h1>
 
         {/* ── Titre + 3 colonnes d'action ── */}
         <section>

--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -221,8 +221,56 @@ export function VisitorContent({
         </div>
       </section>
 
-      {/* ── 4. Feature : IA sur-mesure (Premium) ── */}
+      {/* ── 4. Feature : Le player ── */}
       <section className="px-6 md:px-10 lg:px-14 py-14 md:py-20 bg-surface-2/50">
+        <div className="max-w-5xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center">
+            {/* Texte */}
+            <div className="space-y-5">
+              <span className="text-xs font-bold tracking-widest uppercase text-brand">Entraînement guidé</span>
+              <h2 className="font-display text-3xl md:text-4xl font-black text-heading leading-tight">
+                Tu n'as qu'à<br />suivre le rythme
+              </h2>
+              <p className="text-muted leading-relaxed">
+                Chrono, compteur de reps, transitions automatiques — le player gère tout pour que tu restes concentré sur l'effort.
+              </p>
+              <ul className="space-y-3">
+                {[
+                  { icon: Play, text: 'Timer et reps guidés en temps réel' },
+                  { icon: Shuffle, text: 'Enchaînement automatique des blocs' },
+                  { icon: Zap, text: 'Signal sonore à chaque transition' },
+                ].map((item) => (
+                  <li key={item.text} className="flex items-start gap-3">
+                    <item.icon className="w-5 h-5 text-brand shrink-0 mt-0.5" aria-hidden="true" />
+                    <span className="text-sm text-body">{item.text}</span>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={onStart}
+                className="inline-flex items-center gap-2 text-sm font-bold text-brand hover:text-brand/80 transition-colors cursor-pointer"
+              >
+                Lancer une séance
+                <ChevronRight className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
+
+            {/* Visuel : carrousel player */}
+            <ScreenshotCarousel
+              images={[
+                { src: '/images/screenshot-player-reps.webp', alt: 'Player — exercice en reps' },
+                { src: '/images/screenshot-player-emom.webp', alt: 'Player — EMOM avec timer' },
+                { src: '/images/screenshot-player-hiit.webp', alt: 'Player — HIIT Mountain climbers' },
+                { src: '/images/screenshot-player-cooldown.webp', alt: 'Player — Retour au calme' },
+              ]}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ── 5. Feature : IA sur-mesure (Premium) ── */}
+      <section className="px-6 md:px-10 lg:px-14 py-14 md:py-20">
         <div className="max-w-5xl mx-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center">
             {/* Visuel : carrousel 3 modes de création (à gauche en desktop) */}
@@ -269,54 +317,6 @@ export function VisitorContent({
                 <ChevronRight className="w-4 h-4" aria-hidden="true" />
               </Link>
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── 5. Feature : Le player ── */}
-      <section className="px-6 md:px-10 lg:px-14 py-14 md:py-20">
-        <div className="max-w-5xl mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center">
-            {/* Texte */}
-            <div className="space-y-5">
-              <span className="text-xs font-bold tracking-widest uppercase text-brand">Entraînement guidé</span>
-              <h2 className="font-display text-3xl md:text-4xl font-black text-heading leading-tight">
-                Tu n'as qu'à<br />suivre le rythme
-              </h2>
-              <p className="text-muted leading-relaxed">
-                Chrono, compteur de reps, transitions automatiques — le player gère tout pour que tu restes concentré sur l'effort.
-              </p>
-              <ul className="space-y-3">
-                {[
-                  { icon: Play, text: 'Timer et reps guidés en temps réel' },
-                  { icon: Shuffle, text: 'Enchaînement automatique des blocs' },
-                  { icon: Zap, text: 'Signal sonore à chaque transition' },
-                ].map((item) => (
-                  <li key={item.text} className="flex items-start gap-3">
-                    <item.icon className="w-5 h-5 text-brand shrink-0 mt-0.5" aria-hidden="true" />
-                    <span className="text-sm text-body">{item.text}</span>
-                  </li>
-                ))}
-              </ul>
-              <button
-                type="button"
-                onClick={onStart}
-                className="inline-flex items-center gap-2 text-sm font-bold text-brand hover:text-brand/80 transition-colors cursor-pointer"
-              >
-                Lancer une séance
-                <ChevronRight className="w-4 h-4" aria-hidden="true" />
-              </button>
-            </div>
-
-            {/* Visuel : carrousel player */}
-            <ScreenshotCarousel
-              images={[
-                { src: '/images/screenshot-player-reps.webp', alt: 'Player — exercice en reps' },
-                { src: '/images/screenshot-player-emom.webp', alt: 'Player — EMOM avec timer' },
-                { src: '/images/screenshot-player-hiit.webp', alt: 'Player — HIIT Mountain climbers' },
-                { src: '/images/screenshot-player-cooldown.webp', alt: 'Player — Retour au calme' },
-              ]}
-            />
           </div>
         </div>
       </section>
@@ -374,8 +374,33 @@ export function VisitorContent({
         </div>
       </section>
 
-      {/* ── 6. CTA final ── */}
-      <section className="px-6 md:px-10 lg:px-14 py-16 md:py-20">
+      {/* ── 7. À propos — encart discret ── */}
+      <section className="px-6 md:px-10 lg:px-14 pt-12 pb-0">
+        <div className="max-w-md mx-auto">
+          <Link
+            to="/a-propos"
+            className="flex items-center gap-4 px-5 py-4 rounded-2xl border border-card-border hover:border-divider-strong bg-surface-card/50 hover:bg-surface-card transition-all group"
+          >
+            <img
+              src="/photo-wan.png"
+              alt="Wan"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-body group-hover:text-heading transition-colors">
+                Pourquoi Wan2Fit ?
+              </p>
+              <p className="text-xs text-muted truncate">
+                L'histoire derrière le projet — par Wan
+              </p>
+            </div>
+            <ChevronRight className="w-4 h-4 text-muted group-hover:text-subtle transition-colors shrink-0 ml-auto" aria-hidden="true" />
+          </Link>
+        </div>
+      </section>
+
+      {/* ── 8. CTA final ── */}
+      <section className="px-6 md:px-10 lg:px-14 pt-10 pb-16 md:pt-12 md:pb-20">
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <h2 className="font-display text-3xl md:text-4xl font-black text-heading">
             Prêt à commencer ?

--- a/src/data/formats.ts
+++ b/src/data/formats.ts
@@ -258,7 +258,7 @@ export const FORMATS_DATA: FormatData[] = [
     principle:
       "Le protocole Tabata, développé par le Dr Izumi Tabata en 1996, est un format d'entraînement par intervalles ultra-courts. Le ratio travail/repos de 2:1 (20s d'effort / 10s de repos) est conçu pour pousser le corps à son maximum absolu. En seulement 4 minutes par set (8 rounds de 30 secondes), ce protocole développe simultanément les filières aérobie et anaérobie.",
     protocol:
-      "Un set Tabata classique : 8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Total : 4 minutes. Sur WAN2FIT, les séances Tabata incluent 1 à 2 sets avec un repos de 60 secondes entre les sets. L'effort pendant les 20 secondes doit être maximal : si vous pouvez parler, vous n'allez pas assez fort.",
+      "Un set Tabata classique : 8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Total : 4 minutes. Sur Wan2Fit, les séances Tabata incluent 1 à 2 sets avec un repos de 60 secondes entre les sets. L'effort pendant les 20 secondes doit être maximal : si vous pouvez parler, vous n'allez pas assez fort.",
     benefits: [
       'Format le plus court : 4 minutes de travail intense par set',
       'Amélioration prouvée scientifiquement des capacités aérobie et anaérobie',

--- a/src/hooks/useDocumentHead.ts
+++ b/src/hooks/useDocumentHead.ts
@@ -5,7 +5,7 @@ interface HeadOptions {
   description?: string;
 }
 
-const BASE_TITLE = 'WAN2FIT';
+const BASE_TITLE = 'Wan2Fit';
 
 export function useDocumentHead({ title, description }: HeadOptions) {
   useEffect(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['sessions/*.json'],
       manifest: {
-        name: 'WAN2FIT',
-        short_name: 'WAN2FIT',
+        name: 'Wan2Fit',
+        short_name: 'Wan2Fit',
         description: 'Ta séance de sport quotidienne, prête à lancer',
         theme_color: '#0f0f17',
         background_color: '#0f0f17',


### PR DESCRIPTION
## Summary
- **Branding** : renomme WAN2FIT → Wan2Fit partout (SEO, PWA, titres, contenu légal, formats)
- **Footer** : lien "À propos" séparé en bleu design system + ajout lien CGV
- **Home visiteur** : encart discret "Pourquoi Wan2Fit ?" avec photo avant le CTA final
- **Landing** : swap blocs Entraînement guidé ↔ IA sur-mesure
- **Meta description** : retire "100% gratuit", aligne sur le wording freemium

## Test plan
- [ ] Vérifier l'onglet navigateur affiche "Wan2Fit" (pas WAN2FIT)
- [ ] Footer : lien "À propos" en bleu, CGV présent
- [ ] Home non connecté : encart "Pourquoi Wan2Fit ?" visible avant "Prêt à commencer ?"
- [ ] Home connecté : pas d'encart "À propos"
- [ ] Ordre landing : Séance du jour → Player → IA sur-mesure → Programmes
- [ ] Pages légales : Wan2Fit (pas WAN2FIT) dans le contenu
- [ ] PWA manifest : nom = Wan2Fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)