### PR TITLE
fix: force Supabase data refetch on navigation

### DIFF
--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
 import { Footer } from './Footer.tsx';
@@ -7,10 +8,12 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
   const { pathname } = useLocation();
+  const { bumpDataGeneration } = useAuth();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers scroll-to-top on route change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers scroll-to-top + data refetch on route change
   useEffect(() => {
     window.scrollTo(0, 0);
+    bumpDataGeneration();
   }, [pathname]);
 
   return (

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -8,13 +8,12 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
   const { pathname } = useLocation();
-  const { bumpDataGeneration } = useAuth();
+  const { user, bumpDataGeneration } = useAuth();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers scroll-to-top + data refetch on route change
   useEffect(() => {
     window.scrollTo(0, 0);
-    bumpDataGeneration();
-  }, [pathname]);
+    if (user) bumpDataGeneration();
+  }, [pathname, user, bumpDataGeneration]);
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
@@ -23,7 +22,7 @@ export function PublicLayout() {
       </a>
       <BrandHeader />
       <SessionExpiredBanner />
-      <main id="main-content" className="flex-1 pb-16 md:pb-0" key={pathname}>
+      <main id="main-content" className="flex-1 pb-16 md:pb-0">
         <div className="animate-fade-in">
           <Outlet />
         </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ interface AuthContextValue {
   loading: boolean;
   sessionExpired: boolean;
   dataGeneration: number;
+  bumpDataGeneration: () => void;
   refreshProfile: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string, displayName: string) => Promise<{ error: string | null }>;
@@ -200,9 +201,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setSessionExpired(false);
   }, []);
 
+  const bumpDataGeneration = useCallback(() => setDataGeneration((g) => g + 1), []);
+
   const value = useMemo<AuthContextValue>(
-    () => ({ user, profile, loading, sessionExpired, dataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }),
-    [user, profile, loading, sessionExpired, dataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut],
+    () => ({ user, profile, loading, sessionExpired, dataGeneration, bumpDataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut }),
+    [user, profile, loading, sessionExpired, dataGeneration, bumpDataGeneration, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut],
   );
 
   return (

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Subscription } from '../types/subscription.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useSubscription() {
-  const { profile, user } = useAuth();
+  const { profile, user, dataGeneration } = useAuth();
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -24,15 +25,18 @@ export function useSubscription() {
 
     (async () => {
       try {
-        const { data } = await supabase
-          .from('subscriptions')
-          .select('*')
-          .eq('user_id', user.id)
-          .in('status', ['active', 'past_due', 'trialing'])
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .maybeSingle();
+        const { data, sessionExpired } = await supabaseQuery(() =>
+          supabase!
+            .from('subscriptions')
+            .select('*')
+            .eq('user_id', user.id)
+            .in('status', ['active', 'past_due', 'trialing'])
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle(),
+        );
 
+        if (sessionExpired) { notifySessionExpired(); return; }
         if (!cancelled) setSubscription(data as Subscription | null);
       } catch (err) {
         console.error('Subscription fetch error:', err);
@@ -42,7 +46,7 @@ export function useSubscription() {
     })();
 
     return () => { cancelled = true; };
-  }, [user, isPremium]);
+  }, [user, isPremium, dataGeneration]);
 
   const checkout = useCallback(
     async (priceId: string): Promise<string | null> => {

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -5,7 +5,7 @@ import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program } from '../types/completion.ts';
 
 export function useUserPrograms() {
-  const { user } = useAuth();
+  const { user, dataGeneration } = useAuth();
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -35,9 +35,6 @@ export function useUserPrograms() {
     }
   }, [user]);
 
-  // Refetch on mount (key={pathname} in PublicLayout forces remount on navigation)
-  // and when user or dataGeneration changes (idle return)
-  const { dataGeneration } = useAuth();
   useEffect(() => {
     fetchPrograms();
   }, [fetchPrograms, dataGeneration]);

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -15,6 +15,7 @@ export function useUserPrograms() {
       return;
     }
 
+    setLoading(true);
     try {
       const { data, sessionExpired } = await supabaseQuery(() =>
         supabase!
@@ -34,9 +35,12 @@ export function useUserPrograms() {
     }
   }, [user]);
 
+  // Refetch on mount (key={pathname} in PublicLayout forces remount on navigation)
+  // and when user or dataGeneration changes (idle return)
+  const { dataGeneration } = useAuth();
   useEffect(() => {
     fetchPrograms();
-  }, [fetchPrograms]);
+  }, [fetchPrograms, dataGeneration]);
 
   const deleteProgram = useCallback(async (id: string) => {
     if (!supabase) return false;


### PR DESCRIPTION
## Summary
- Bump `dataGeneration` on every route change (authenticated users only) to force all Supabase hooks to refetch fresh data
- Add missing `dataGeneration` dependency to `useUserPrograms` and `useSubscription`
- Wrap `useSubscription` queries with `supabaseQuery` for session recovery
- Remove `key={pathname}` from PublicLayout to avoid double-fetch

## Context
After staying on a page for a few minutes, navigating to pages that load Supabase data (e.g. custom programs) would show stale or empty data. The root cause was that `useUserPrograms` and `useSubscription` did not react to `dataGeneration` changes, and there was no mechanism to trigger refetch on navigation.

## Test plan
- [ ] Stay on home for 2+ minutes, navigate to `/programmes` → custom programs load
- [ ] Navigate between pages rapidly → no double loading states
- [ ] Visitor (logged out) navigation still works without unnecessary refetches
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)