### PR TITLE
feat: exercise demo videos in player

### DIFF
--- a/src/components/AMRAPView.tsx
+++ b/src/components/AMRAPView.tsx
@@ -1,4 +1,8 @@
+import { useState } from 'react';
+import { Play, X } from 'lucide-react';
 import type { AtomicStep } from '../types/player.ts';
+import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
 interface Props {
@@ -7,9 +11,13 @@ interface Props {
   progress: number;
   rounds: number;
   onIncrementRound: () => void;
+  showVideos: boolean;
+  onToggleShowVideos: () => void;
 }
 
-export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound }: Props) {
+export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound, showVideos, onToggleShowVideos }: Props) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
   return (
     <div className="flex flex-col items-center justify-center flex-1 gap-5 px-6 text-center">
       {/* Block name */}
@@ -20,15 +28,52 @@ export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound 
 
       {/* Exercise list */}
       <div className="w-full max-w-sm space-y-2">
-        {step.amrapExercises?.map((ex, i) => (
-          <div key={i} className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
-            <span className="text-white font-medium">{ex.name}</span>
-            <span className="text-lg font-bold" style={{ color: step.blockColor }}>
-              x{ex.reps}
-            </span>
-          </div>
-        ))}
+        {step.amrapExercises?.map((ex, i) => {
+          const videoUrl = getExerciseVideoUrl(ex.name);
+          const visible = videoUrl && (showVideos || expandedIndex === i);
+
+          return (
+            <div key={i} className="space-y-2">
+              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
+                <div className="flex items-center gap-2">
+                  <span className="text-white font-medium">{ex.name}</span>
+                  {videoUrl && (
+                    <button
+                      type="button"
+                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
+                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
+                    >
+                      {visible ? (
+                        <X className="w-3.5 h-3.5" aria-hidden="true" />
+                      ) : (
+                        <Play className="w-3.5 h-3.5" aria-hidden="true" />
+                      )}
+                    </button>
+                  )}
+                </div>
+                <span className="text-lg font-bold" style={{ color: step.blockColor }}>
+                  x{ex.reps}
+                </span>
+              </div>
+              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} />}
+            </div>
+          );
+        })}
       </div>
+
+      {/* Always-show toggle */}
+      {step.amrapExercises?.some((ex) => getExerciseVideoUrl(ex.name)) && (
+        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showVideos}
+            onChange={onToggleShowVideos}
+            className="w-3.5 h-3.5 rounded accent-white/60"
+          />
+          Toujours montrer les exemples
+        </label>
+      )}
 
       {/* Round counter + button */}
       <div className="flex items-center gap-6">

--- a/src/components/AMRAPView.tsx
+++ b/src/components/AMRAPView.tsx
@@ -1,8 +1,5 @@
-import { useState } from 'react';
-import { Play, X } from 'lucide-react';
 import type { AtomicStep } from '../types/player.ts';
-import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
-import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
+import { ExerciseListWithVideos } from './ExerciseListWithVideos.tsx';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
 interface Props {
@@ -16,8 +13,6 @@ interface Props {
 }
 
 export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound, showVideos, onToggleShowVideos }: Props) {
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-
   return (
     <div className="flex flex-col items-center justify-center flex-1 gap-5 px-6 text-center">
       {/* Block name */}
@@ -26,53 +21,14 @@ export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound,
       {/* Timer */}
       <TimerDisplay remaining={remaining} progress={progress} color={step.blockColor} />
 
-      {/* Exercise list */}
-      <div className="w-full max-w-sm space-y-2">
-        {step.amrapExercises?.map((ex, i) => {
-          const videoUrl = getExerciseVideoUrl(ex.name);
-          const visible = videoUrl && (showVideos || expandedIndex === i);
-
-          return (
-            <div key={i} className="space-y-2">
-              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
-                <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{ex.name}</span>
-                  {videoUrl && (
-                    <button
-                      type="button"
-                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
-                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
-                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
-                    >
-                      {visible ? (
-                        <X className="w-3.5 h-3.5" aria-hidden="true" />
-                      ) : (
-                        <Play className="w-3.5 h-3.5" aria-hidden="true" />
-                      )}
-                    </button>
-                  )}
-                </div>
-                <span className="text-lg font-bold" style={{ color: step.blockColor }}>
-                  x{ex.reps}
-                </span>
-              </div>
-              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} />}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Always-show toggle */}
-      {step.amrapExercises?.some((ex) => getExerciseVideoUrl(ex.name)) && (
-        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={showVideos}
-            onChange={onToggleShowVideos}
-            className="w-3.5 h-3.5 rounded accent-white/60"
-          />
-          Toujours montrer les exemples
-        </label>
+      {/* Exercise list with video demos */}
+      {step.amrapExercises && (
+        <ExerciseListWithVideos
+          exercises={step.amrapExercises}
+          blockColor={step.blockColor}
+          showVideos={showVideos}
+          onToggleShowVideos={onToggleShowVideos}
+        />
       )}
 
       {/* Round counter + button */}

--- a/src/components/EMOMView.tsx
+++ b/src/components/EMOMView.tsx
@@ -1,13 +1,21 @@
+import { useState } from 'react';
+import { Play, X } from 'lucide-react';
 import type { AtomicStep } from '../types/player.ts';
+import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
 interface Props {
   step: AtomicStep;
   remaining: number;
   progress: number;
+  showVideos: boolean;
+  onToggleShowVideos: () => void;
 }
 
-export function EMOMView({ step, remaining, progress }: Props) {
+export function EMOMView({ step, remaining, progress, showVideos, onToggleShowVideos }: Props) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
   return (
     <div className="flex flex-col items-center justify-center flex-1 gap-6 px-6 text-center">
       {/* Minute indicator */}
@@ -23,15 +31,52 @@ export function EMOMView({ step, remaining, progress }: Props) {
 
       {/* Exercise list */}
       <div className="w-full max-w-sm space-y-3">
-        {step.emomExercises?.map((ex, i) => (
-          <div key={i} className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
-            <span className="text-white font-medium">{ex.name}</span>
-            <span className="text-lg font-bold" style={{ color: step.blockColor }}>
-              x{ex.reps}
-            </span>
-          </div>
-        ))}
+        {step.emomExercises?.map((ex, i) => {
+          const videoUrl = getExerciseVideoUrl(ex.name);
+          const visible = videoUrl && (showVideos || expandedIndex === i);
+
+          return (
+            <div key={i} className="space-y-2">
+              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
+                <div className="flex items-center gap-2">
+                  <span className="text-white font-medium">{ex.name}</span>
+                  {videoUrl && (
+                    <button
+                      type="button"
+                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
+                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
+                    >
+                      {visible ? (
+                        <X className="w-3.5 h-3.5" aria-hidden="true" />
+                      ) : (
+                        <Play className="w-3.5 h-3.5" aria-hidden="true" />
+                      )}
+                    </button>
+                  )}
+                </div>
+                <span className="text-lg font-bold" style={{ color: step.blockColor }}>
+                  x{ex.reps}
+                </span>
+              </div>
+              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} />}
+            </div>
+          );
+        })}
       </div>
+
+      {/* Always-show toggle — only if at least one exercise has a video */}
+      {step.emomExercises?.some((ex) => getExerciseVideoUrl(ex.name)) && (
+        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showVideos}
+            onChange={onToggleShowVideos}
+            className="w-3.5 h-3.5 rounded accent-white/60"
+          />
+          Toujours montrer les exemples
+        </label>
+      )}
 
       <p className="text-white/40 text-xs">Faites les exercices puis récupérez jusqu'à la prochaine minute</p>
     </div>

--- a/src/components/EMOMView.tsx
+++ b/src/components/EMOMView.tsx
@@ -1,8 +1,5 @@
-import { useState } from 'react';
-import { Play, X } from 'lucide-react';
 import type { AtomicStep } from '../types/player.ts';
-import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
-import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
+import { ExerciseListWithVideos } from './ExerciseListWithVideos.tsx';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
 interface Props {
@@ -14,8 +11,6 @@ interface Props {
 }
 
 export function EMOMView({ step, remaining, progress, showVideos, onToggleShowVideos }: Props) {
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-
   return (
     <div className="flex flex-col items-center justify-center flex-1 gap-6 px-6 text-center">
       {/* Minute indicator */}
@@ -29,53 +24,14 @@ export function EMOMView({ step, remaining, progress, showVideos, onToggleShowVi
       {/* Timer */}
       <TimerDisplay remaining={remaining} progress={progress} color={step.blockColor} />
 
-      {/* Exercise list */}
-      <div className="w-full max-w-sm space-y-3">
-        {step.emomExercises?.map((ex, i) => {
-          const videoUrl = getExerciseVideoUrl(ex.name);
-          const visible = videoUrl && (showVideos || expandedIndex === i);
-
-          return (
-            <div key={i} className="space-y-2">
-              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
-                <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{ex.name}</span>
-                  {videoUrl && (
-                    <button
-                      type="button"
-                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
-                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
-                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
-                    >
-                      {visible ? (
-                        <X className="w-3.5 h-3.5" aria-hidden="true" />
-                      ) : (
-                        <Play className="w-3.5 h-3.5" aria-hidden="true" />
-                      )}
-                    </button>
-                  )}
-                </div>
-                <span className="text-lg font-bold" style={{ color: step.blockColor }}>
-                  x{ex.reps}
-                </span>
-              </div>
-              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} />}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Always-show toggle — only if at least one exercise has a video */}
-      {step.emomExercises?.some((ex) => getExerciseVideoUrl(ex.name)) && (
-        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={showVideos}
-            onChange={onToggleShowVideos}
-            className="w-3.5 h-3.5 rounded accent-white/60"
-          />
-          Toujours montrer les exemples
-        </label>
+      {/* Exercise list with video demos */}
+      {step.emomExercises && (
+        <ExerciseListWithVideos
+          exercises={step.emomExercises}
+          blockColor={step.blockColor}
+          showVideos={showVideos}
+          onToggleShowVideos={onToggleShowVideos}
+        />
       )}
 
       <p className="text-white/40 text-xs">Faites les exercices puis récupérez jusqu'à la prochaine minute</p>

--- a/src/components/ExerciseListWithVideos.tsx
+++ b/src/components/ExerciseListWithVideos.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Play, X } from 'lucide-react';
+import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
+
+interface Exercise {
+  name: string;
+  reps: number;
+}
+
+interface Props {
+  exercises: Exercise[];
+  blockColor: string;
+  showVideos: boolean;
+  onToggleShowVideos: () => void;
+}
+
+export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onToggleShowVideos }: Props) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const hasAnyVideo = exercises.some((ex) => getExerciseVideoUrl(ex.name));
+
+  return (
+    <>
+      <div className="w-full max-w-sm space-y-3">
+        {exercises.map((ex, i) => {
+          const videoUrl = getExerciseVideoUrl(ex.name);
+          const visible = videoUrl && (showVideos || expandedIndex === i);
+
+          return (
+            <div key={`${i}-${ex.name}`} className="space-y-2">
+              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
+                <div className="flex items-center gap-2">
+                  <span className="text-white font-medium">{ex.name}</span>
+                  {videoUrl && (
+                    <button
+                      type="button"
+                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
+                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
+                    >
+                      {visible ? (
+                        <X className="w-3.5 h-3.5" aria-hidden="true" />
+                      ) : (
+                        <Play className="w-3.5 h-3.5" aria-hidden="true" />
+                      )}
+                    </button>
+                  )}
+                </div>
+                <span className="text-lg font-bold" style={{ color: blockColor }}>
+                  x{ex.reps}
+                </span>
+              </div>
+              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
+            </div>
+          );
+        })}
+      </div>
+
+      {hasAnyVideo && (
+        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showVideos}
+            onChange={onToggleShowVideos}
+            className="w-3.5 h-3.5 rounded accent-white/60"
+          />
+          Toujours montrer les exemples
+        </label>
+      )}
+    </>
+  );
+}

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -19,27 +19,29 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
 
   return (
     <div className="w-full max-w-sm flex flex-col items-center gap-3">
-      {/* Toggle button */}
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/10 text-white/60 text-sm hover:bg-white/15 hover:text-white/80 transition-colors"
-      >
-        {visible ? (
-          <>
-            <X className="w-3.5 h-3.5" aria-hidden="true" />
-            Masquer
-          </>
-        ) : (
-          <>
-            <Play className="w-3.5 h-3.5" aria-hidden="true" />
-            Voir l'exemple
-          </>
-        )}
-      </button>
+      {/* Toggle button — hidden when alwaysShow is active (video is auto-displayed) */}
+      {!alwaysShow && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/10 text-white/60 text-sm hover:bg-white/15 hover:text-white/80 transition-colors"
+        >
+          {expanded ? (
+            <>
+              <X className="w-3.5 h-3.5" aria-hidden="true" />
+              Masquer
+            </>
+          ) : (
+            <>
+              <Play className="w-3.5 h-3.5" aria-hidden="true" />
+              Voir l'exemple
+            </>
+          )}
+        </button>
+      )}
 
       {/* Video */}
-      {visible && <PlayerVideoDemo videoUrl={videoUrl} />}
+      {visible && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={exerciseName} />}
 
       {/* Always-show toggle — only shown when video is visible */}
       {visible && (

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Play, X } from 'lucide-react';
+import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
+
+interface Props {
+  exerciseName: string;
+  alwaysShow: boolean;
+  onToggleAlwaysShow: () => void;
+}
+
+export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysShow }: Props) {
+  const videoUrl = getExerciseVideoUrl(exerciseName);
+  const [expanded, setExpanded] = useState(false);
+
+  if (!videoUrl) return null;
+
+  const visible = expanded || alwaysShow;
+
+  return (
+    <div className="w-full max-w-sm flex flex-col items-center gap-3">
+      {/* Toggle button */}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/10 text-white/60 text-sm hover:bg-white/15 hover:text-white/80 transition-colors"
+      >
+        {visible ? (
+          <>
+            <X className="w-3.5 h-3.5" aria-hidden="true" />
+            Masquer
+          </>
+        ) : (
+          <>
+            <Play className="w-3.5 h-3.5" aria-hidden="true" />
+            Voir l'exemple
+          </>
+        )}
+      </button>
+
+      {/* Video */}
+      {visible && <PlayerVideoDemo videoUrl={videoUrl} />}
+
+      {/* Always-show toggle — only shown when video is visible */}
+      {visible && (
+        <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={alwaysShow}
+            onChange={onToggleAlwaysShow}
+            className="w-3.5 h-3.5 rounded accent-white/60"
+          />
+          Toujours montrer les exemples
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/components/ExerciseView.tsx
+++ b/src/components/ExerciseView.tsx
@@ -1,4 +1,5 @@
 import type { AtomicStep } from '../types/player.ts';
+import { ExerciseVideoButton } from './ExerciseVideoButton.tsx';
 import { NextPreview } from './NextPreview.tsx';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
@@ -6,9 +7,11 @@ interface Props {
   step: AtomicStep;
   remaining: number;
   progress: number;
+  showVideos: boolean;
+  onToggleShowVideos: () => void;
 }
 
-export function ExerciseView({ step, remaining, progress }: Props) {
+export function ExerciseView({ step, remaining, progress, showVideos, onToggleShowVideos }: Props) {
   const pulse = remaining <= 3 && remaining > 0;
 
   return (
@@ -43,6 +46,13 @@ export function ExerciseView({ step, remaining, progress }: Props) {
 
       {/* Tempo */}
       {step.tempo && <p className="text-white/40 text-sm font-mono">Tempo {step.tempo}</p>}
+
+      {/* Video demo */}
+      <ExerciseVideoButton
+        exerciseName={step.exerciseName}
+        alwaysShow={showVideos}
+        onToggleAlwaysShow={onToggleShowVideos}
+      />
 
       {/* Next preview */}
       {step.nextStepPreview && <NextPreview preview={step.nextStepPreview} />}

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -100,6 +100,9 @@ export function Player({
   const navigate = useNavigate();
   const steps = useMemo(() => compileSession(session), [session]);
   const [showQuitConfirm, setShowQuitConfirm] = useState(false);
+  const [showVideos, setShowVideos] = useState(
+    () => localStorage.getItem('wan2fit-show-exercise-videos') === 'true',
+  );
   const resumeButtonRef = useRef<HTMLButtonElement>(null);
   const quitDialogRef = useRef<HTMLDivElement>(null);
   const startedRef = useRef(false);
@@ -126,6 +129,14 @@ export function Player({
       resumeButtonRef.current.focus();
     }
   }, [workout.status]);
+
+  const toggleShowVideos = useCallback(() => {
+    setShowVideos((prev) => {
+      const next = !prev;
+      localStorage.setItem('wan2fit-show-exercise-videos', String(next));
+      return next;
+    });
+  }, []);
 
   const goBack = () => navigate(backTo);
 
@@ -277,7 +288,7 @@ export function Player({
         )}
 
         {step.phase === 'work' && step.timerMode === 'emom' && (
-          <EMOMView step={step} remaining={workout.timer.remaining} progress={workout.timer.progress} />
+          <EMOMView step={step} remaining={workout.timer.remaining} progress={workout.timer.progress} showVideos={showVideos} onToggleShowVideos={toggleShowVideos} />
         )}
 
         {step.phase === 'work' && step.timerMode === 'amrap' && (
@@ -287,14 +298,16 @@ export function Player({
             progress={workout.timer.progress}
             rounds={workout.amrapRounds}
             onIncrementRound={workout.incrementAmrap}
+            showVideos={showVideos}
+            onToggleShowVideos={toggleShowVideos}
           />
         )}
 
         {step.phase === 'work' && step.timerMode === 'countdown' && (
-          <ExerciseView step={step} remaining={workout.timer.remaining} progress={workout.timer.progress} />
+          <ExerciseView step={step} remaining={workout.timer.remaining} progress={workout.timer.progress} showVideos={showVideos} onToggleShowVideos={toggleShowVideos} />
         )}
 
-        {step.phase === 'work' && step.timerMode === 'manual' && <RepsView step={step} onDone={workout.done} />}
+        {step.phase === 'work' && step.timerMode === 'manual' && <RepsView step={step} onDone={workout.done} showVideos={showVideos} onToggleShowVideos={toggleShowVideos} />}
 
         {step.phase === 'rest' && (
           <RestView

--- a/src/components/PlayerVideoDemo.tsx
+++ b/src/components/PlayerVideoDemo.tsx
@@ -1,17 +1,30 @@
+import { useCallback, useState } from 'react';
+
 interface Props {
   videoUrl: string;
+  exerciseName?: string;
 }
 
-export function PlayerVideoDemo({ videoUrl }: Props) {
+export function PlayerVideoDemo({ videoUrl, exerciseName }: Props) {
+  const [hasError, setHasError] = useState(false);
+  const handleError = useCallback(() => setHasError(true), []);
+
+  if (hasError) return null;
+
   return (
     <div className="w-full max-w-xs mx-auto rounded-xl overflow-hidden">
       <video
         autoPlay
+        // loop is intentional here: in the player context, the user glances at the demo
+        // while exercising, so the clip needs to repeat. ExercisePage omits loop because
+        // the user is reading and the video is a one-time preview.
         loop
         muted
         playsInline
+        preload="metadata"
         className="w-full aspect-video object-cover"
-        aria-label="Démonstration de l'exercice"
+        aria-label={exerciseName ? `Démonstration : ${exerciseName}` : "Démonstration de l'exercice"}
+        onError={handleError}
       >
         <source src={videoUrl} type="video/mp4" />
       </video>

--- a/src/components/PlayerVideoDemo.tsx
+++ b/src/components/PlayerVideoDemo.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  videoUrl: string;
+}
+
+export function PlayerVideoDemo({ videoUrl }: Props) {
+  return (
+    <div className="w-full max-w-xs mx-auto rounded-xl overflow-hidden">
+      <video
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="w-full aspect-video object-cover"
+        aria-label="Démonstration de l'exercice"
+      >
+        <source src={videoUrl} type="video/mp4" />
+      </video>
+    </div>
+  );
+}

--- a/src/components/RepsView.tsx
+++ b/src/components/RepsView.tsx
@@ -1,12 +1,15 @@
 import type { AtomicStep } from '../types/player.ts';
+import { ExerciseVideoButton } from './ExerciseVideoButton.tsx';
 import { NextPreview } from './NextPreview.tsx';
 
 interface Props {
   step: AtomicStep;
   onDone: () => void;
+  showVideos: boolean;
+  onToggleShowVideos: () => void;
 }
 
-export function RepsView({ step, onDone }: Props) {
+export function RepsView({ step, onDone, showVideos, onToggleShowVideos }: Props) {
   const repsLabel = step.repTarget === 'max' ? 'MAX' : step.repTarget;
 
   return (
@@ -39,6 +42,13 @@ export function RepsView({ step, onDone }: Props) {
 
       {/* Tempo */}
       {step.tempo && <p className="text-white/40 text-sm font-mono">Tempo {step.tempo}</p>}
+
+      {/* Video demo */}
+      <ExerciseVideoButton
+        exerciseName={step.exerciseName}
+        alwaysShow={showVideos}
+        onToggleAlwaysShow={onToggleShowVideos}
+      />
 
       {/* Done button */}
       <button

--- a/src/utils/exerciseVideo.ts
+++ b/src/utils/exerciseVideo.ts
@@ -8,47 +8,69 @@ function normalize(name: string): string {
     .toLowerCase();
 }
 
+/** Exact lookup: normalized name → video URL */
+const exactMap = new Map<string, string>();
+
+/** Prefix lookup: sorted longest-first for fuzzy matching */
+const prefixCandidates: { name: string; video: string }[] = [];
+
+// Build lookup tables once at module load
+for (const ex of EXERCISES_DATA) {
+  const mainVideo = ex.video;
+
+  // Main name + aliases → exercise video
+  if (mainVideo) {
+    exactMap.set(normalize(ex.name), mainVideo);
+    for (const a of ex.aliases) {
+      exactMap.set(normalize(a), mainVideo);
+    }
+  }
+
+  // Variants → variant video (or parent fallback)
+  for (const v of ex.variants) {
+    const video = v.video ?? mainVideo;
+    if (video) {
+      exactMap.set(normalize(v.name), video);
+    }
+  }
+
+  // Prefix candidates (aliases are typically short/generic, best for prefix matching)
+  if (mainVideo) {
+    prefixCandidates.push({ name: normalize(ex.name), video: mainVideo });
+    for (const a of ex.aliases) {
+      prefixCandidates.push({ name: normalize(a), video: mainVideo });
+    }
+  }
+  for (const v of ex.variants) {
+    const video = v.video ?? mainVideo;
+    if (video) {
+      prefixCandidates.push({ name: normalize(v.name), video });
+    }
+  }
+}
+
+prefixCandidates.sort((a, b) => b.name.length - a.name.length);
+
 /**
  * Returns the video URL for an exercise name by searching:
- * 1. Exact match on exercise name or alias → exercise video
- * 2. Exact match on variant name → variant video (or parent video)
- * 3. Fuzzy prefix match on known names
- * Returns null if no match or no video found.
+ * 1. Exact match on exercise name, alias, or variant → specific video
+ * 2. Fuzzy prefix match (longest known name that is a prefix of input)
+ *
+ * Note: prefix matching can produce false positives for exercises sharing
+ * a common prefix (e.g. "Planche laterale" matching "Planche"). This is
+ * acceptable as a v1 heuristic since most session names match exactly.
  */
 export function getExerciseVideoUrl(exerciseName: string): string | null {
   const key = normalize(exerciseName);
 
-  for (const ex of EXERCISES_DATA) {
-    // Check main name and aliases
-    if (normalize(ex.name) === key || ex.aliases.some((a) => normalize(a) === key)) {
-      return ex.video ?? null;
-    }
+  // 1. Exact match (O(1))
+  const exact = exactMap.get(key);
+  if (exact) return exact;
 
-    // Check variants — return variant-specific video if available
-    for (const v of ex.variants) {
-      if (normalize(v.name) === key) {
-        return v.video ?? ex.video ?? null;
-      }
-    }
-  }
-
-  // Fuzzy prefix: "Pompes sur genoux" → match "Pompes" alias → pompes-classiques
-  // Build a list of all names with their video, sorted longest first
-  const candidates: { name: string; video: string | undefined }[] = [];
-  for (const ex of EXERCISES_DATA) {
-    candidates.push({ name: normalize(ex.name), video: ex.video });
-    for (const a of ex.aliases) {
-      candidates.push({ name: normalize(a), video: ex.video });
-    }
-    for (const v of ex.variants) {
-      candidates.push({ name: normalize(v.name), video: v.video ?? ex.video });
-    }
-  }
-  candidates.sort((a, b) => b.name.length - a.name.length);
-
-  for (const c of candidates) {
+  // 2. Fuzzy prefix match
+  for (const c of prefixCandidates) {
     if (key.startsWith(c.name) && (key.length === c.name.length || key[c.name.length] === ' ')) {
-      return c.video ?? null;
+      return c.video;
     }
   }
 

--- a/src/utils/exerciseVideo.ts
+++ b/src/utils/exerciseVideo.ts
@@ -1,0 +1,56 @@
+import { EXERCISES_DATA } from '../data/exercises.ts';
+
+/** Lowercase, strip accents */
+function normalize(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Returns the video URL for an exercise name by searching:
+ * 1. Exact match on exercise name or alias → exercise video
+ * 2. Exact match on variant name → variant video (or parent video)
+ * 3. Fuzzy prefix match on known names
+ * Returns null if no match or no video found.
+ */
+export function getExerciseVideoUrl(exerciseName: string): string | null {
+  const key = normalize(exerciseName);
+
+  for (const ex of EXERCISES_DATA) {
+    // Check main name and aliases
+    if (normalize(ex.name) === key || ex.aliases.some((a) => normalize(a) === key)) {
+      return ex.video ?? null;
+    }
+
+    // Check variants — return variant-specific video if available
+    for (const v of ex.variants) {
+      if (normalize(v.name) === key) {
+        return v.video ?? ex.video ?? null;
+      }
+    }
+  }
+
+  // Fuzzy prefix: "Pompes sur genoux" → match "Pompes" alias → pompes-classiques
+  // Build a list of all names with their video, sorted longest first
+  const candidates: { name: string; video: string | undefined }[] = [];
+  for (const ex of EXERCISES_DATA) {
+    candidates.push({ name: normalize(ex.name), video: ex.video });
+    for (const a of ex.aliases) {
+      candidates.push({ name: normalize(a), video: ex.video });
+    }
+    for (const v of ex.variants) {
+      candidates.push({ name: normalize(v.name), video: v.video ?? ex.video });
+    }
+  }
+  candidates.sort((a, b) => b.name.length - a.name.length);
+
+  for (const c of candidates) {
+    if (key.startsWith(c.name) && (key.length === c.name.length || key[c.name.length] === ' ')) {
+      return c.video ?? null;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Bouton **"Voir l'exemple"** dans le player pour les exercices qui ont une vidéo démo (autoplay, loop, muted, inline)
- Fonctionne dans les 4 types de vues : **ExerciseView** (countdown), **RepsView** (manual), **EMOM** et **AMRAP**
- Toggle **"Toujours montrer les exemples"** persisté en `localStorage` (`wan2fit-show-exercise-videos`)
- Lookup vidéo corrigé : résout correctement les alias et variantes (fix "Scapular push-ups" → vidéo variante, pas parent)

## Nouveaux fichiers
- `src/utils/exerciseVideo.ts` — lookup Map O(1) par nom/alias/variante + fuzzy prefix
- `src/components/PlayerVideoDemo.tsx` — vidéo avec error handling, preload metadata
- `src/components/ExerciseVideoButton.tsx` — bouton toggle pour ExerciseView/RepsView
- `src/components/ExerciseListWithVideos.tsx` — composant partagé EMOM/AMRAP

## Test plan
- [ ] Lancer la séance du jour, vérifier le bouton "Voir l'exemple" sur un exercice avec vidéo (ex: Pompes classiques)
- [ ] Vérifier qu'un exercice sans vidéo n'affiche aucun bouton supplémentaire
- [ ] Séance du 25/03 : vérifier que "Scapular push-ups" affiche la bonne vidéo (scapular-push-ups.mp4, pas pompes-classiques.mp4)
- [ ] Tester le toggle "Toujours montrer les exemples" : persiste entre exercices et entre séances
- [ ] Tester sur une séance EMOM/AMRAP : boutons play inline par exercice
- [ ] Vérifier graceful degradation si vidéo manquante (composant disparaît)
- [ ] `npm run build` passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)