### PR TITLE
fix: données Supabase vides après inactivité

### DIFF
--- a/src/components/CustomPlayerPage.tsx
+++ b/src/components/CustomPlayerPage.tsx
@@ -12,7 +12,7 @@ import { SessionNotFound } from './SessionNotFound.tsx';
 export function CustomPlayerPage() {
   const { id } = useParams<{ id: string }>();
   const { user, loading: authLoading } = useAuth();
-  const { session: record, loading } = useCustomSession(id);
+  const { session: record, loading } = useCustomSession(id, user?.id);
 
   const sessionData = record?.session_data as Session | undefined;
 

--- a/src/components/CustomSessionPage.tsx
+++ b/src/components/CustomSessionPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Dumbbell, Flame, Heart, Zap } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useCustomSessions } from '../hooks/useCustomSessions.ts';
 import { useGenerateSession } from '../hooks/useGenerateSession.ts';
@@ -45,9 +46,10 @@ const BODY_FOCUS_OPTIONS: { value: BodyFocus; label: string }[] = [
 export function CustomSessionPage() {
   useDocumentHead({ title: 'Créer ma séance — Wan2Fit' });
 
+  const { user } = useAuth();
   const navigate = useNavigate();
   const { generate, loading, error } = useGenerateSession();
-  const { sessions: history, loading: historyLoading, error: historyError, refresh } = useCustomSessions();
+  const { sessions: history, loading: historyLoading, error: historyError, refresh } = useCustomSessions(user?.id);
 
   const [mode, setMode] = useState<CustomSessionMode>('quick');
   const [preset, setPreset] = useState<CustomSessionPreset>('transpirer');

--- a/src/components/CustomSessionPreviewPage.tsx
+++ b/src/components/CustomSessionPreviewPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import {
   ChevronLeft,
   ClipboardList,
@@ -117,7 +118,8 @@ function BlockDetail({ block, index }: { block: Block; index: number }) {
 
 export function CustomSessionPreviewPage() {
   const { id } = useParams<{ id: string }>();
-  const { session: record, loading } = useCustomSession(id);
+  const { user } = useAuth();
+  const { session: record, loading } = useCustomSession(id, user?.id);
   const navigate = useNavigate();
   const { generate, loading: regenerating, error: regenError } = useGenerateSession();
 

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -17,7 +17,7 @@ export function ProgramPage() {
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { program, loading } = useProgram(slug);
+  const { program, loading } = useProgram(slug, user?.id);
   const { deleteProgram } = useUserPrograms();
   const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
   const [showDeleteModal, setShowDeleteModal] = useState(false);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ interface AuthContextValue {
   profile: Profile | null;
   loading: boolean;
   sessionExpired: boolean;
+  dataGeneration: number;
   refreshProfile: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string, displayName: string) => Promise<{ error: string | null }>;
@@ -45,12 +46,41 @@ async function fetchProfile(userId: string): Promise<Profile | null> {
   return data as Profile | null;
 }
 
+/** After this duration in background, force a session refresh + data refetch */
+const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(!!supabase);
   const [sessionExpired, setSessionExpired] = useState(false);
+  const [dataGeneration, setDataGeneration] = useState(0);
   const mounted = useRef(true);
+  const lastVisibleAt = useRef(Date.now());
+
+  // Refresh session + bump dataGeneration when returning from background after inactivity
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        const elapsed = Date.now() - lastVisibleAt.current;
+        if (elapsed > STALE_THRESHOLD_MS && supabase) {
+          supabase.auth.refreshSession().then(() => {
+            if (mounted.current) {
+              setDataGeneration((g) => g + 1);
+            }
+          }).catch(() => {
+            // Refresh failed — session may be truly expired
+          });
+        }
+        lastVisibleAt.current = Date.now();
+      } else {
+        lastVisibleAt.current = Date.now();
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
 
   useEffect(() => {
     mounted.current = true;
@@ -171,8 +201,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const value = useMemo<AuthContextValue>(
-    () => ({ user, profile, loading, sessionExpired, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }),
-    [user, profile, loading, sessionExpired, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut],
+    () => ({ user, profile, loading, sessionExpired, dataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }),
+    [user, profile, loading, sessionExpired, dataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut],
   );
 
   return (

--- a/src/hooks/useCustomSessions.ts
+++ b/src/hooks/useCustomSessions.ts
@@ -1,31 +1,30 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { CustomSessionRecord } from '../types/custom-session.ts';
 
-export function useCustomSessions() {
+export function useCustomSessions(userId: string | undefined) {
+  const { dataGeneration } = useAuth();
   const [sessions, setSessions] = useState<CustomSessionRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    if (!supabase) {
+    if (!supabase || !userId) {
+      setSessions([]);
+      setError(null);
       setLoading(false);
       return;
     }
 
+    setLoading(true);
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) {
-        setLoading(false);
-        return;
-      }
-
       const { data, error: fetchError, sessionExpired } = await supabaseQuery(() =>
         supabase!
           .from('custom_sessions')
           .select('*')
-          .eq('user_id', user.id)
+          .eq('user_id', userId)
           .eq('status', 'confirmed')
           .order('created_at', { ascending: false })
           .limit(20),
@@ -46,7 +45,7 @@ export function useCustomSessions() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [userId, dataGeneration]);
 
   useEffect(() => {
     refresh();
@@ -55,28 +54,29 @@ export function useCustomSessions() {
   return { sessions, loading, error, refresh };
 }
 
-export function useCustomSession(id: string | undefined) {
+export function useCustomSession(id: string | undefined, userId: string | undefined) {
+  const { dataGeneration } = useAuth();
   const [session, setSession] = useState<CustomSessionRecord | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!id || !supabase) {
+    if (!id || !userId || !supabase) {
+      setSession(null);
       setLoading(false);
       return;
     }
 
     let cancelled = false;
+    setLoading(true);
 
     async function load() {
       try {
-        const { data: { user } } = await supabase!.auth.getUser();
-        if (!user) { if (!cancelled) setLoading(false); return; }
         const { data, sessionExpired } = await supabaseQuery(() =>
           supabase!
             .from('custom_sessions')
             .select('*')
             .eq('id', id)
-            .eq('user_id', user.id)
+            .eq('user_id', userId)
             .single(),
         );
 
@@ -96,7 +96,7 @@ export function useCustomSession(id: string | undefined) {
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, userId, dataGeneration]);
 
   return { session, loading };
 }

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { SessionCompletion } from '../types/completion.ts';
@@ -104,6 +105,7 @@ function getISOWeekNumber(date: Date): number {
 }
 
 export function useHistory(userId: string | undefined): HistoryStats {
+  const { dataGeneration } = useAuth();
   const [completions, setCompletions] = useState<CompletionWithTitle[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -153,7 +155,7 @@ export function useHistory(userId: string | undefined): HistoryStats {
     return () => {
       cancelled = true;
     };
-  }, [userId]);
+  }, [userId, dataGeneration]);
 
   const derived = useMemo(() => {
     const totalSessions = completions.length;

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -24,16 +24,19 @@ export interface ActiveProgramInfo {
  *  including progression and next session info.
  *  Uses a single RPC call instead of 5 sequential queries. */
 export function useActiveProgram(userId: string | undefined) {
+  const { dataGeneration } = useAuth();
   const [activeProgram, setActiveProgram] = useState<ActiveProgramInfo | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!userId || !supabase) {
+      setActiveProgram(null);
       setLoading(false);
       return;
     }
 
     let cancelled = false;
+    setLoading(true);
 
     (async () => {
       try {
@@ -84,13 +87,13 @@ export function useActiveProgram(userId: string | undefined) {
     return () => {
       cancelled = true;
     };
-  }, [userId]);
+  }, [userId, dataGeneration]);
 
   return { activeProgram, loading };
 }
 
 export function usePrograms() {
-  const { loading: authLoading } = useAuth();
+  const { loading: authLoading, dataGeneration } = useAuth();
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -120,12 +123,13 @@ export function usePrograms() {
     return () => {
       cancelled = true;
     };
-  }, [authLoading]);
+  }, [authLoading, dataGeneration]);
 
   return { programs, loading };
 }
 
-export function useProgram(slug: string | undefined) {
+export function useProgram(slug: string | undefined, userId: string | undefined) {
+  const { dataGeneration } = useAuth();
   const [program, setProgram] = useState<ProgramWithSessions | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -161,28 +165,22 @@ export function useProgram(slug: string | undefined) {
         const sessionIds = (sessions ?? []).map((s: ProgramSession) => s.id);
         let completedIds = new Set<string>();
 
-        if (sessionIds.length > 0) {
-          const {
-            data: { user },
-          } = await supabase!.auth.getUser();
+        if (sessionIds.length > 0 && userId) {
+          const { data: completions, sessionExpired: compExp } = await supabaseQuery(() =>
+            supabase!
+              .from('session_completions')
+              .select('program_session_id')
+              .eq('user_id', userId)
+              .in('program_session_id', sessionIds),
+          );
 
-          if (user) {
-            const { data: completions, sessionExpired: compExp } = await supabaseQuery(() =>
-              supabase!
-                .from('session_completions')
-                .select('program_session_id')
-                .eq('user_id', user.id)
-                .in('program_session_id', sessionIds),
-            );
+          if (compExp) { notifySessionExpired(); setLoading(false); return; }
 
-            if (compExp) { notifySessionExpired(); setLoading(false); return; }
-
-            completedIds = new Set(
-              (completions as Pick<SessionCompletion, 'program_session_id'>[] | null)
-                ?.map((c) => c.program_session_id)
-                .filter((id): id is string => id !== null) ?? [],
-            );
-          }
+          completedIds = new Set(
+            (completions as Pick<SessionCompletion, 'program_session_id'>[] | null)
+              ?.map((c) => c.program_session_id)
+              .filter((id): id is string => id !== null) ?? [],
+          );
         }
 
         if (cancelled) return;
@@ -202,12 +200,13 @@ export function useProgram(slug: string | undefined) {
     return () => {
       cancelled = true;
     };
-  }, [slug]);
+  }, [slug, userId, dataGeneration]);
 
   return { program, loading };
 }
 
 export function useProgramSession(slug: string | undefined, order: number | undefined) {
+  const { dataGeneration } = useAuth();
   const [session, setSession] = useState<ProgramSession | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -247,7 +246,7 @@ export function useProgramSession(slug: string | undefined, order: number | unde
     return () => {
       cancelled = true;
     };
-  }, [slug, order]);
+  }, [slug, order, dataGeneration]);
 
   return { session, loading };
 }


### PR DESCRIPTION
## Summary
- **Race condition auth** : les hooks appelaient `auth.getUser()` (appel réseau) avant que la session soit restaurée → données vides au mount. Remplacé par `userId` passé en paramètre depuis le contexte auth.
- **JWT expiré après inactivité** : le navigateur suspend les timers en background → le `autoRefreshToken` de Supabase ne se déclenche pas → RLS retourne des résultats vides silencieusement. Ajout d'un mécanisme `visibilitychange` + compteur `dataGeneration` qui force le refresh de session et le refetch de tous les hooks après 5min d'inactivité.

## Fichiers modifiés
- `AuthContext.tsx` : ajout `dataGeneration`, `visibilitychange` listener, `refreshSession()` après inactivité
- `useProgram.ts` : `useProgram(slug, userId)`, `dataGeneration` dans les deps de tous les hooks
- `useCustomSessions.ts` : `useCustomSessions(userId)`, `useCustomSession(id, userId)`, `dataGeneration` dans les deps
- `useHistory.ts` : `dataGeneration` dans les deps
- Composants appelants : passage du `userId` depuis `useAuth()`

## Test plan
- [ ] Se connecter, naviguer dans l'app → données chargées normalement
- [ ] Mettre l'app en arrière-plan 5+ minutes → revenir → les données se rechargent
- [ ] Ouvrir un programme avec des sessions complétées → progression affichée correctement
- [ ] Vérifier l'historique après inactivité → données présentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)