### PR TITLE
fix: meta title duplicates, missing accents, short duration, tutoiement

### DIFF
--- a/public/sessions/20260216.json
+++ b/public/sessions/20260216.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -42,13 +42,13 @@
           "name": "Squats",
           "mode": "reps",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes classiques",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Fentes alternees",

--- a/public/sessions/20260217.json
+++ b/public/sessions/20260217.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Squat jumps",
@@ -79,7 +79,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260218.json
+++ b/public/sessions/20260218.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -44,11 +44,11 @@
           "instructions": "Pieds tres largement ecartes, pointes vers l'exterieur"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
@@ -63,7 +63,7 @@
           "sets": 3,
           "reps": "max",
           "restBetweenSets": 60,
-          "instructions": "Dos contre le mur, cuisses paralleles, maintenir la position"
+          "instructions": "Dos contre le mur, cuisses parallèles, maintenir la position"
         }
       ]
     },
@@ -115,7 +115,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260219.json
+++ b/public/sessions/20260219.json
@@ -89,7 +89,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260219.json
+++ b/public/sessions/20260219.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -39,7 +39,7 @@
         {
           "name": "Pompes classiques",
           "reps": 8,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Squats sautes",
@@ -66,7 +66,7 @@
         {
           "name": "V-ups",
           "reps": 10,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },

--- a/public/sessions/20260220.json
+++ b/public/sessions/20260220.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Pike push-ups",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },
@@ -76,7 +76,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         },
         {
           "name": "Prone Y raises",

--- a/public/sessions/20260221.json
+++ b/public/sessions/20260221.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -42,19 +42,19 @@
           "name": "Pompes classiques",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Squats",
           "mode": "reps",
           "reps": 15,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Fentes avant",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         },
         {
@@ -67,7 +67,7 @@
           "name": "Crunchs",
           "mode": "reps",
           "reps": 15,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },

--- a/public/sessions/20260222.json
+++ b/public/sessions/20260222.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -41,21 +41,21 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes inclinees",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {

--- a/public/sessions/20260223.json
+++ b/public/sessions/20260223.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Jump lunges",

--- a/public/sessions/20260223.json
+++ b/public/sessions/20260223.json
@@ -100,7 +100,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260224.json
+++ b/public/sessions/20260224.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -39,7 +39,7 @@
       "exercises": [
         {
           "name": "Pompes classiques",
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Squats sautes",
@@ -57,7 +57,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -65,14 +65,14 @@
           "sets": 3,
           "reps": 8,
           "restBetweenSets": 75,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Crunchs",
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },
@@ -95,7 +95,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260225.json
+++ b/public/sessions/20260225.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -39,7 +39,7 @@
         {
           "name": "Pompes larges",
           "reps": 10,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Squats sumo",

--- a/public/sessions/20260226.json
+++ b/public/sessions/20260226.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -42,13 +42,13 @@
           "name": "Squats",
           "mode": "reps",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes classiques",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Fentes alternees",

--- a/public/sessions/20260227.json
+++ b/public/sessions/20260227.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },
@@ -83,7 +83,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         }
       ]
     },

--- a/public/sessions/20260227.json
+++ b/public/sessions/20260227.json
@@ -106,7 +106,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260228.json
+++ b/public/sessions/20260228.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "High knees",
@@ -79,7 +79,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260301.json
+++ b/public/sessions/20260301.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -48,7 +48,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -77,7 +77,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Gainage lateral",
@@ -108,7 +108,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260302.json
+++ b/public/sessions/20260302.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -39,7 +39,7 @@
         {
           "name": "Pompes explosives",
           "reps": 8,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         },
         {
           "name": "Goblet squat (sans poids)",

--- a/public/sessions/20260303.json
+++ b/public/sessions/20260303.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -52,7 +52,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         }
       ]
     },

--- a/public/sessions/20260304.json
+++ b/public/sessions/20260304.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -43,7 +43,7 @@
         },
         {
           "name": "Squats",
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -53,11 +53,11 @@
       "restBetweenExercises": 45,
       "exercises": [
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
@@ -65,7 +65,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         },
         {
           "name": "Russian twists",
@@ -95,7 +95,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260305.json
+++ b/public/sessions/20260305.json
@@ -102,7 +102,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260305.json
+++ b/public/sessions/20260305.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes larges",
               "reps": 10,
-              "instructions": "Mains plus larges que les epaules, focus pectoraux"
+              "instructions": "Mains plus larges que les épaules, focus pectoraux"
             },
             {
               "name": "Rowing inverse (table)",

--- a/public/sessions/20260306.json
+++ b/public/sessions/20260306.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -44,7 +44,7 @@
         {
           "name": "Pompes inclinees",
           "reps": 10,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
           "name": "Fentes marchees",

--- a/public/sessions/20260307.json
+++ b/public/sessions/20260307.json
@@ -81,11 +81,11 @@
           "instructions": "Coude vers genou oppose en alternant, jambe tendue"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         }
       ]
     },

--- a/public/sessions/20260307.json
+++ b/public/sessions/20260307.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -102,7 +102,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260308.json
+++ b/public/sessions/20260308.json
@@ -55,7 +55,7 @@
           "name": "Gainage Superman",
           "mode": "timed",
           "duration": 25,
-          "instructions": "En planche, lever un bras et la jambe opposee, alterner"
+          "instructions": "En planche, lever un bras et la jambe opposée, alterner"
         },
         {
           "name": "Good morning",

--- a/public/sessions/20260308.json
+++ b/public/sessions/20260308.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -42,14 +42,14 @@
           "name": "Fentes avant",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         },
         {
           "name": "Pompes declinees",
           "mode": "reps",
           "reps": 8,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Gainage Superman",
@@ -79,7 +79,7 @@
       "exercises": [
         {
           "name": "Pompes classiques",
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Squats sautes",

--- a/public/sessions/20260309.json
+++ b/public/sessions/20260309.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Pop squats",
@@ -104,7 +104,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260310.json
+++ b/public/sessions/20260310.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -44,7 +44,7 @@
         {
           "name": "Squats",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -56,17 +56,17 @@
         {
           "name": "Fentes avant",
           "reps": 10,
-          "instructions": "Grand pas en avant, genou arriere frole le sol"
+          "instructions": "Grand pas en avant, genou arrière frôle le sol"
         },
         {
           "name": "Pompes classiques",
           "reps": 8,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Crunchs",
           "reps": 12,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },

--- a/public/sessions/20260311.json
+++ b/public/sessions/20260311.json
@@ -107,7 +107,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260311.json
+++ b/public/sessions/20260311.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -49,14 +49,14 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
           "name": "Pompes explosives",
           "sets": 3,
           "reps": 8,
           "restBetweenSets": 75,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         }
       ]
     },
@@ -70,7 +70,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arriere"
+          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arrière"
         },
         {
           "name": "Reverse snow angels",

--- a/public/sessions/20260312.json
+++ b/public/sessions/20260312.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -49,7 +49,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Sur une jambe, pencher le buste en avant, jambe arriere tendue",
+          "instructions": "Sur une jambe, pencher le buste en avant, jambe arrière tendue",
           "bilateral": true
         },
         {
@@ -108,7 +108,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260313.json
+++ b/public/sessions/20260313.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -43,12 +43,12 @@
             {
               "name": "Pompes classiques",
               "reps": 12,
-              "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+              "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
             },
             {
               "name": "Superman",
               "reps": 12,
-              "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+              "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
             }
           ]
         },
@@ -57,7 +57,7 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Prone Y raises",

--- a/public/sessions/20260314.json
+++ b/public/sessions/20260314.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -51,10 +51,10 @@
           "instructions": "Mains rapprochees sous la poitrine, coudes le long du corps"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
@@ -67,7 +67,7 @@
           "name": "Burpees sans pompe",
           "mode": "reps",
           "reps": 8,
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Glute bridge",
@@ -102,7 +102,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260315.json
+++ b/public/sessions/20260315.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -49,7 +49,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'equilibre",
+          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'équilibre",
           "bilateral": true
         },
         {
@@ -57,7 +57,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos contre le mur, cuisses paralleles, maintenir la position"
+          "instructions": "Dos contre le mur, cuisses parallèles, maintenir la position"
         },
         {
           "name": "Glute bridge marche",
@@ -92,7 +92,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },
@@ -115,7 +115,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260316.json
+++ b/public/sessions/20260316.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Star jumps",

--- a/public/sessions/20260317.json
+++ b/public/sessions/20260317.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",

--- a/public/sessions/20260318.json
+++ b/public/sessions/20260318.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -39,11 +39,11 @@
       "exercises": [
         {
           "name": "Squats",
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes classiques",
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         }
       ]
     },
@@ -57,7 +57,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         },
         {
@@ -65,7 +65,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         },
         {
           "name": "Bicycle crunchs",

--- a/public/sessions/20260319.json
+++ b/public/sessions/20260319.json
@@ -106,7 +106,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260319.json
+++ b/public/sessions/20260319.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },

--- a/public/sessions/20260320.json
+++ b/public/sessions/20260320.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Mountain climbers",
@@ -75,7 +75,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260321.json
+++ b/public/sessions/20260321.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -48,7 +48,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -77,7 +77,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Gainage planche",
@@ -109,7 +109,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260322.json
+++ b/public/sessions/20260322.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -39,12 +39,12 @@
         {
           "name": "Squats",
           "reps": 10,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes inclinees",
           "reps": 8,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
           "name": "Fentes alternees",
@@ -54,7 +54,7 @@
         {
           "name": "Crunchs",
           "reps": 12,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },

--- a/public/sessions/20260323.json
+++ b/public/sessions/20260323.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Pop squats",

--- a/public/sessions/20260324.json
+++ b/public/sessions/20260324.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -43,7 +43,7 @@
           "name": "Pompes larges",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Goblet squat (sans poids)",
@@ -97,7 +97,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260324.json
+++ b/public/sessions/20260324.json
@@ -52,10 +52,10 @@
           "instructions": "Mains devant la poitrine, descendre profond"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "mode": "timed",
           "duration": 30,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         },
         {
           "name": "Fentes laterales",
@@ -103,7 +103,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260325.json
+++ b/public/sessions/20260325.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes classiques",
               "reps": 10,
-              "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+              "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
             },
             {
               "name": "Superman alterne",
@@ -57,7 +57,7 @@
             {
               "name": "Pompes declinees",
               "reps": 8,
-              "instructions": "Pieds sureleves sur une chaise, corps gaine"
+              "instructions": "Pieds surélevés sur une chaise, corps gaine"
             },
             {
               "name": "Prone T raises",
@@ -71,12 +71,12 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Face pulls au sol",
               "reps": 12,
-              "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arriere"
+              "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arrière"
             }
           ]
         }

--- a/public/sessions/20260325.json
+++ b/public/sessions/20260325.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260326.json
+++ b/public/sessions/20260326.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -49,7 +49,7 @@
         {
           "name": "V-ups",
           "reps": 10,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },
@@ -66,7 +66,7 @@
         {
           "name": "Pompes larges",
           "reps": 8,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Sit-ups",

--- a/public/sessions/20260327.json
+++ b/public/sessions/20260327.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -64,7 +64,7 @@
           "sets": 3,
           "reps": 8,
           "restBetweenSets": 60,
-          "instructions": "Se pencher en arriere, genoux vers l'avant, quadriceps en feu"
+          "instructions": "Se pencher en arrière, genoux vers l'avant, quadriceps en feu"
         }
       ]
     },
@@ -111,7 +111,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260328.json
+++ b/public/sessions/20260328.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -58,17 +58,17 @@
           "instructions": "Dos au sol, bras et jambes en l'air, etendre bras/jambe opposes en alternant"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
           "name": "Burpees sans pompe",
           "mode": "reps",
           "reps": 6,
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         }
       ]
     },

--- a/public/sessions/20260329.json
+++ b/public/sessions/20260329.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Lateral bounds",
@@ -79,7 +79,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260330.json
+++ b/public/sessions/20260330.json
@@ -72,7 +72,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260330.json
+++ b/public/sessions/20260330.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -39,12 +39,12 @@
         {
           "name": "Dips sur chaise",
           "reps": 10,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         },
         {
           "name": "Squats",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Mountain climbers",

--- a/public/sessions/20260331.json
+++ b/public/sessions/20260331.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -56,7 +56,7 @@
           "sets": 3,
           "reps": 8,
           "restBetweenSets": 60,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         }
       ]
     },

--- a/public/sessions/20260401.json
+++ b/public/sessions/20260401.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -57,7 +57,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Sur une jambe, pencher le buste en avant, jambe arriere tendue",
+          "instructions": "Sur une jambe, pencher le buste en avant, jambe arrière tendue",
           "bilateral": true
         },
         {
@@ -112,7 +112,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260402.json
+++ b/public/sessions/20260402.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -57,12 +57,12 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Superman",
               "reps": 12,
-              "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+              "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
             }
           ]
         },

--- a/public/sessions/20260402.json
+++ b/public/sessions/20260402.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260403.json
+++ b/public/sessions/20260403.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Pompes classiques",
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         }
       ]
     },
@@ -99,7 +99,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260403.json
+++ b/public/sessions/20260403.json
@@ -69,7 +69,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "En planche, lever un bras et la jambe opposee, alterner"
+          "instructions": "En planche, lever un bras et la jambe opposée, alterner"
         },
         {
           "name": "Toe touches",

--- a/public/sessions/20260404.json
+++ b/public/sessions/20260404.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -48,7 +48,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -56,7 +56,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'equilibre",
+          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'équilibre",
           "bilateral": true
         },
         {

--- a/public/sessions/20260405.json
+++ b/public/sessions/20260405.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -69,7 +69,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260406.json
+++ b/public/sessions/20260406.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -44,12 +44,12 @@
         {
           "name": "Pompes classiques",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "reps": 10,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {

--- a/public/sessions/20260406.json
+++ b/public/sessions/20260406.json
@@ -78,7 +78,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260407.json
+++ b/public/sessions/20260407.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -48,7 +48,7 @@
           "name": "Pompes classiques",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Mountain climbers",
@@ -78,11 +78,11 @@
       "exercises": [
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "V-ups",
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },

--- a/public/sessions/20260408.json
+++ b/public/sessions/20260408.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Pompes diamant",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },
@@ -83,7 +83,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         }
       ]
     },

--- a/public/sessions/20260408.json
+++ b/public/sessions/20260408.json
@@ -106,7 +106,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260409.json
+++ b/public/sessions/20260409.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Skaters",
@@ -104,7 +104,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260410.json
+++ b/public/sessions/20260410.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -49,7 +49,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -103,7 +103,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260411.json
+++ b/public/sessions/20260411.json
@@ -99,7 +99,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260411.json
+++ b/public/sessions/20260411.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -39,17 +39,17 @@
         {
           "name": "Pompes explosives",
           "reps": 8,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         },
         {
           "name": "Squats",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "V-ups",
           "reps": 10,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },

--- a/public/sessions/20260412.json
+++ b/public/sessions/20260412.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Lateral bounds",

--- a/public/sessions/20260413.json
+++ b/public/sessions/20260413.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -48,7 +48,7 @@
           "name": "Pompes larges",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Planche epaule",
@@ -90,7 +90,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260413.json
+++ b/public/sessions/20260413.json
@@ -51,10 +51,10 @@
           "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "mode": "timed",
           "duration": 30,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         },
         {
           "name": "Fentes curtsy",

--- a/public/sessions/20260414.json
+++ b/public/sessions/20260414.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes classiques",
               "reps": 12,
-              "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+              "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
             },
             {
               "name": "Rowing inverse (table)",
@@ -71,7 +71,7 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Back extensions",

--- a/public/sessions/20260414.json
+++ b/public/sessions/20260414.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260415.json
+++ b/public/sessions/20260415.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",

--- a/public/sessions/20260416.json
+++ b/public/sessions/20260416.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -44,11 +44,11 @@
           "instructions": "Rester en bas du squat, petits mouvements de montee-descente"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
@@ -64,7 +64,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Sur une jambe, pencher le buste en avant, jambe arriere tendue",
+          "instructions": "Sur une jambe, pencher le buste en avant, jambe arrière tendue",
           "bilateral": true
         }
       ]
@@ -86,7 +86,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         },
         {
           "name": "Bear hold",
@@ -116,7 +116,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260417.json
+++ b/public/sessions/20260417.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -40,11 +40,11 @@
       "exercises": [
         {
           "name": "Pompes inclinees",
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
           "name": "Squats",
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },

--- a/public/sessions/20260418.json
+++ b/public/sessions/20260418.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -52,7 +52,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         }
       ]
     },

--- a/public/sessions/20260419.json
+++ b/public/sessions/20260419.json
@@ -77,7 +77,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260419.json
+++ b/public/sessions/20260419.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -39,7 +39,7 @@
         {
           "name": "Fentes avant",
           "reps": 10,
-          "instructions": "Grand pas en avant, genou arriere frole le sol"
+          "instructions": "Grand pas en avant, genou arrière frôle le sol"
         },
         {
           "name": "Pompes diamant",
@@ -54,7 +54,7 @@
         {
           "name": "Squats",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -71,7 +71,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260420.json
+++ b/public/sessions/20260420.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -49,7 +49,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Pike push-ups",
@@ -84,7 +84,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arriere"
+          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arrière"
         }
       ]
     },

--- a/public/sessions/20260421.json
+++ b/public/sessions/20260421.json
@@ -85,7 +85,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "En planche, lever un bras et la jambe opposee, alterner"
+          "instructions": "En planche, lever un bras et la jambe opposée, alterner"
         },
         {
           "name": "Scissors",

--- a/public/sessions/20260421.json
+++ b/public/sessions/20260421.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 75,
-          "instructions": "Se pencher en arriere, genoux vers l'avant, quadriceps en feu"
+          "instructions": "Se pencher en arrière, genoux vers l'avant, quadriceps en feu"
         },
         {
           "name": "Fentes laterales",
@@ -63,7 +63,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'equilibre",
+          "instructions": "Pencher le buste, une jambe se leve derriere, garder l'équilibre",
           "bilateral": true
         }
       ]
@@ -78,7 +78,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Gainage Superman",
@@ -109,7 +109,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260422.json
+++ b/public/sessions/20260422.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes declinees",
               "reps": 10,
-              "instructions": "Pieds sureleves sur une chaise, corps gaine"
+              "instructions": "Pieds surélevés sur une chaise, corps gaine"
             },
             {
               "name": "Superman alterne",
@@ -57,7 +57,7 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Prone Y raises",

--- a/public/sessions/20260422.json
+++ b/public/sessions/20260422.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260423.json
+++ b/public/sessions/20260423.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -49,7 +49,7 @@
           "name": "Pompes declinees",
           "mode": "reps",
           "reps": 8,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Planche epaule",
@@ -67,7 +67,7 @@
           "name": "Superman",
           "mode": "reps",
           "reps": 12,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         }
       ]
     },
@@ -79,11 +79,11 @@
       "exercises": [
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Crunchs",
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },
@@ -106,7 +106,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260423.json
+++ b/public/sessions/20260423.json
@@ -52,10 +52,10 @@
           "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "mode": "timed",
           "duration": 30,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         },
         {
           "name": "Squats sautes",

--- a/public/sessions/20260424.json
+++ b/public/sessions/20260424.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -115,7 +115,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 35,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260425.json
+++ b/public/sessions/20260425.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Box jumps (marche)",

--- a/public/sessions/20260426.json
+++ b/public/sessions/20260426.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 45,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -39,7 +39,7 @@
         {
           "name": "Pompes larges",
           "reps": 10,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Squats sumo",
@@ -59,14 +59,14 @@
       "duration": 480,
       "exercises": [
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "reps": 10,
-          "instructions": "Grand pas en arriere, descendre le genou"
+          "instructions": "Grand pas en arrière, descendre le genou"
         },
         {
           "name": "Pompes classiques",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Bicycle crunchs",

--- a/public/sessions/20260426.json
+++ b/public/sessions/20260426.json
@@ -94,7 +94,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260427.json
+++ b/public/sessions/20260427.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -42,13 +42,13 @@
           "name": "Squats",
           "mode": "reps",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "Pompes classiques",
           "mode": "reps",
           "reps": 10,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Gainage planche",

--- a/public/sessions/20260428.json
+++ b/public/sessions/20260428.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Pompes diamant",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },
@@ -76,7 +76,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         },
         {
           "name": "Prone Y raises",

--- a/public/sessions/20260429.json
+++ b/public/sessions/20260429.json
@@ -1,7 +1,7 @@
 {
   "date": "20260429",
   "title": "HIIT Explosif",
-  "description": "Intervalles haute intensite avec burpees, squat jumps et high knees pour un cardio intense",
+  "description": "Intervalles haute intensité avec burpees, squat jumps et high knees pour un cardio intense",
   "estimatedDuration": 27,
   "focus": ["cardio"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Squat jumps",
@@ -79,7 +79,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260430.json
+++ b/public/sessions/20260430.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -48,7 +48,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -108,7 +108,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260501.json
+++ b/public/sessions/20260501.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -39,7 +39,7 @@
         {
           "name": "Pompes declinees",
           "reps": 8,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Squats sautes",

--- a/public/sessions/20260502.json
+++ b/public/sessions/20260502.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -44,7 +44,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Star jumps",
@@ -52,7 +52,7 @@
         },
         {
           "name": "V-ups",
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },

--- a/public/sessions/20260502.json
+++ b/public/sessions/20260502.json
@@ -75,7 +75,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260503.json
+++ b/public/sessions/20260503.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Pompes larges",
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Squats pulse",
@@ -54,11 +54,11 @@
       "restBetweenExercises": 60,
       "exercises": [
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {

--- a/public/sessions/20260504.json
+++ b/public/sessions/20260504.json
@@ -1,7 +1,7 @@
 {
   "date": "20260504",
   "title": "Superset Antagonistes",
-  "description": "Superset push/pull avec pompes et rowing, dips et superman pour un haut du corps equilibre",
+  "description": "Superset push/pull avec pompes et rowing, dips et superman pour un haut du corps équilibre",
   "estimatedDuration": 32,
   "focus": ["upper-body"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes inclinees",
               "reps": 12,
-              "instructions": "Mains sur un support sureleve, plus facile"
+              "instructions": "Mains sur un support surélevé, plus facile"
             },
             {
               "name": "Rowing inverse (table)",
@@ -57,12 +57,12 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Superman",
               "reps": 10,
-              "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+              "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
             }
           ]
         },

--- a/public/sessions/20260504.json
+++ b/public/sessions/20260504.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260505.json
+++ b/public/sessions/20260505.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -49,7 +49,7 @@
         {
           "name": "Crunchs",
           "reps": 12,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         },
         {
           "name": "Goblet squat (sans poids)",

--- a/public/sessions/20260506.json
+++ b/public/sessions/20260506.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -72,7 +72,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Dead bug",
@@ -103,7 +103,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260507.json
+++ b/public/sessions/20260507.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -42,7 +42,7 @@
           "name": "Pompes explosives",
           "mode": "reps",
           "reps": 8,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         },
         {
           "name": "Squats sautes",
@@ -82,7 +82,7 @@
         },
         {
           "name": "Squats",
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -105,7 +105,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260507.json
+++ b/public/sessions/20260507.json
@@ -51,10 +51,10 @@
           "instructions": "Squat explosif avec saut, amortir a la reception"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "mode": "timed",
           "duration": 30,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         },
         {
           "name": "Fentes sautees",

--- a/public/sessions/20260508.json
+++ b/public/sessions/20260508.json
@@ -104,7 +104,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 25,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260508.json
+++ b/public/sessions/20260508.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "High knees",

--- a/public/sessions/20260509.json
+++ b/public/sessions/20260509.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -44,7 +44,7 @@
         {
           "name": "Squats",
           "reps": 10,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -56,7 +56,7 @@
         {
           "name": "Fentes avant",
           "reps": 8,
-          "instructions": "Grand pas en avant, genou arriere frole le sol"
+          "instructions": "Grand pas en avant, genou arrière frôle le sol"
         },
         {
           "name": "Toe touches",
@@ -66,7 +66,7 @@
         {
           "name": "Pompes larges",
           "reps": 8,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         }
       ]
     },

--- a/public/sessions/20260510.json
+++ b/public/sessions/20260510.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -56,7 +56,7 @@
           "sets": 3,
           "reps": 8,
           "restBetweenSets": 60,
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         }
       ]
     },
@@ -77,7 +77,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arriere"
+          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arrière"
         },
         {
           "name": "Reverse snow angels",

--- a/public/sessions/20260511.json
+++ b/public/sessions/20260511.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -108,7 +108,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260512.json
+++ b/public/sessions/20260512.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -43,7 +43,7 @@
             {
               "name": "Pompes classiques",
               "reps": 10,
-              "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+              "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
             },
             {
               "name": "Rowing inverse (table)",
@@ -71,7 +71,7 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Prone Y raises",

--- a/public/sessions/20260512.json
+++ b/public/sessions/20260512.json
@@ -101,7 +101,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260513.json
+++ b/public/sessions/20260513.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",

--- a/public/sessions/20260514.json
+++ b/public/sessions/20260514.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -41,14 +41,14 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Se pencher en arriere, genoux vers l'avant, quadriceps en feu"
+          "instructions": "Se pencher en arrière, genoux vers l'avant, quadriceps en feu"
         },
         {
           "name": "Fentes avant",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         },
         {
@@ -63,7 +63,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Sur une jambe, pencher le buste en avant, jambe arriere tendue",
+          "instructions": "Sur une jambe, pencher le buste en avant, jambe arrière tendue",
           "bilateral": true
         }
       ]
@@ -92,7 +92,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         }
       ]
     },
@@ -115,7 +115,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260514.json
+++ b/public/sessions/20260514.json
@@ -78,7 +78,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "En planche, lever un bras et la jambe opposee, alterner"
+          "instructions": "En planche, lever un bras et la jambe opposée, alterner"
         },
         {
           "name": "Leg raises",

--- a/public/sessions/20260515.json
+++ b/public/sessions/20260515.json
@@ -83,7 +83,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260515.json
+++ b/public/sessions/20260515.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Tuck jumps",

--- a/public/sessions/20260516.json
+++ b/public/sessions/20260516.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -49,7 +49,7 @@
         {
           "name": "V-ups",
           "reps": 8,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         }
       ]
     },

--- a/public/sessions/20260517.json
+++ b/public/sessions/20260517.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -39,7 +39,7 @@
       "exercises": [
         {
           "name": "Squats",
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         }
       ]
     },
@@ -53,7 +53,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+          "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
         },
         {
           "name": "Fentes alternees",

--- a/public/sessions/20260518.json
+++ b/public/sessions/20260518.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pieds sureleves sur une chaise, corps gaine"
+          "instructions": "Pieds surélevés sur une chaise, corps gaine"
         },
         {
           "name": "Pompes diamant",
@@ -55,7 +55,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+          "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
         }
       ]
     },
@@ -76,7 +76,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+          "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
         },
         {
           "name": "Prone Y raises",

--- a/public/sessions/20260519.json
+++ b/public/sessions/20260519.json
@@ -1,7 +1,7 @@
 {
   "date": "20260519",
   "title": "Tabata Explosif",
-  "description": "4 exercices en Tabata haute intensite pour un cardio explosif et efficace",
+  "description": "4 exercices en Tabata haute intensité pour un cardio explosif et efficace",
   "estimatedDuration": 26,
   "focus": ["cardio", "explosive"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -52,7 +52,7 @@
         },
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         }
       ]
     },
@@ -75,7 +75,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260520.json
+++ b/public/sessions/20260520.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -49,7 +49,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Pied arriere sur une chaise, descendre le genou",
+          "instructions": "Pied arrière sur une chaise, descendre le genou",
           "bilateral": true
         },
         {
@@ -108,7 +108,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260521.json
+++ b/public/sessions/20260521.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -34,22 +34,22 @@
         {
           "name": "Pompes larges",
           "reps": 10,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Squats",
           "reps": 12,
-          "instructions": "Pieds largeur epaules, descendre cuisses paralleles au sol"
+          "instructions": "Pieds largeur épaules, descendre cuisses parallèles au sol"
         },
         {
           "name": "V-ups",
           "reps": 8,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Fentes avant",
           "reps": 10,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         }
       ]

--- a/public/sessions/20260522.json
+++ b/public/sessions/20260522.json
@@ -1,7 +1,7 @@
 {
   "date": "20260522",
   "title": "Cardio Double Impact",
-  "description": "Combo HIIT explosif et Tabata pour un cardio haute intensite complet",
+  "description": "Combo HIIT explosif et Tabata pour un cardio haute intensité complet",
   "estimatedDuration": 30,
   "focus": ["cardio"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "High knees",

--- a/public/sessions/20260522.json
+++ b/public/sessions/20260522.json
@@ -104,7 +104,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260523.json
+++ b/public/sessions/20260523.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -79,7 +79,7 @@
       "exercises": [
         {
           "name": "Pompes explosives",
-          "instructions": "Pousser fort pour decoller les mains du sol"
+          "instructions": "Pousser fort pour décoller les mains du sol"
         }
       ]
     },
@@ -102,7 +102,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260524.json
+++ b/public/sessions/20260524.json
@@ -1,7 +1,7 @@
 {
   "date": "20260524",
   "title": "Superset Antagonistes",
-  "description": "Paires push-pull et squat-hinge en superset pour un travail equilibre du haut du corps",
+  "description": "Paires push-pull et squat-hinge en superset pour un travail équilibre du haut du corps",
   "estimatedDuration": 32,
   "focus": ["upper-body"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -44,7 +44,7 @@
             {
               "name": "Pompes classiques",
               "reps": 10,
-              "instructions": "Mains largeur epaules, corps gaine, descendre poitrine au sol"
+              "instructions": "Mains largeur épaules, corps gaine, descendre poitrine au sol"
             },
             {
               "name": "Superman alterne",
@@ -72,7 +72,7 @@
             {
               "name": "Dips sur chaise",
               "reps": 10,
-              "instructions": "Mains sur le bord, coudes vers l'arriere, descendre a 90 degres"
+              "instructions": "Mains sur le bord, coudes vers l'arrière, descendre a 90 degres"
             },
             {
               "name": "Prone T raises",

--- a/public/sessions/20260525.json
+++ b/public/sessions/20260525.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -49,20 +49,20 @@
       "duration": 480,
       "exercises": [
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "reps": 10,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
           "name": "Crunchs",
           "reps": 12,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         },
         {
           "name": "Pompes inclinees",
           "reps": 10,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         }
       ]
     },

--- a/public/sessions/20260526.json
+++ b/public/sessions/20260526.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -114,7 +114,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260526.json
+++ b/public/sessions/20260526.json
@@ -80,11 +80,11 @@
           "instructions": "Dos au sol, jambes verticales, toucher les pieds avec les mains"
         },
         {
-          "name": "Planche epaule",
+          "name": "Planche épaule",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "En planche haute, toucher l'epaule opposee en alternant"
+          "instructions": "En planche haute, toucher l'épaule opposée en alternant"
         },
         {
           "name": "Scissors",

--- a/public/sessions/20260527.json
+++ b/public/sessions/20260527.json
@@ -92,7 +92,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260527.json
+++ b/public/sessions/20260527.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",

--- a/public/sessions/20260528.json
+++ b/public/sessions/20260528.json
@@ -1,7 +1,7 @@
 {
   "date": "20260528",
   "title": "HIIT Machine",
-  "description": "Intervalles haute intensite avec burpees, skaters et sauts pour un cardio intense",
+  "description": "Intervalles haute intensité avec burpees, skaters et sauts pour un cardio intense",
   "estimatedDuration": 27,
   "focus": ["cardio"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -40,7 +40,7 @@
       "exercises": [
         {
           "name": "Burpees sans pompe",
-          "instructions": "Descendre, sauter les pieds en arriere, revenir, sauter debout"
+          "instructions": "Descendre, sauter les pieds en arrière, revenir, sauter debout"
         },
         {
           "name": "Skaters",

--- a/public/sessions/20260529.json
+++ b/public/sessions/20260529.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -44,7 +44,7 @@
         {
           "name": "Pompes larges",
           "reps": 8,
-          "instructions": "Mains plus larges que les epaules, focus pectoraux"
+          "instructions": "Mains plus larges que les épaules, focus pectoraux"
         },
         {
           "name": "Mountain climbers",
@@ -72,7 +72,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260530.json
+++ b/public/sessions/20260530.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Marche rapide sur place",
@@ -50,7 +50,7 @@
           "sets": 3,
           "reps": 12,
           "restBetweenSets": 60,
-          "instructions": "Mains sur un support sureleve, plus facile"
+          "instructions": "Mains sur un support surélevé, plus facile"
         },
         {
           "name": "Pike push-ups",
@@ -85,7 +85,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arriere"
+          "instructions": "A plat ventre, coudes a 90 degres, tirer vers l'arrière"
         }
       ]
     },

--- a/public/sessions/20260530.json
+++ b/public/sessions/20260530.json
@@ -108,7 +108,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260531.json
+++ b/public/sessions/20260531.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -41,7 +41,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Se pencher en arriere, genoux vers l'avant, quadriceps en feu"
+          "instructions": "Se pencher en arrière, genoux vers l'avant, quadriceps en feu"
         },
         {
           "name": "Fentes avec pause",
@@ -79,7 +79,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Dos au sol, lever bras et jambes simultanement pour toucher les pieds"
+          "instructions": "Dos au sol, lever bras et jambes simultanément pour toucher les pieds"
         },
         {
           "name": "Planche to downward dog",

--- a/public/sessions/20260601.json
+++ b/public/sessions/20260601.json
@@ -87,7 +87,7 @@
         {
           "name": "Scorpion stretch",
           "duration": 30,
-          "instructions": "A plat ventre, amener le pied vers la main opposee en tournant",
+          "instructions": "A plat ventre, amener le pied vers la main opposée en tournant",
           "bilateral": true
         },
         {

--- a/public/sessions/20260601.json
+++ b/public/sessions/20260601.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Montees de genoux moderees",
@@ -43,12 +43,12 @@
             {
               "name": "Pompes explosives",
               "reps": 8,
-              "instructions": "Pousser fort pour decoller les mains du sol"
+              "instructions": "Pousser fort pour décoller les mains du sol"
             },
             {
               "name": "Superman",
               "reps": 10,
-              "instructions": "A plat ventre, lever bras et jambes simultanement, maintenir 2s"
+              "instructions": "A plat ventre, lever bras et jambes simultanément, maintenir 2s"
             }
           ]
         },
@@ -57,7 +57,7 @@
             {
               "name": "Pompes declinees",
               "reps": 10,
-              "instructions": "Pieds sureleves sur une chaise, corps gaine"
+              "instructions": "Pieds surélevés sur une chaise, corps gaine"
             },
             {
               "name": "Reverse snow angels",

--- a/public/sessions/20260602.json
+++ b/public/sessions/20260602.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -60,7 +60,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en avant, genou arriere frole le sol",
+          "instructions": "Grand pas en avant, genou arrière frôle le sol",
           "bilateral": true
         },
         {
@@ -91,7 +91,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260603.json
+++ b/public/sessions/20260603.json
@@ -1,7 +1,7 @@
 {
   "date": "20260603",
   "title": "Bas du Corps Focus",
-  "description": "Renforcement jambes avec goblet squat et fentes arriere suivi d'un travail core intense",
+  "description": "Renforcement jambes avec goblet squat et fentes arrière suivi d'un travail core intense",
   "estimatedDuration": 32,
   "focus": ["lower-body", "core"],
   "blocks": [
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Talon-fesses",
@@ -45,11 +45,11 @@
           "instructions": "Mains devant la poitrine, descendre profond"
         },
         {
-          "name": "Fentes arriere",
+          "name": "Fentes arrière",
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Grand pas en arriere, descendre le genou",
+          "instructions": "Grand pas en arrière, descendre le genou",
           "bilateral": true
         },
         {
@@ -57,7 +57,7 @@
           "sets": 3,
           "reps": 10,
           "restBetweenSets": 60,
-          "instructions": "Sur une jambe, pencher le buste en avant, jambe arriere tendue",
+          "instructions": "Sur une jambe, pencher le buste en avant, jambe arrière tendue",
           "bilateral": true
         }
       ]
@@ -103,7 +103,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/public/sessions/20260604.json
+++ b/public/sessions/20260604.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Pas chasses",
@@ -48,7 +48,7 @@
         },
         {
           "name": "Burpees",
-          "instructions": "Descendre, poser les mains, sauter les pieds en arriere, pompe, sauter debout"
+          "instructions": "Descendre, poser les mains, sauter les pieds en arrière, pompe, sauter debout"
         },
         {
           "name": "Scissors",

--- a/public/sessions/20260605.json
+++ b/public/sessions/20260605.json
@@ -12,7 +12,7 @@
         {
           "name": "Rotations articulaires",
           "duration": 60,
-          "instructions": "Cou, epaules, poignets, hanches, chevilles - lents et controles"
+          "instructions": "Cou, épaules, poignets, hanches, chevilles - lents et contrôlés"
         },
         {
           "name": "Jumping jacks",
@@ -49,7 +49,7 @@
         {
           "name": "Crunchs",
           "reps": 12,
-          "instructions": "Dos au sol, decoller les epaules, serrer les abdos"
+          "instructions": "Dos au sol, décoller les épaules, serrer les abdos"
         },
         {
           "name": "Squats sumo",
@@ -77,7 +77,7 @@
         {
           "name": "Pigeon stretch",
           "duration": 30,
-          "instructions": "Jambe avant pliee devant, jambe arriere tendue, se pencher",
+          "instructions": "Jambe avant pliee devant, jambe arrière tendue, se pencher",
           "bilateral": true
         },
         {

--- a/src/components/BlockTransition.tsx
+++ b/src/components/BlockTransition.tsx
@@ -14,9 +14,9 @@ function HealthDisclaimer() {
     <div className="bg-white/10 backdrop-blur-sm rounded-2xl px-5 py-4 max-w-sm text-left space-y-2">
       <p className="text-white/90 text-sm font-medium">Avant de commencer :</p>
       <ul className="text-white/70 text-sm space-y-1.5">
-        <li className="flex items-center gap-2"><Cross className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Consultez un médecin en cas de doute</li>
-        <li className="flex items-center gap-2"><CheckCircle className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Assurez-vous de n'avoir aucune contre-indication</li>
-        <li className="flex items-center gap-2"><OctagonX className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Arrêtez immédiatement en cas de douleur</li>
+        <li className="flex items-center gap-2"><Cross className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Consulte un médecin en cas de doute</li>
+        <li className="flex items-center gap-2"><CheckCircle className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Assure-toi de n'avoir aucune contre-indication</li>
+        <li className="flex items-center gap-2"><OctagonX className="w-4 h-4 shrink-0 text-white/50" aria-hidden="true" /> Arrête immédiatement en cas de douleur</li>
       </ul>
     </div>
   );

--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -55,7 +55,7 @@ const DEFAULT_DRAFT: DraftState = {
 };
 
 export function CreateProgramPage() {
-  useDocumentHead({ title: 'Créer mon programme — Wan2Fit' });
+  useDocumentHead({ title: 'Créer mon programme' });
 
   const navigate = useNavigate();
   const { generate, loading: generating, error: generateError } = useGenerateProgram();

--- a/src/components/CustomSessionPage.tsx
+++ b/src/components/CustomSessionPage.tsx
@@ -44,7 +44,7 @@ const BODY_FOCUS_OPTIONS: { value: BodyFocus; label: string }[] = [
 ];
 
 export function CustomSessionPage() {
-  useDocumentHead({ title: 'Créer ma séance — Wan2Fit' });
+  useDocumentHead({ title: 'Créer ma séance' });
 
   const { user } = useAuth();
   const navigate = useNavigate();

--- a/src/components/CustomSessionPage.tsx
+++ b/src/components/CustomSessionPage.tsx
@@ -305,7 +305,7 @@ export function CustomSessionPage() {
       {loading && (
         <div className="mt-4 flex items-center justify-center gap-3">
           <div className="w-5 h-5 border-2 border-divider-strong border-t-brand rounded-full animate-spin" />
-          <p className="text-sm text-muted">L'IA prépare votre séance...</p>
+          <p className="text-sm text-muted">L'IA prépare ta séance...</p>
         </div>
       )}
 

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -28,7 +28,7 @@ function groupByCategory(exercises: ExerciseData[]): [ExerciseCategory, Exercise
 
 export function Discover() {
   useDocumentHead({
-    title: 'Découvrir — Wan2Fit',
+    title: 'Découvrir',
     description: "Explorez nos 8 formats d'entraînement et notre bibliothèque d'exercices.",
   });
 

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -92,7 +92,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
       <div className="flex gap-6">
         <div className="text-center">
           <div className="text-3xl font-bold text-white">{displayMinutes}</div>
-          <div className="text-white/50 text-sm">minutes</div>
+          <div className="text-white/50 text-sm">{displayMinutes === '< 1' ? 'minute' : 'minutes'}</div>
         </div>
         <div className="text-center">
           <div className="text-3xl font-bold text-white">{session.blocks.length}</div>

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -33,7 +33,9 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
     });
   }, [user, save, session.date, programSessionId, customSessionId, durationSeconds, amrapRounds]);
 
-  const realMinutes = durationSeconds > 0 ? Math.round(durationSeconds / 60) : session.estimatedDuration;
+  const rawMinutes = durationSeconds > 0 ? Math.round(durationSeconds / 60) : session.estimatedDuration;
+  const realMinutes = rawMinutes > 0 ? rawMinutes : 1;
+  const displayMinutes = (durationSeconds > 0 && durationSeconds < 60) ? '< 1' : String(realMinutes);
 
   const [shareState, setShareState] = useState<'idle' | 'loading' | 'shared' | 'copied'>('idle');
 
@@ -89,7 +91,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
 
       <div className="flex gap-6">
         <div className="text-center">
-          <div className="text-3xl font-bold text-white">{realMinutes}</div>
+          <div className="text-3xl font-bold text-white">{displayMinutes}</div>
           <div className="text-white/50 text-sm">minutes</div>
         </div>
         <div className="text-center">

--- a/src/components/HealthDisclaimer.tsx
+++ b/src/components/HealthDisclaimer.tsx
@@ -79,15 +79,15 @@ export function HealthDisclaimer({ onAccept, onCancel }: Props) {
             ne s'agit pas de coaching sportif personnalisé ni d'encadrement par un éducateur sportif diplômé.
           </p>
           <p>
-            Les séances sont des suggestions d'exercices à caractère général. Vous êtes seul responsable de leur
-            exécution et de leur adaptation à votre condition physique.
+            Les séances sont des suggestions d'exercices à caractère général. Tu es seul responsable de leur
+            exécution et de leur adaptation à ta condition physique.
           </p>
           <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 space-y-2">
             <p className="font-semibold text-amber-800">Avant de pratiquer :</p>
             <ul className="list-disc list-inside space-y-1 text-amber-700">
-              <li>Consultez un médecin pour vérifier votre aptitude sportive</li>
-              <li>Ne pratiquez pas en cas de contre-indication médicale</li>
-              <li>Arrêtez immédiatement en cas de douleur ou de malaise</li>
+              <li>Consulte un médecin pour vérifier ton aptitude sportive</li>
+              <li>Ne pratique pas en cas de contre-indication médicale</li>
+              <li>Arrête immédiatement en cas de douleur ou de malaise</li>
             </ul>
           </div>
           <p className="text-gray-400 text-xs">

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -319,7 +319,7 @@ export function Player({
       <div className="px-6 pb-3 text-center">
         <p className="text-xs text-white inline-flex items-center gap-1.5">
           <HeartPulse className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Écoutez votre corps. En cas de douleur, arrêtez immédiatement.
+          Écoute ton corps. En cas de douleur, arrête immédiatement.
         </p>
       </div>
     </div>

--- a/src/components/ProgramContentPage.tsx
+++ b/src/components/ProgramContentPage.tsx
@@ -11,7 +11,7 @@ export function ProgramContentPage() {
   const content = slug ? PROGRAM_CONTENT[slug] : undefined;
 
   useDocumentHead({
-    title: content ? `${content.headline} — Programme Wan2Fit` : 'Programme',
+    title: content ? `${content.headline} — Programme` : 'Programme',
     description: content?.intro,
   });
 

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -34,7 +34,7 @@ export function ProgramList() {
   useDocumentHead({
     title: 'Programmes',
     description:
-      "Programmes d'entraînement structurés sur plusieurs semaines. Progressez à votre rythme avec des séances guidées.",
+      "Programmes d'entraînement structurés sur plusieurs semaines. Progresse à ton rythme avec des séances guidées.",
   });
 
   return (

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -48,7 +48,7 @@ export function ConnectedContent({
   return (
     <div className="px-6 md:px-10 lg:px-14 py-8">
       <div className="max-w-5xl mx-auto space-y-10">
-        <h1 className="sr-only">Wan2Fit — Votre séance de sport quotidienne</h1>
+        <h1 className="sr-only">Wan2Fit — Ta séance de sport quotidienne</h1>
 
         {/* ── Titre + 3 colonnes d'action ── */}
         <section>


### PR DESCRIPTION
## Summary
- **Meta titles** : suppression du doublon "Wan2Fit | Wan2Fit" sur 4 pages (Discover, CustomSession, CreateProgram, ProgramContent)
- **Accents** : correction des accents manquants dans 110 fichiers JSON de sessions (épaules, contrôlés, arrière, parallèles, surélevé, opposée, etc.)
- **Durée courte** : affiche "< 1 minute" au lieu de "0 minutes" dans EndScreen pour les séances < 60s
- **Tutoiement** : harmonisation tu/vous dans HealthDisclaimer, Player, BlockTransition, CustomSessionPage, ProgramList (meta), ConnectedContent (sr-only)

## Test plan
- [ ] Vérifier les `<title>` sur /decouvrir, /seance/custom, /programme/creer, /programme/:slug/contenu → pas de doublon "Wan2Fit"
- [ ] Ouvrir une session JSON quelconque → accents corrects (épaules, contrôlés, arrière…)
- [ ] Terminer une séance très courte → EndScreen affiche "< 1 minute"
- [ ] Lancer une séance → vérifier le tutoiement cohérent (disclaimer, transition bloc, rappel santé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)