### PR TITLE
cosmetic: images programmes plus lumineuses + texte lisible

### DIFF
--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -19,7 +19,7 @@ export function ProgramCard({ program }: { program: Program }) {
           className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
           loading="lazy"
         />
-        <div className="absolute inset-0 bg-gradient-to-b from-black/80 via-black/50 to-black/70 transition-opacity group-hover:opacity-70" />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/25 to-black/50 transition-opacity group-hover:opacity-50" />
 
         <div className="relative z-10 flex flex-col justify-between flex-1 p-6">
           {/* Top: badge */}
@@ -32,16 +32,16 @@ export function ProgramCard({ program }: { program: Program }) {
           </div>
 
           {/* Bottom: info */}
-          <div className="space-y-2 mt-auto">
+          <div className="space-y-2 mt-auto text-outline">
             <h3 className="text-2xl font-bold text-white group-hover:text-white/90 transition-colors">
               {program.title}
             </h3>
 
             {program.description && (
-              <p className="text-sm text-white/70 leading-relaxed line-clamp-2">{program.description}</p>
+              <p className="text-sm text-white leading-relaxed line-clamp-2">{program.description}</p>
             )}
 
-            <div className="flex items-center gap-3 text-xs text-white/50 pt-1">
+            <div className="flex items-center gap-3 text-xs text-white pt-1">
               <span className="flex items-center gap-1.5">
                 <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
@@ -64,7 +64,7 @@ export function ProgramCard({ program }: { program: Program }) {
                 {program.goals.map((goal) => (
                   <li
                     key={goal}
-                    className="text-xs font-medium px-2.5 py-1 rounded-full bg-white/10 border border-white/15 text-white/70"
+                    className="text-xs font-medium px-2.5 py-1 rounded-full bg-white/10 border border-white/15 text-white"
                   >
                     {goal}
                   </li>

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -213,16 +213,16 @@ export function ProgramList() {
                     className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
                     loading="lazy"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-black/70 transition-opacity group-hover:opacity-70" />
+                  <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/25 to-black/50 transition-opacity group-hover:opacity-50" />
                   <div className="relative z-10 flex flex-col justify-between flex-1 p-5">
                     <span className="self-start text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full bg-brand/30 border border-brand/40 text-white backdrop-blur-sm">
                       IA
                     </span>
-                    <div className="mt-auto space-y-1.5">
+                    <div className="mt-auto space-y-1.5 text-outline">
                       <p className="text-lg font-bold text-white group-hover:text-white/90 transition-colors line-clamp-2">
                         {p.title}
                       </p>
-                      <p className="text-xs text-white/50">
+                      <p className="text-xs text-white">
                         {goalLabel && <>Objectif : {goalLabel} · </>}
                         {p.duration_weeks} sem · {p.frequency_per_week}x/sem
                       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -141,6 +141,13 @@ body {
   background-clip: text;
 }
 
+/* Text outline for readability on images */
+.text-outline {
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.8),
+    0 0 1px rgba(0, 0, 0, 0.6);
+}
+
 /* CTA gradient button */
 .cta-gradient {
   background: linear-gradient(135deg, var(--color-brand), var(--color-brand-secondary));


### PR DESCRIPTION
## Summary
- Réduit l'opacité du gradient overlay sur les cartes programmes (images plus vives par défaut, encore plus au hover)
- Passe tous les sous-textes (description, métadonnées, tags) en blanc
- Ajoute une classe `.text-outline` (text-shadow sombre) pour garantir la lisibilité sur fond clair

## Test plan
- [ ] Vérifier `/programmes` : les images sont plus lumineuses qu'avant
- [ ] Hover sur une carte : l'image devient encore plus bright
- [ ] Texte blanc lisible sur toutes les images (fixes + IA)
- [ ] Vérifier en mode clair et sombre

🤖 Generated with [Claude Code](https://claude.com/claude-code)