### PR TITLE
feat: add /seances page and refactor BottomNav

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -60,6 +60,44 @@ function ProgramsIcon() {
   );
 }
 
+function HomeIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </svg>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+
 function ChartIcon() {
   return (
     <svg
@@ -109,13 +147,12 @@ export function BottomNav() {
   const { pathname } = useLocation();
   const { user } = useAuth();
 
+  const isHome = pathname === '/';
   const isSeances = pathname === '/seances' || pathname.startsWith('/seance');
   const isPrograms = pathname.startsWith('/programme');
   const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
   const isSuivi = pathname === '/suivi';
-
-  const seancesTo = user ? '/seances' : '/login';
-  const suiviTo = user ? '/suivi' : '/login';
+  const isLogin = pathname === '/login' || pathname === '/signup';
 
   return (
     <nav
@@ -124,18 +161,37 @@ export function BottomNav() {
       aria-label="Navigation principale"
     >
       <div className="flex items-center justify-around h-16 max-w-lg mx-auto">
-        <NavItem to={seancesTo} label="Séances" active={isSeances}>
-          <DumbbellIcon />
-        </NavItem>
-        <NavItem to="/programmes" label="Programmes" active={isPrograms}>
-          <ProgramsIcon />
-        </NavItem>
-        <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
-          <DiscoverIcon />
-        </NavItem>
-        <NavItem to={suiviTo} label="Suivi" active={isSuivi}>
-          <ChartIcon />
-        </NavItem>
+        {user ? (
+          <>
+            <NavItem to="/seances" label="Séances" active={isSeances}>
+              <DumbbellIcon />
+            </NavItem>
+            <NavItem to="/programmes" label="Programmes" active={isPrograms}>
+              <ProgramsIcon />
+            </NavItem>
+            <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
+              <DiscoverIcon />
+            </NavItem>
+            <NavItem to="/suivi" label="Suivi" active={isSuivi}>
+              <ChartIcon />
+            </NavItem>
+          </>
+        ) : (
+          <>
+            <NavItem to="/" label="Accueil" active={isHome}>
+              <HomeIcon />
+            </NavItem>
+            <NavItem to="/programmes" label="Programmes" active={isPrograms}>
+              <ProgramsIcon />
+            </NavItem>
+            <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
+              <DiscoverIcon />
+            </NavItem>
+            <NavItem to="/login" label="Connexion" active={isLogin}>
+              <UserIcon />
+            </NavItem>
+          </>
+        )}
       </div>
     </nav>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,10 +1,7 @@
 import { Link, useLocation } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
-import { useHealthCheck } from '../hooks/useHealthCheck.ts';
-import { getInitials } from '../utils/getInitials.ts';
-import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 
-function HomeIcon() {
+function DumbbellIcon() {
   return (
     <svg
       aria-hidden="true"
@@ -17,8 +14,8 @@ function HomeIcon() {
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
+      <path d="M6.5 6.5h11M6.5 17.5h11" />
+      <path d="M4 10v4M8 8v8M16 8v8M20 10v4" />
     </svg>
   );
 }
@@ -63,25 +60,6 @@ function ProgramsIcon() {
   );
 }
 
-function UserIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-      <circle cx="12" cy="7" r="4" />
-    </svg>
-  );
-}
-
 function ChartIcon() {
   return (
     <svg
@@ -98,21 +76,6 @@ function ChartIcon() {
       <line x1="18" y1="20" x2="18" y2="10" />
       <line x1="12" y1="20" x2="12" y2="4" />
       <line x1="6" y1="20" x2="6" y2="14" />
-    </svg>
-  );
-}
-
-function PlayIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      stroke="none"
-    >
-      <polygon points="6 3 20 12 6 21 6 3" />
     </svg>
   );
 }
@@ -144,70 +107,36 @@ function NavItem({
 
 export function BottomNav() {
   const { pathname } = useLocation();
-  const { user, profile } = useAuth();
-  const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
+  const { user } = useAuth();
 
-  const isHome = pathname === '/';
-  const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
+  const isSeances = pathname === '/seances' || pathname.startsWith('/seance');
   const isPrograms = pathname.startsWith('/programme');
+  const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
   const isSuivi = pathname === '/suivi';
-  const isProfile = pathname === '/parametres' || pathname === '/profil' || pathname === '/login' || pathname === '/signup';
 
+  const seancesTo = user ? '/seances' : '/login';
   const suiviTo = user ? '/suivi' : '/login';
-  const profileTo = user ? '/parametres' : '/login';
-  const profileLabel = user ? 'Profil' : 'Connexion';
 
   return (
-    <>
-      {showDisclaimer && <HealthDisclaimer onAccept={acceptAndNavigate} onCancel={cancelDisclaimer} />}
-
-      <nav
-        className="fixed bottom-0 inset-x-0 z-50 bg-surface/95 backdrop-blur-lg border-t border-divider md:hidden"
-        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-        aria-label="Navigation principale"
-      >
-        <div className="flex items-end justify-around h-16 max-w-lg mx-auto relative">
-          <NavItem to="/" label="Accueil" active={isHome}>
-            <HomeIcon />
-          </NavItem>
-          <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
-            <DiscoverIcon />
-          </NavItem>
-
-          {/* Center FAB — Play button */}
-          <div className="flex flex-col items-center -mt-5">
-            <button
-              type="button"
-              onClick={() => guardNavigation('/seance/play')}
-              className="fab-button w-14 h-14 rounded-full flex items-center justify-center text-white cursor-pointer"
-              aria-label="Lancer la séance du jour"
-            >
-              <PlayIcon />
-            </button>
-          </div>
-
-          <NavItem to="/programmes" label="Programmes" active={isPrograms}>
-            <ProgramsIcon />
-          </NavItem>
-          {user && (
-            <NavItem to={suiviTo} label="Suivi" active={isSuivi}>
-              <ChartIcon />
-            </NavItem>
-          )}
-          {!user && (
-          <NavItem to={profileTo} label={profileLabel} active={isProfile}>
-            <UserIcon />
-          </NavItem>
-          )}
-          {user && (
-            <NavItem to={profileTo} label={profileLabel} active={isProfile}>
-              <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] text-white font-bold bg-brand">
-                {getInitials(profile?.display_name ?? user.user_metadata?.display_name, user.email)}
-              </div>
-            </NavItem>
-          )}
-        </div>
-      </nav>
-    </>
+    <nav
+      className="fixed bottom-0 inset-x-0 z-50 bg-surface/95 backdrop-blur-lg border-t border-divider md:hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      aria-label="Navigation principale"
+    >
+      <div className="flex items-center justify-around h-16 max-w-lg mx-auto">
+        <NavItem to={seancesTo} label="Séances" active={isSeances}>
+          <DumbbellIcon />
+        </NavItem>
+        <NavItem to="/programmes" label="Programmes" active={isPrograms}>
+          <ProgramsIcon />
+        </NavItem>
+        <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
+          <DiscoverIcon />
+        </NavItem>
+        <NavItem to={suiviTo} label="Suivi" active={isSuivi}>
+          <ChartIcon />
+        </NavItem>
+      </div>
+    </nav>
   );
 }

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -4,6 +4,7 @@ import { AuthButton } from './auth/AuthButton.tsx';
 
 const NAV_ITEMS = [
   { to: '/', label: 'Accueil', match: (p: string) => p === '/' },
+  { to: '/seances', label: 'Séances', match: (p: string) => p === '/seances' || p.startsWith('/seance'), requiresAuth: true },
   {
     to: '/decouvrir',
     label: 'Explorer',

--- a/src/components/SeancesPage.tsx
+++ b/src/components/SeancesPage.tsx
@@ -1,0 +1,317 @@
+import { Link } from 'react-router';
+import { Play, Sparkles } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { useDocumentHead } from '../hooks/useDocumentHead.ts';
+import { useHealthCheck } from '../hooks/useHealthCheck.ts';
+import { useSession } from '../hooks/useSession.ts';
+import { useCustomSessions } from '../hooks/useCustomSessions.ts';
+import { getTodayKey, getTomorrowKey, formatDate } from '../utils/date.ts';
+import { getSessionImage } from '../utils/sessionImage.ts';
+import { computeDifficulty } from '../utils/sessionDifficulty.ts';
+import { SessionAccordion } from './SessionAccordion.tsx';
+import { HealthDisclaimer } from './HealthDisclaimer.tsx';
+
+export function SeancesPage() {
+  const todayKey = getTodayKey();
+  const tomorrowKey = getTomorrowKey();
+  const { session, loading, error } = useSession(todayKey);
+  const { session: tomorrowSession, loading: tomorrowLoading } = useSession(tomorrowKey);
+  const { user, profile } = useAuth();
+  const { showDisclaimer, guardNavigation, acceptAndNavigate, cancelDisclaimer } = useHealthCheck();
+
+  const isPremium = profile?.subscription_tier === 'premium';
+  const { sessions: customSessions, loading: customLoading } = useCustomSessions(isPremium ? user?.id : undefined);
+
+  useDocumentHead({
+    title: 'Mes séances',
+    description: 'Retrouvez vos séances du jour, de demain et vos séances sur-mesure.',
+  });
+
+  const difficulty = session ? computeDifficulty(session) : null;
+
+  return (
+    <>
+      {showDisclaimer && <HealthDisclaimer onAccept={acceptAndNavigate} onCancel={cancelDisclaimer} />}
+
+      <div className="px-6 md:px-10 lg:px-14 py-8">
+        <div className="max-w-5xl mx-auto space-y-10">
+
+          {/* ── Grille : Séance du jour (2 cols) + Demain / CTA (1 col) ── */}
+          <section>
+            <h1 className="font-display text-2xl sm:text-3xl font-black text-heading mb-6">
+              Mes séances
+            </h1>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:items-start">
+              {/* 1 — Séance du jour */}
+              <div className="flex flex-col rounded-2xl overflow-hidden border border-card-border transition-all hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10">
+                <h2 className="font-display text-base font-bold text-heading px-5 py-4 bg-surface-card border-b border-divider">
+                  Séance du jour
+                </h2>
+                {loading ? (
+                  <div className="p-5 space-y-3">
+                    <div className="skeleton h-44 rounded-xl" />
+                    <div className="skeleton h-5 w-3/4" />
+                    <div className="skeleton h-10 w-full rounded-xl" />
+                  </div>
+                ) : session ? (
+                  <>
+                    <button type="button" onClick={() => guardNavigation('/seance/play')} className="relative h-44 w-full cursor-pointer text-left">
+                      <img src={getSessionImage(session)} alt={`Séance du jour : ${session.title}`} className="w-full h-full object-cover object-[50%_30%]" />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+                      <div className="absolute bottom-3 left-4 right-4">
+                        <p className="font-display text-lg font-bold text-white leading-tight">
+                          {session.title.toUpperCase()}
+                        </p>
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className="text-xs text-white/70">~{session.estimatedDuration} min</span>
+                          {session.focus.slice(0, 2).map((f) => (
+                            <span key={f} className="text-xs text-white/70">· {f}</span>
+                          ))}
+                          {difficulty && (
+                            <>
+                              <span className="text-xs text-white/70">·</span>
+                              <span
+                                className={`text-xs font-semibold ${
+                                  difficulty.level === 'accessible'
+                                    ? 'text-emerald-400'
+                                    : difficulty.level === 'modere'
+                                      ? 'text-amber-400'
+                                      : 'text-red-400'
+                                }`}
+                              >
+                                {difficulty.label}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </button>
+                    <div className="px-5 py-4 bg-surface-card space-y-3">
+                      {session.description && (
+                        <p className="text-sm text-muted leading-relaxed">{session.description}</p>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => guardNavigation('/seance/play')}
+                        className="cta-gradient flex items-center justify-center gap-2 w-full py-3 rounded-xl text-sm font-bold text-white cursor-pointer"
+                      >
+                        <Play className="w-4 h-4" aria-hidden="true" />
+                        C'est parti
+                      </button>
+                    </div>
+                    <SessionAccordion session={session} defaultOpen />
+                  </>
+                ) : error ? (
+                  <div className="p-6 flex items-center justify-center">
+                    <div className="text-center">
+                      <p className="text-sm text-red-400">Impossible de charger la séance</p>
+                      <p className="text-xs text-muted mt-1">Vérifie ta connexion et réessaie.</p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="p-6 flex items-center justify-center">
+                    <div className="text-center">
+                      <img src="/images/illustration-empty-state.webp" alt="Pas de séance prévue" className="w-40 h-auto mx-auto mb-3 rounded-lg opacity-80" />
+                      <p className="text-sm text-muted">Pas de séance aujourd'hui</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* 2 — CTA Séance sur-mesure */}
+              {isPremium ? (
+                <Link
+                  to="/seance/custom"
+                  className="flex flex-col rounded-2xl overflow-hidden border border-card-border group cursor-pointer transition-all hover:border-accent/30 hover:shadow-lg hover:shadow-accent/10"
+                >
+                  <div className="flex items-center gap-2 px-5 py-4 bg-surface-card border-b border-divider">
+                    <h3 className="font-display text-base font-bold text-heading group-hover:text-accent transition-colors">
+                      Séance sur-mesure
+                    </h3>
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-brand/60 bg-brand/8 px-2 py-0.5 rounded-full shrink-0">Premium</span>
+                  </div>
+                  <div className="relative h-36 overflow-hidden">
+                    <img src="/images/illustration-ai-session.webp" alt="Séance personnalisée par IA" className="w-full h-full object-cover object-center" />
+                  </div>
+                  <div className="px-5 py-4 bg-surface-card space-y-3">
+                    <p className="text-sm text-muted leading-relaxed">
+                      Choisis ta durée, ton intensité et tes zones ciblées : l'IA compose une séance 100 % personnalisée, prête à lancer en quelques secondes.
+                    </p>
+                    <ul className="text-xs text-subtle space-y-1">
+                      <li>Durée, intensité et focus au choix</li>
+                      <li>Adaptée à ton matériel disponible</li>
+                      <li>Nouvelle séance à chaque demande</li>
+                    </ul>
+                    <div className="flex items-center justify-center gap-2 w-full py-3 rounded-xl text-sm font-bold text-white bg-accent hover:bg-accent/90 transition-colors">
+                      <Play className="w-4 h-4" aria-hidden="true" />
+                      Créer une séance
+                    </div>
+                  </div>
+                </Link>
+              ) : (
+                <Link
+                  to="/premium"
+                  className="flex flex-col rounded-2xl overflow-hidden border border-card-border group cursor-pointer transition-all hover:border-accent/30 hover:shadow-lg hover:shadow-accent/10"
+                >
+                  <div className="flex items-center gap-2 px-5 py-4 bg-surface-card border-b border-divider">
+                    <h3 className="font-display text-base font-bold text-heading group-hover:text-accent transition-colors">
+                      Séance sur-mesure
+                    </h3>
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-accent/80 bg-accent/10 px-2 py-0.5 rounded-full shrink-0">Premium</span>
+                  </div>
+                  <div className="relative h-36 overflow-hidden">
+                    <img src="/images/illustration-ai-session.webp" alt="Séance personnalisée par IA" className="w-full h-full object-cover object-center" />
+                  </div>
+                  <div className="px-5 py-4 bg-surface-card space-y-3">
+                    <p className="text-sm text-muted leading-relaxed">
+                      Choisis ta durée, ton intensité et tes zones ciblées : l'IA compose une séance 100 % personnalisée, prête à lancer en quelques secondes.
+                    </p>
+                    <ul className="text-xs text-subtle space-y-1">
+                      <li>Durée, intensité et focus au choix</li>
+                      <li>Adaptée à ton matériel disponible</li>
+                      <li>Nouvelle séance à chaque demande</li>
+                    </ul>
+                    <div className="flex items-center justify-center gap-2 w-full py-3 rounded-xl text-sm font-bold text-white bg-accent hover:bg-accent/90 transition-colors">
+                      <Sparkles className="w-4 h-4" aria-hidden="true" />
+                      Débloquer avec Premium
+                    </div>
+                  </div>
+                </Link>
+              )}
+            </div>
+          </section>
+
+          {/* ── Demain — ligne compacte + accordion ── */}
+          {!tomorrowLoading && tomorrowSession && (
+            <section>
+              <div className="rounded-2xl overflow-hidden border border-card-border transition-all hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10">
+                <div className="flex items-stretch min-h-[100px]">
+                  <div className="relative w-28 sm:w-36 shrink-0">
+                    <img src={getSessionImage(tomorrowSession)} alt={`Séance de demain : ${tomorrowSession.title}`} className="absolute inset-0 w-full h-full object-cover object-[50%_30%]" loading="lazy" />
+                    <div className="absolute inset-0 bg-black/30" />
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="session-label-tomorrow px-2 py-0.5 rounded-md">
+                        <span className="text-xs font-bold text-white">Demain</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex-1 p-4 flex flex-col justify-center min-w-0 bg-surface-card">
+                    <h3 className="font-display text-base font-bold text-heading truncate">
+                      {tomorrowSession.title.toUpperCase()}
+                    </h3>
+                    <div className="flex items-center gap-2 mt-2">
+                      <span className="text-xs text-muted">~{tomorrowSession.estimatedDuration} min</span>
+                      {tomorrowSession.focus.slice(0, 2).map((f) => (
+                        <span key={f} className="text-xs text-muted">· {f}</span>
+                      ))}
+                      {(() => {
+                        const d = computeDifficulty(tomorrowSession);
+                        return (
+                          <>
+                            <span className="text-xs text-muted">·</span>
+                            <span
+                              className={`text-xs font-semibold ${
+                                d.level === 'accessible'
+                                  ? 'text-emerald-400'
+                                  : d.level === 'modere'
+                                    ? 'text-amber-400'
+                                    : 'text-red-400'
+                              }`}
+                            >
+                              {d.label}
+                            </span>
+                          </>
+                        );
+                      })()}
+                    </div>
+                  </div>
+                </div>
+                <SessionAccordion session={tomorrowSession} />
+              </div>
+            </section>
+          )}
+
+          {/* ── Section 4 : Mes séances sur-mesure (premium only) ── */}
+          {isPremium && (
+            <section>
+              <h2 className="font-display text-xl sm:text-2xl font-bold text-heading mb-4">
+                Mes séances sur-mesure
+              </h2>
+
+              {customLoading ? (
+                <div className="space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <div key={i} className="rounded-2xl overflow-hidden border border-card-border">
+                      <div className="flex items-stretch min-h-[80px]">
+                        <div className="skeleton w-28 shrink-0 rounded-none" />
+                        <div className="flex-1 p-4 space-y-2">
+                          <div className="skeleton h-4 w-3/4" />
+                          <div className="skeleton h-3 w-1/2" />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : customSessions.length > 0 ? (
+                <div className="space-y-3">
+                  {customSessions.map((cs) => {
+                    const sessionData = cs.session_data;
+                    const image = getSessionImage(sessionData);
+                    const diff = computeDifficulty(sessionData);
+
+                    return (
+                      <Link
+                        key={cs.id}
+                        to={`/seance/custom/${cs.id}`}
+                        className="flex items-stretch min-h-[80px] rounded-2xl overflow-hidden border border-card-border transition-all hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10"
+                      >
+                        <div className="relative w-28 sm:w-36 shrink-0">
+                          <img src={image} alt={sessionData.title} className="absolute inset-0 w-full h-full object-cover object-[50%_30%]" loading="lazy" />
+                          <div className="absolute inset-0 bg-black/20" />
+                        </div>
+                        <div className="flex-1 p-4 flex flex-col justify-center min-w-0 bg-surface-card">
+                          <h3 className="font-display text-base font-bold text-heading truncate">
+                            {sessionData.title}
+                          </h3>
+                          <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                            <span className="text-xs text-muted">~{sessionData.estimatedDuration} min</span>
+                            {sessionData.focus.slice(0, 2).map((f) => (
+                              <span key={f} className="text-xs text-muted">· {f}</span>
+                            ))}
+                            <span className="text-xs text-muted">·</span>
+                            <span
+                              className={`text-xs font-semibold ${
+                                diff.level === 'accessible'
+                                  ? 'text-emerald-400'
+                                  : diff.level === 'modere'
+                                    ? 'text-amber-400'
+                                    : 'text-red-400'
+                              }`}
+                            >
+                              {diff.label}
+                            </span>
+                          </div>
+                          <p className="text-[11px] text-faint mt-1.5">
+                            Créée le {formatDate(cs.created_at)}
+                          </p>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-card-border p-6 text-center bg-surface-card">
+                  <p className="text-sm text-muted">
+                    Pas encore de séance sur-mesure. Crée ta première séance personnalisée !
+                  </p>
+                </div>
+              )}
+            </section>
+          )}
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/SeancesPage.tsx
+++ b/src/components/SeancesPage.tsx
@@ -28,6 +28,7 @@ export function SeancesPage() {
   });
 
   const difficulty = session ? computeDifficulty(session) : null;
+  const tomorrowDifficulty = tomorrowSession ? computeDifficulty(tomorrowSession) : null;
 
   return (
     <>
@@ -205,25 +206,22 @@ export function SeancesPage() {
                       {tomorrowSession.focus.slice(0, 2).map((f) => (
                         <span key={f} className="text-xs text-muted">· {f}</span>
                       ))}
-                      {(() => {
-                        const d = computeDifficulty(tomorrowSession);
-                        return (
-                          <>
-                            <span className="text-xs text-muted">·</span>
-                            <span
-                              className={`text-xs font-semibold ${
-                                d.level === 'accessible'
-                                  ? 'text-emerald-400'
-                                  : d.level === 'modere'
-                                    ? 'text-amber-400'
-                                    : 'text-red-400'
-                              }`}
-                            >
-                              {d.label}
-                            </span>
-                          </>
-                        );
-                      })()}
+                      {tomorrowDifficulty && (
+                        <>
+                          <span className="text-xs text-muted">·</span>
+                          <span
+                            className={`text-xs font-semibold ${
+                              tomorrowDifficulty.level === 'accessible'
+                                ? 'text-emerald-400'
+                                : tomorrowDifficulty.level === 'modere'
+                                  ? 'text-amber-400'
+                                  : 'text-red-400'
+                            }`}
+                          >
+                            {tomorrowDifficulty.label}
+                          </span>
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/SessionAccordion.tsx
+++ b/src/components/SessionAccordion.tsx
@@ -5,8 +5,8 @@ import type { Block, Session } from '../types/session.ts';
 import { getExerciseLink } from '../utils/exerciseLinks.ts';
 import { computeTimeline } from '../utils/sessionTimeline.ts';
 
-export function SessionAccordion({ session }: { session: Session }) {
-  const [open, setOpen] = useState(false);
+export function SessionAccordion({ session, defaultOpen = false }: { session: Session; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
   const panelId = useId();
 
   return (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -64,6 +64,9 @@ const LazyPremiumPromoPage = lazy(() =>
 const LazyAboutPage = lazy(() =>
   import('./components/AboutPage.tsx').then((m) => ({ default: m.AboutPage })),
 );
+const LazySeancesPage = lazy(() =>
+  import('./components/SeancesPage.tsx').then((m) => ({ default: m.SeancesPage })),
+);
 
 function Lazy({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<LoadingFallback />}>{children}</Suspense>;
@@ -182,6 +185,16 @@ export const router = createBrowserRouter([
         ),
       },
       { path: 'stats', element: <Navigate to="/suivi" replace /> },
+      {
+        path: 'seances',
+        element: (
+          <Lazy>
+            <RequireAuth>
+              <LazySeancesPage />
+            </RequireAuth>
+          </Lazy>
+        ),
+      },
       {
         path: 'parametres',
         element: (


### PR DESCRIPTION
## Summary
- **New `/seances` page** (RequireAuth) with today's session (auto-expanded accordion), tomorrow preview with accordion, custom session CTA (premium/upsell), and premium custom sessions list
- **BottomNav refactored**: removed FAB play button; connected users see Séances/Programmes/Explorer/Suivi, guests see Accueil/Programmes/Explorer/Connexion
- **BrandHeader**: added "Séances" nav item (visible only when authenticated)
- **SessionAccordion**: added `defaultOpen` prop (non-breaking)

## Test plan
- [ ] `/seances` as connected free user: today session + tomorrow + premium upsell CTA, no custom sessions list
- [ ] `/seances` as connected premium user: all sections including custom sessions list
- [ ] `/seances` as visitor: redirects to `/login`
- [ ] BottomNav mobile connected: 4 items (Séances, Programmes, Explorer, Suivi), active states correct
- [ ] BottomNav mobile visitor: 4 items (Accueil, Programmes, Explorer, Connexion)
- [ ] BrandHeader desktop: "Séances" visible only when logged in
- [ ] Today's session accordion opens by default on SeancesPage
- [ ] Tomorrow accordion opens on click
- [ ] Home page unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)