### PR TITLE
feat: redesign stats dashboard with animated metrics & enriched history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "wanshape",
-  "version": "0.0.0",
+  "name": "wan2fit",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wanshape",
-      "version": "0.0.0",
+      "name": "wan2fit",
+      "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.97.0",
         "@vercel/analytics": "^1.6.1",

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -34,7 +34,19 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
       sessionFocus: session.focus,
       blockTypes: [...new Set(session.blocks.map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown'))],
     });
-  }, [user, save, session, programSessionId, customSessionId, durationSeconds, amrapRounds]);
+  }, [
+    user,
+    save,
+    session.date,
+    session.title,
+    session.description,
+    session.focus,
+    session.blocks,
+    programSessionId,
+    customSessionId,
+    durationSeconds,
+    amrapRounds,
+  ]);
 
   const rawMinutes = durationSeconds > 0 ? Math.round(durationSeconds / 60) : session.estimatedDuration;
   const realMinutes = rawMinutes > 0 ? rawMinutes : 1;

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -1,12 +1,12 @@
+import { Check, Download, Share2, Trophy } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Trophy, Share2, Check, Download } from 'lucide-react';
-import { useAuth } from '../contexts/AuthContext.tsx';
 import { STORAGE_KEYS } from '../config/storage-keys.ts';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { useSaveCompletion } from '../hooks/useSaveCompletion.ts';
-import { shareSession } from '../utils/share.ts';
 import { supabase } from '../lib/supabase.ts';
 import type { Session } from '../types/session.ts';
+import { shareSession } from '../utils/share.ts';
 
 interface Props {
   session: Session;
@@ -30,12 +30,15 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
       durationSeconds,
       amrapRounds,
       sessionTitle: session.title,
+      sessionDescription: session.description,
+      sessionFocus: session.focus,
+      blockTypes: [...new Set(session.blocks.map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown'))],
     });
-  }, [user, save, session.date, programSessionId, customSessionId, durationSeconds, amrapRounds]);
+  }, [user, save, session, programSessionId, customSessionId, durationSeconds, amrapRounds]);
 
   const rawMinutes = durationSeconds > 0 ? Math.round(durationSeconds / 60) : session.estimatedDuration;
   const realMinutes = rawMinutes > 0 ? rawMinutes : 1;
-  const displayMinutes = (durationSeconds > 0 && durationSeconds < 60) ? '< 1' : String(realMinutes);
+  const displayMinutes = durationSeconds > 0 && durationSeconds < 60 ? '< 1' : String(realMinutes);
 
   const [shareState, setShareState] = useState<'idle' | 'loading' | 'shared' | 'copied'>('idle');
 
@@ -64,7 +67,19 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
 
       {user && saved && (
         <div className="flex items-center gap-2 text-accent text-sm font-medium">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12" /></svg>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
           Séance enregistrée
         </div>
       )}
@@ -74,14 +89,21 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
           <p className="text-red-400">Enregistrement échoué</p>
           <button
             type="button"
-            onClick={() => save({
-              sessionDate: programSessionId || customSessionId ? undefined : session.date,
-              programSessionId,
-              customSessionId,
-              durationSeconds,
-              amrapRounds,
-              sessionTitle: session.title,
-            })}
+            onClick={() =>
+              save({
+                sessionDate: programSessionId || customSessionId ? undefined : session.date,
+                programSessionId,
+                customSessionId,
+                durationSeconds,
+                amrapRounds,
+                sessionTitle: session.title,
+                sessionDescription: session.description,
+                sessionFocus: session.focus,
+                blockTypes: [
+                  ...new Set(session.blocks.map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown')),
+                ],
+              })
+            }
             className="text-brand hover:text-brand-secondary font-semibold transition-colors cursor-pointer"
           >
             Réessayer
@@ -166,7 +188,11 @@ function SignupNudge() {
   if (!visible) return null;
 
   const dismiss = () => {
-    try { localStorage.setItem(STORAGE_KEYS.NUDGE_DISMISSED, String(Date.now())); } catch { /* ignore */ }
+    try {
+      localStorage.setItem(STORAGE_KEYS.NUDGE_DISMISSED, String(Date.now()));
+    } catch {
+      /* ignore */
+    }
     setVisible(false);
   };
 

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -25,7 +25,7 @@ function formatDurationUnit(totalSeconds: number): string {
 }
 
 function durationFormatter(seconds: number) {
-  return (n: number) => formatDuration(Math.round((n * seconds) / (seconds || 1)));
+  return (n: number) => formatDuration(seconds > 0 ? Math.round(n) : 0);
 }
 
 interface WeekMessage {

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -1,14 +1,15 @@
-import { Link } from 'react-router';
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { useHistory } from '../../hooks/useHistory.ts';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import { LoadingSpinner } from '../LoadingSpinner.tsx';
-import { WeeklyBarChart } from '../stats/WeeklyBarChart.tsx';
-import { WeekDots } from '../stats/WeekDots.tsx';
+import { MetricCard } from '../stats/MetricCard.tsx';
 import { ProgramCard } from '../stats/ProgramCard.tsx';
 import { RecentSessions } from '../stats/RecentSessions.tsx';
+import { WeekDots } from '../stats/WeekDots.tsx';
+import { WeeklyBarChart } from '../stats/WeeklyBarChart.tsx';
 
 function formatDuration(totalSeconds: number): string {
   const h = Math.floor(totalSeconds / 3600);
@@ -23,16 +24,24 @@ function formatDurationUnit(totalSeconds: number): string {
   return '';
 }
 
-interface WeekMessage { emoji: string; title: string; subtitle: string }
+function durationFormatter(seconds: number) {
+  return (n: number) => formatDuration(Math.round((n * seconds) / (seconds || 1)));
+}
+
+interface WeekMessage {
+  emoji: string;
+  title: string;
+  subtitle: string;
+}
 
 function getWeekMessage(sessions: number): WeekMessage {
-  const dayOfWeek = new Date().getDay(); // 0 = dimanche
+  const dayOfWeek = new Date().getDay();
   const isEndOfWeek = dayOfWeek === 0 || dayOfWeek === 6;
 
   if (sessions === 0) {
     return isEndOfWeek
       ? { emoji: '😌', title: 'Week-end mérité', subtitle: 'Recharge les batteries, lundi on envoie du lourd.' }
-      : { emoji: '🚀', title: 'Nouvelle semaine', subtitle: 'Prêt à t\'entraîner ?' };
+      : { emoji: '🚀', title: 'Nouvelle semaine', subtitle: "Prêt à t'entraîner ?" };
   }
   if (sessions === 1) {
     return isEndOfWeek
@@ -46,11 +55,27 @@ function getWeekMessage(sessions: number): WeekMessage {
 }
 
 const WEEK_CARD_STYLES: Record<string, { bg: string; border: string; text: string }> = {
-  idle:    { bg: 'from-slate-500/10 to-slate-500/5',     border: 'border-slate-500/20',   text: 'text-body' },
-  start:   { bg: 'from-emerald-500/20 to-emerald-500/5', border: 'border-emerald-500/30', text: 'text-emerald-700 dark:text-emerald-300' },
-  cruise:  { bg: 'from-blue-500/20 to-blue-500/5',       border: 'border-blue-500/30',    text: 'text-blue-700 dark:text-blue-300' },
-  peak:    { bg: 'from-violet-500/25 to-violet-500/5',   border: 'border-violet-500/30',  text: 'text-violet-700 dark:text-violet-300' },
-  warning: { bg: 'from-amber-500/25 to-amber-500/5',     border: 'border-amber-500/30',   text: 'text-amber-700 dark:text-amber-300' },
+  idle: { bg: 'from-slate-500/10 to-slate-500/5', border: 'border-slate-500/20', text: 'text-body' },
+  start: {
+    bg: 'from-emerald-500/20 to-emerald-500/5',
+    border: 'border-emerald-500/30',
+    text: 'text-emerald-700 dark:text-emerald-300',
+  },
+  cruise: {
+    bg: 'from-blue-500/20 to-blue-500/5',
+    border: 'border-blue-500/30',
+    text: 'text-blue-700 dark:text-blue-300',
+  },
+  peak: {
+    bg: 'from-violet-500/25 to-violet-500/5',
+    border: 'border-violet-500/30',
+    text: 'text-violet-700 dark:text-violet-300',
+  },
+  warning: {
+    bg: 'from-amber-500/25 to-amber-500/5',
+    border: 'border-amber-500/30',
+    text: 'text-amber-700 dark:text-amber-300',
+  },
 };
 
 function weekCardStyle(sessions: number) {
@@ -63,7 +88,17 @@ function weekCardStyle(sessions: number) {
 
 export function StatsPage() {
   const { user } = useAuth();
-  const { completions, totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions, loading } = useHistory(user?.id);
+  const {
+    completions,
+    totalSessions,
+    totalDuration,
+    avgDuration,
+    weekDots,
+    weeklyChart,
+    thisWeekSessions,
+    thisWeekDuration,
+    loading,
+  } = useHistory(user?.id);
   const { activeProgram } = useActiveProgram(user?.id);
 
   useDocumentHead({
@@ -71,9 +106,10 @@ export function StatsPage() {
     description: 'Tableau de bord sportif Wan2Fit.',
   });
 
-  const progressPct = activeProgram && activeProgram.totalSessions > 0
-    ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
-    : 0;
+  const progressPct =
+    activeProgram && activeProgram.totalSessions > 0
+      ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
+      : 0;
 
   if (loading) {
     return (
@@ -88,15 +124,27 @@ export function StatsPage() {
       <div className="flex-1 px-6 md:px-10 lg:px-14 py-12">
         <div className="max-w-md mx-auto text-center space-y-6">
           <div className="w-20 h-20 rounded-2xl bg-brand/10 flex items-center justify-center mx-auto">
-            <svg aria-hidden="true" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+            <svg
+              aria-hidden="true"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-brand"
+            >
               <polygon points="5 3 19 12 5 21 5 3" />
             </svg>
           </div>
           <h1 className="font-display text-2xl font-black text-heading">Pas encore de stats</h1>
-          <p className="text-body text-sm">
-            Lance ta première séance pour commencer à suivre ta progression ici.
-          </p>
-          <Link to="/" className="inline-flex items-center gap-2 text-sm font-bold text-brand hover:text-brand/80 transition-colors">
+          <p className="text-body text-sm">Lance ta première séance pour commencer à suivre ta progression ici.</p>
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-sm font-bold text-brand hover:text-brand/80 transition-colors"
+          >
             Séance du jour
             <ChevronRight className="w-4 h-4" aria-hidden="true" />
           </Link>
@@ -104,6 +152,9 @@ export function StatsPage() {
       </div>
     );
   }
+
+  const style = weekCardStyle(thisWeekSessions);
+  const msg = getWeekMessage(thisWeekSessions);
 
   return (
     <div className="flex-1 px-4 md:px-10 lg:px-14 py-6 md:py-8">
@@ -113,58 +164,71 @@ export function StatsPage() {
 
         {/* Bento Grid */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+          {/* Row 1: 4 MetricCards */}
+          <MetricCard
+            label="Séances"
+            value={totalSessions}
+            subtitle="total"
+            variant="brand"
+            className="stagger-fade-in stagger-1"
+          />
+          <MetricCard
+            label="Temps"
+            value={totalDuration}
+            unit={formatDurationUnit(totalDuration)}
+            formatter={durationFormatter(totalDuration)}
+            subtitle="cumulé"
+            className="stagger-fade-in stagger-2"
+          />
+          <MetricCard
+            label="Moy / séance"
+            value={avgDuration}
+            unit={formatDurationUnit(avgDuration)}
+            formatter={durationFormatter(avgDuration)}
+            subtitle="durée moyenne"
+            className="stagger-fade-in stagger-3"
+          />
+          <MetricCard
+            label="Cette semaine"
+            value={thisWeekDuration}
+            unit={formatDurationUnit(thisWeekDuration)}
+            formatter={durationFormatter(thisWeekDuration)}
+            subtitle={`${thisWeekSessions} séance${thisWeekSessions > 1 ? 's' : ''}`}
+            className="stagger-fade-in stagger-4"
+          />
 
-          {/* Metric: Total sessions */}
-          <div className="rounded-2xl bg-brand p-5 text-white">
-            <div className="text-xs font-semibold uppercase tracking-wider opacity-70 mb-3">Séances</div>
-            <div className="font-display text-4xl md:text-5xl font-black leading-none">{totalSessions}</div>
-            <div className="text-xs opacity-60 mt-1">total</div>
-          </div>
-
-          {/* Metric: Total duration */}
-          <div className="rounded-2xl bg-surface-card border border-divider p-5">
-            <div className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Temps</div>
-            <div className="font-display text-4xl md:text-5xl font-black leading-none text-heading">
-              {formatDuration(totalDuration)}
-              <span className="text-lg font-normal text-muted ml-0.5">{formatDurationUnit(totalDuration)}</span>
-            </div>
-            <div className="text-xs text-muted mt-1">cumulé</div>
-          </div>
-
-          {/* Weekly bar chart */}
-          <div className="col-span-2 md:row-span-2 rounded-2xl bg-surface-card border border-divider p-5">
+          {/* Row 2-3: Bar chart (col-2, row-2) + WeekDots + Programme */}
+          <div className="col-span-2 md:row-span-2 rounded-2xl bg-surface-card border border-divider p-5 stagger-fade-in stagger-5">
             <WeeklyBarChart data={weeklyChart} />
           </div>
 
-          {/* This week: dots + contextual message */}
-          {(() => {
-            const style = weekCardStyle(thisWeekSessions);
-            const msg = getWeekMessage(thisWeekSessions);
-            return (
-              <div className={`col-span-2 rounded-2xl p-5 border bg-gradient-to-br ${style.bg} ${style.border}`}>
-                <WeekDots weekDots={weekDots} />
-                <div className="mt-4 rounded-xl border border-divider px-4 py-3 shadow-sm bg-surface-0">
-                  <p className={`text-sm font-bold ${style.text}`}>
-                    {msg.emoji}{'  '}{msg.title}
-                  </p>
-                  <p className="text-xs text-body mt-0.5">{msg.subtitle}</p>
-                </div>
-              </div>
-            );
-          })()}
+          {/* WeekDots + Message */}
+          <div
+            className={`col-span-2 rounded-2xl p-5 border bg-gradient-to-br ${style.bg} ${style.border} stagger-fade-in stagger-5`}
+          >
+            <WeekDots weekDots={weekDots} />
+            <div className="mt-4 rounded-xl border border-divider px-4 py-3 shadow-sm bg-surface-0">
+              <p className={`text-sm font-bold ${style.text}`}>
+                {msg.emoji}
+                {'  '}
+                {msg.title}
+              </p>
+              <p className="text-xs text-body mt-0.5">{msg.subtitle}</p>
+            </div>
+          </div>
 
           {/* Programme progress */}
           {activeProgram ? (
             <Link
               to={`/programme/${activeProgram.slug}/suivi`}
-              className="col-span-2 rounded-2xl bg-surface-card border border-divider p-5 group hover:border-brand/30 transition-colors"
+              className="col-span-2 rounded-2xl bg-surface-card border border-divider p-5 group hover:border-brand/30 transition-colors stagger-fade-in stagger-6"
             >
               <ProgramCard activeProgram={activeProgram} progressPct={progressPct} />
             </Link>
           ) : (
             <Link
               to="/programmes"
-              className="col-span-2 rounded-2xl overflow-hidden relative group hover:ring-2 hover:ring-brand/40 transition-all"
+              className="col-span-2 rounded-2xl overflow-hidden relative group hover:ring-2 hover:ring-brand/40 transition-all stagger-fade-in stagger-6"
             >
               <img
                 src="/images/illustration-program.webp"
@@ -178,7 +242,10 @@ export function StatsPage() {
                   <p className="text-white font-bold text-base md:text-lg">Passe au niveau supérieur</p>
                   <p className="text-white/60 text-xs mt-0.5">Commence à suivre un programme personnalisé</p>
                 </div>
-                <ChevronRight className="w-5 h-5 text-white/70 shrink-0 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+                <ChevronRight
+                  className="w-5 h-5 text-white/70 shrink-0 group-hover:translate-x-1 transition-transform"
+                  aria-hidden="true"
+                />
               </div>
             </Link>
           )}

--- a/src/components/stats/AnimatedNumber.tsx
+++ b/src/components/stats/AnimatedNumber.tsx
@@ -1,0 +1,15 @@
+import { useAnimatedValue } from '../../hooks/useAnimatedValue.ts';
+
+interface AnimatedNumberProps {
+  value: number;
+  duration?: number;
+  formatter?: (n: number) => string;
+  className?: string;
+}
+
+export function AnimatedNumber({ value, duration = 800, formatter, className }: AnimatedNumberProps) {
+  const animated = useAnimatedValue(value, duration);
+  const display = formatter ? formatter(animated) : String(Math.round(animated));
+
+  return <span className={className}>{display}</span>;
+}

--- a/src/components/stats/MetricCard.tsx
+++ b/src/components/stats/MetricCard.tsx
@@ -1,0 +1,40 @@
+import { AnimatedNumber } from './AnimatedNumber.tsx';
+
+interface MetricCardProps {
+  label: string;
+  value: number;
+  unit?: string;
+  formatter?: (n: number) => string;
+  subtitle?: string;
+  variant?: 'brand' | 'default';
+  className?: string;
+}
+
+export function MetricCard({
+  label,
+  value,
+  unit,
+  formatter,
+  subtitle,
+  variant = 'default',
+  className = '',
+}: MetricCardProps) {
+  const isBrand = variant === 'brand';
+
+  return (
+    <div
+      className={`rounded-2xl p-5 ${
+        isBrand ? 'bg-brand text-white' : 'bg-surface-card border border-divider'
+      } ${className}`}
+    >
+      <div className={`text-xs font-semibold uppercase tracking-wider mb-3 ${isBrand ? 'opacity-70' : 'text-muted'}`}>
+        {label}
+      </div>
+      <div className="font-display text-4xl md:text-5xl font-black leading-none animate-number-pop">
+        <AnimatedNumber value={value} formatter={formatter} className={isBrand ? '' : 'text-heading'} />
+        {unit && <span className={`text-lg font-normal ml-0.5 ${isBrand ? 'opacity-70' : 'text-muted'}`}>{unit}</span>}
+      </div>
+      {subtitle && <div className={`text-xs mt-1 ${isBrand ? 'opacity-60' : 'text-muted'}`}>{subtitle}</div>}
+    </div>
+  );
+}

--- a/src/components/stats/ProgramCard.tsx
+++ b/src/components/stats/ProgramCard.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight } from 'lucide-react';
 import type { useActiveProgram } from '../../hooks/useProgram.ts';
+import { AnimatedNumber } from './AnimatedNumber.tsx';
 
 export interface ProgramCardProps {
   activeProgram: NonNullable<ReturnType<typeof useActiveProgram>['activeProgram']>;
@@ -7,14 +8,13 @@ export interface ProgramCardProps {
 }
 
 export function ProgramCard({ activeProgram, progressPct }: ProgramCardProps) {
-  // SVG donut chart
   const radius = 32;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - progressPct / 100);
 
   return (
     <div className="flex items-center gap-5">
-      {/* Donut */}
+      {/* SVG donut */}
       <div className="relative shrink-0">
         <svg width="80" height="80" viewBox="0 0 80 80" className="-rotate-90">
           <circle cx="40" cy="40" r={radius} fill="none" stroke="var(--color-divider-strong)" strokeWidth="6" />
@@ -28,11 +28,16 @@ export function ProgramCard({ activeProgram, progressPct }: ProgramCardProps) {
             strokeLinecap="round"
             strokeDasharray={circumference}
             strokeDashoffset={dashOffset}
-            className="transition-all duration-500"
+            className="transition-all duration-700"
+            style={{ transitionTimingFunction: 'cubic-bezier(0.33, 1, 0.68, 1)' }}
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center">
-          <span className="font-display text-lg font-black text-heading">{progressPct}%</span>
+          <AnimatedNumber
+            value={progressPct}
+            formatter={(n) => `${Math.round(n)}%`}
+            className="font-display text-lg font-black text-heading"
+          />
         </div>
       </div>
 

--- a/src/components/stats/RecentSessions.tsx
+++ b/src/components/stats/RecentSessions.tsx
@@ -125,9 +125,10 @@ function SessionCard({ completion: c }: { completion: CompletionWithTitle }) {
   const isCustom = c.custom_session_id != null;
   const hasDetails = c.session_description || c.block_types.length > 0 || c.session_focus.length > 0;
 
+  const isFree = !isCustom && !isProgram;
   const Icon = isCustom ? Sparkles : isProgram ? Dumbbell : Zap;
-  const iconBg = isCustom ? 'bg-brand/10' : isProgram ? 'bg-brand/10' : 'bg-emerald-500/10';
-  const iconColor = isCustom ? 'text-brand' : isProgram ? 'text-brand' : 'text-emerald-500';
+  const iconBg = isFree ? 'bg-emerald-500/10' : 'bg-brand/10';
+  const iconColor = isFree ? 'text-emerald-500' : 'text-brand';
 
   return (
     <div className="rounded-xl border border-divider bg-surface-card/50 px-4 py-3 hover:border-divider-strong transition-colors group/card">

--- a/src/components/stats/RecentSessions.tsx
+++ b/src/components/stats/RecentSessions.tsx
@@ -1,8 +1,31 @@
+import { Dumbbell, Sparkles, Zap } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { CompletionWithTitle } from '../../hooks/useHistory.ts';
 import { formatShortDate } from '../../utils/date.ts';
 
 type HistoryFilter = 'all' | 'program' | 'free';
+
+const BLOCK_LABELS: Record<string, string> = {
+  classic: 'Classique',
+  circuit: 'Circuit',
+  hiit: 'HIIT',
+  tabata: 'Tabata',
+  emom: 'EMOM',
+  amrap: 'AMRAP',
+  superset: 'Superset',
+  pyramid: 'Pyramide',
+};
+
+const BLOCK_COLORS: Record<string, string> = {
+  classic: 'bg-classic/15 text-classic',
+  circuit: 'bg-circuit/15 text-circuit',
+  hiit: 'bg-hiit/15 text-hiit',
+  tabata: 'bg-tabata/15 text-tabata',
+  emom: 'bg-emom/15 text-emom',
+  amrap: 'bg-amrap/15 text-amrap',
+  superset: 'bg-superset/15 text-superset',
+  pyramid: 'bg-pyramid/15 text-pyramid',
+};
 
 function formatMonthYear(iso: string): string {
   return new Date(iso).toLocaleDateString('fr-FR', {
@@ -42,21 +65,21 @@ export function RecentSessions({ completions }: { completions: CompletionWithTit
     <>
       <div className="flex items-center justify-between mb-4">
         <p className="text-sm font-bold text-heading">Historique</p>
-        {/* Filter pills */}
         <div className="flex items-center gap-1.5">
-          {([
+          {[
             { value: 'all' as const, label: 'Tout' },
             { value: 'program' as const, label: 'Prog' },
             { value: 'free' as const, label: 'Libre' },
-          ]).map(({ value, label }) => (
+          ].map(({ value, label }) => (
             <button
               key={value}
               type="button"
-              onClick={() => { setFilter(value); setLimit(10); }}
+              onClick={() => {
+                setFilter(value);
+                setLimit(10);
+              }}
               className={`px-3 py-1 rounded-full text-[11px] font-semibold transition-colors cursor-pointer ${
-                filter === value
-                  ? 'bg-brand text-white'
-                  : 'bg-surface-2 text-muted hover:text-heading'
+                filter === value ? 'bg-brand text-white' : 'bg-surface-2 text-muted hover:text-heading'
               }`}
             >
               {label}
@@ -68,13 +91,13 @@ export function RecentSessions({ completions }: { completions: CompletionWithTit
       {grouped.length === 0 ? (
         <p className="text-sm text-muted text-center py-4">Aucune séance dans cette catégorie.</p>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-5">
           {grouped.map(({ month, items }) => (
             <section key={month}>
-              <h3 className="text-[11px] font-bold uppercase tracking-wider text-subtle mb-2 capitalize">{month}</h3>
-              <div className="space-y-0.5">
+              <h3 className="text-[11px] font-bold uppercase tracking-wider text-subtle mb-3 capitalize">{month}</h3>
+              <div className="space-y-2">
                 {items.map((c) => (
-                  <SessionRow key={c.id} completion={c} />
+                  <SessionCard key={c.id} completion={c} />
                 ))}
               </div>
             </section>
@@ -95,19 +118,70 @@ export function RecentSessions({ completions }: { completions: CompletionWithTit
   );
 }
 
-function SessionRow({ completion: c }: { completion: CompletionWithTitle }) {
+function SessionCard({ completion: c }: { completion: CompletionWithTitle }) {
   const minutes = c.duration_seconds ? Math.round(c.duration_seconds / 60) : null;
   const title = c.session_title ?? 'Séance';
   const isProgram = c.program_session_id != null;
+  const isCustom = c.custom_session_id != null;
+  const hasDetails = c.session_description || c.block_types.length > 0 || c.session_focus.length > 0;
+
+  const Icon = isCustom ? Sparkles : isProgram ? Dumbbell : Zap;
+  const iconBg = isCustom ? 'bg-brand/10' : isProgram ? 'bg-brand/10' : 'bg-emerald-500/10';
+  const iconColor = isCustom ? 'text-brand' : isProgram ? 'text-brand' : 'text-emerald-500';
 
   return (
-    <div className="flex items-center gap-3 rounded-xl px-3 py-2 hover:bg-surface-2/50 transition-colors">
-      <div className={`w-2 h-2 rounded-full shrink-0 ${isProgram ? 'bg-brand' : 'bg-emerald-500'}`} />
-      <p className="text-sm text-heading truncate flex-1">{title}</p>
-      <div className="flex items-center gap-3 shrink-0 text-right">
-        {minutes != null && <span className="text-xs font-medium text-heading">{minutes} min</span>}
-        <span className="text-[11px] text-muted w-14">{formatShortDate(c.completed_at)}</span>
+    <div className="rounded-xl border border-divider bg-surface-card/50 px-4 py-3 hover:border-divider-strong transition-colors group/card">
+      {/* Top row: icon, title, duration, date */}
+      <div className="flex items-center gap-3">
+        <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${iconBg}`}>
+          <Icon className={`w-4 h-4 ${iconColor}`} aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-heading truncate group-hover/card:text-brand transition-colors">
+            {title}
+          </p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0 text-right">
+          {minutes != null && <span className="text-xs font-semibold text-heading tabular-nums">{minutes} min</span>}
+          <span className="text-[11px] text-muted w-14">{formatShortDate(c.completed_at)}</span>
+        </div>
       </div>
+
+      {/* Details row: description + block type badges + focus */}
+      {hasDetails && (
+        <div className="mt-2 ml-11 space-y-1.5">
+          {c.session_description && <p className="text-xs text-subtle line-clamp-2">{c.session_description}</p>}
+          {(c.block_types.length > 0 || c.session_focus.length > 0) && (
+            <div className="flex flex-wrap gap-1.5">
+              {c.block_types.map((type) => (
+                <span
+                  key={type}
+                  className={`inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold ${BLOCK_COLORS[type] ?? 'bg-surface-2 text-muted'}`}
+                >
+                  {BLOCK_LABELS[type] ?? type}
+                </span>
+              ))}
+              {c.session_focus.map((f) => (
+                <span
+                  key={f}
+                  className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium bg-surface-2 text-subtle"
+                >
+                  {f}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* AMRAP rounds indicator */}
+      {c.amrap_rounds != null && c.amrap_rounds > 0 && (
+        <div className="mt-1.5 ml-11">
+          <span className="text-[10px] font-semibold text-amrap">
+            {c.amrap_rounds} round{c.amrap_rounds > 1 ? 's' : ''}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/stats/WeekDots.tsx
+++ b/src/components/stats/WeekDots.tsx
@@ -4,23 +4,34 @@ export function WeekDots({ weekDots }: { weekDots: boolean[] }) {
   const activeDays = weekDots.filter(Boolean).length;
 
   return (
-    <div aria-label={`Activité de la semaine : ${activeDays} jour${activeDays > 1 ? 's' : ''} sur 7`}>
+    <section aria-label={`Activité de la semaine : ${activeDays} jour${activeDays > 1 ? 's' : ''} sur 7`}>
       <div className="flex items-center justify-between mb-4">
         <p className="text-sm font-bold text-heading">Cette semaine</p>
-        <p className="text-xs text-muted">{activeDays} jour{activeDays > 1 ? 's' : ''} d'activité</p>
+        <p className="text-xs text-muted">
+          {activeDays} jour{activeDays > 1 ? 's' : ''} d'activité
+        </p>
       </div>
       <div className="flex gap-2">
         {weekDots.map((done, i) => (
-          <div key={i} className="flex-1 flex flex-col items-center gap-2">
+          <div key={i} className={`flex-1 flex flex-col items-center gap-2 stagger-fade-in stagger-${i + 1}`}>
             <div
               className={`w-full aspect-square max-w-[44px] rounded-xl flex items-center justify-center transition-colors ${
-                done
-                  ? 'bg-emerald-500/20 border-2 border-emerald-500'
-                  : 'bg-surface-2 border-2 border-divider-strong'
+                done ? 'bg-emerald-500/20 border-2 border-emerald-500' : 'bg-surface-2 border-2 border-divider-strong'
               }`}
             >
               {done && (
-                <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-emerald-400">
+                <svg
+                  aria-hidden="true"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-emerald-400"
+                >
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
               )}
@@ -29,6 +40,6 @@ export function WeekDots({ weekDots }: { weekDots: boolean[] }) {
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/stats/WeeklyBarChart.tsx
+++ b/src/components/stats/WeeklyBarChart.tsx
@@ -1,12 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { WeeklyData } from '../../hooks/useHistory.ts';
 
 export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
   const maxMinutes = Math.max(...data.map((d) => d.minutes), 1);
   const [activeIdx, setActiveIdx] = useState<number | null>(null);
+  const [animated, setAnimated] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Animate bars on mount
+  useEffect(() => {
+    const timer = requestAnimationFrame(() => setAnimated(true));
+    return () => cancelAnimationFrame(timer);
+  }, []);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col" ref={containerRef}>
       <div className="flex items-center justify-between mb-4">
         <p className="text-sm font-bold text-heading">Volume hebdo</p>
         <p className="text-xs text-muted">
@@ -21,7 +29,7 @@ export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
       </div>
       <div className="flex items-end gap-2 flex-1 min-h-[120px]">
         {data.map((week, i) => {
-          const heightPct = Math.max((week.minutes / maxMinutes) * 100, 4);
+          const heightPct = animated ? Math.max((week.minutes / maxMinutes) * 100, 4) : 4;
           const isActive = activeIdx === i;
           return (
             <button
@@ -33,17 +41,29 @@ export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
               aria-label={`${week.label} : ${week.minutes} minutes, ${week.sessions} séance${week.sessions > 1 ? 's' : ''}`}
               className="flex-1 flex flex-col items-center gap-1.5 cursor-pointer group"
             >
-              <div className="w-full flex items-end" style={{ height: '100px' }}>
+              <div className="w-full flex items-end relative" style={{ height: '100px' }}>
                 <div
-                  className={`w-full rounded-lg transition-all duration-200 ${
+                  className={`w-full rounded-t-lg transition-all ${
                     week.isCurrent
                       ? 'bg-brand shadow-sm shadow-brand/30'
                       : isActive
                         ? 'bg-brand/60'
                         : 'bg-divider-strong group-hover:bg-brand/30'
                   }`}
-                  style={{ height: `${heightPct}%` }}
+                  style={{
+                    height: `${heightPct}%`,
+                    transitionDuration: animated ? '800ms' : '0ms',
+                    transitionTimingFunction: 'cubic-bezier(0.33, 1, 0.68, 1)',
+                    transitionDelay: `${i * 60}ms`,
+                    borderRadius: '6px 6px 0 0',
+                  }}
                 />
+                {/* Tooltip */}
+                {isActive && (
+                  <div className="absolute -top-10 left-1/2 -translate-x-1/2 rounded-lg bg-surface-card border border-divider px-2.5 py-1.5 shadow-lg text-[10px] font-semibold text-heading whitespace-nowrap z-10 pointer-events-none animate-fade-in">
+                    {week.minutes} min
+                  </div>
+                )}
               </div>
               <span className={`text-[10px] font-medium ${week.isCurrent ? 'text-brand font-bold' : 'text-muted'}`}>
                 {week.label}

--- a/src/components/stats/WeeklyBarChart.tsx
+++ b/src/components/stats/WeeklyBarChart.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { WeeklyData } from '../../hooks/useHistory.ts';
 
 export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
   const maxMinutes = Math.max(...data.map((d) => d.minutes), 1);
   const [activeIdx, setActiveIdx] = useState<number | null>(null);
   const [animated, setAnimated] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   // Animate bars on mount
   useEffect(() => {
@@ -14,7 +13,7 @@ export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
   }, []);
 
   return (
-    <div className="h-full flex flex-col" ref={containerRef}>
+    <div className="h-full flex flex-col">
       <div className="flex items-center justify-between mb-4">
         <p className="text-sm font-bold text-heading">Volume hebdo</p>
         <p className="text-xs text-muted">
@@ -43,7 +42,7 @@ export function WeeklyBarChart({ data }: { data: WeeklyData[] }) {
             >
               <div className="w-full flex items-end relative" style={{ height: '100px' }}>
                 <div
-                  className={`w-full rounded-t-lg transition-all ${
+                  className={`w-full transition-all ${
                     week.isCurrent
                       ? 'bg-brand shadow-sm shadow-brand/30'
                       : isActive

--- a/src/hooks/useAnimatedValue.ts
+++ b/src/hooks/useAnimatedValue.ts
@@ -10,11 +10,7 @@ export function useAnimatedValue(target: number, duration = 800): number {
   const startRef = useRef<number | null>(null);
   const fromRef = useRef(0);
   const valueRef = useRef(0);
-  const prefersReducedMotion = useRef(false);
-
-  useEffect(() => {
-    prefersReducedMotion.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  }, []);
+  const prefersReducedMotion = useRef(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
   // Keep valueRef in sync without triggering effect
   valueRef.current = value;

--- a/src/hooks/useAnimatedValue.ts
+++ b/src/hooks/useAnimatedValue.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react';
+
+function easeOutCubic(t: number): number {
+  return 1 - (1 - t) ** 3;
+}
+
+export function useAnimatedValue(target: number, duration = 800): number {
+  const [value, setValue] = useState(0);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number | null>(null);
+  const fromRef = useRef(0);
+  const valueRef = useRef(0);
+  const prefersReducedMotion = useRef(false);
+
+  useEffect(() => {
+    prefersReducedMotion.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }, []);
+
+  // Keep valueRef in sync without triggering effect
+  valueRef.current = value;
+
+  useEffect(() => {
+    if (prefersReducedMotion.current) {
+      setValue(target);
+      return;
+    }
+
+    fromRef.current = valueRef.current;
+    startRef.current = null;
+
+    const animate = (timestamp: number) => {
+      if (startRef.current === null) startRef.current = timestamp;
+      const elapsed = timestamp - startRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutCubic(progress);
+      setValue(fromRef.current + (target - fromRef.current) * eased);
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [target, duration]);
+
+  return value;
+}

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -6,6 +6,9 @@ import type { SessionCompletion } from '../types/completion.ts';
 
 export interface CompletionWithTitle extends SessionCompletion {
   session_title: string | null;
+  session_description: string | null;
+  session_focus: string[];
+  block_types: string[];
 }
 
 export interface WeeklyData {
@@ -19,9 +22,11 @@ export interface HistoryStats {
   completions: CompletionWithTitle[];
   totalSessions: number;
   totalDuration: number;
+  avgDuration: number;
   weekDots: boolean[];
   weeklyChart: WeeklyData[];
   thisWeekSessions: number;
+  thisWeekDuration: number;
   loading: boolean;
 }
 
@@ -96,6 +101,19 @@ function computeWeeklyChart(completions: SessionCompletion[]): WeeklyData[] {
   return weeks;
 }
 
+function computeThisWeekDuration(completions: SessionCompletion[]): number {
+  const today = new Date();
+  const monday = getMonday(today);
+  let total = 0;
+  for (const c of completions) {
+    const d = new Date(c.completed_at);
+    if (d >= monday) {
+      total += c.duration_seconds ?? 0;
+    }
+  }
+  return total;
+}
+
 function getISOWeekNumber(date: Date): number {
   const d = new Date(date);
   d.setHours(0, 0, 0, 0);
@@ -104,11 +122,19 @@ function getISOWeekNumber(date: Date): number {
   return Math.round(((d.getTime() - yearStart.getTime()) / 86400000 - 3 + ((yearStart.getDay() + 6) % 7)) / 7) + 1;
 }
 
+interface SessionData {
+  title?: string;
+  description?: string;
+  focus?: string[];
+  blocks?: { type: string }[];
+}
+
 export function useHistory(userId: string | undefined): HistoryStats {
   const { dataGeneration } = useAuth();
   const [completions, setCompletions] = useState<CompletionWithTitle[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration forces re-fetch on auth state change
   useEffect(() => {
     if (!userId || !supabase) {
       setCompletions([]);
@@ -124,25 +150,37 @@ export function useHistory(userId: string | undefined): HistoryStats {
         const { data, sessionExpired } = await supabaseQuery(() =>
           supabase!
             .from('session_completions')
-            .select('*, program_sessions(session_data)')
+            .select('*, program_sessions(session_data), custom_sessions(session_data)')
             .eq('user_id', userId!)
             .order('completed_at', { ascending: false })
             .limit(200),
         );
 
         if (cancelled) return;
-        if (sessionExpired) { notifySessionExpired(); setLoading(false); return; }
+        if (sessionExpired) {
+          notifySessionExpired();
+          setLoading(false);
+          return;
+        }
 
         const rows = (data ?? []) as unknown as (SessionCompletion & {
-          program_sessions: { session_data?: { title?: string } } | null;
+          program_sessions: { session_data?: SessionData } | null;
+          custom_sessions: { session_data?: SessionData } | null;
         })[];
-        const enriched: CompletionWithTitle[] = rows.map((row) => ({
-          ...row,
-          session_title:
-            (row.metadata as Record<string, unknown>)?.session_title as string | undefined
-            ?? row.program_sessions?.session_data?.title
-            ?? null,
-        }));
+
+        const enriched: CompletionWithTitle[] = rows.map((row) => {
+          const meta = row.metadata as Record<string, unknown>;
+          const sd = row.program_sessions?.session_data ?? row.custom_sessions?.session_data;
+          return {
+            ...row,
+            session_title: (meta?.session_title as string | undefined) ?? sd?.title ?? null,
+            session_description: (meta?.session_description as string | undefined) ?? sd?.description ?? null,
+            session_focus: (meta?.session_focus as string[] | undefined) ?? sd?.focus ?? [],
+            block_types: (meta?.block_types as string[] | undefined) ?? [
+              ...new Set((sd?.blocks ?? []).map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown')),
+            ],
+          };
+        });
 
         setCompletions(enriched);
         setLoading(false);
@@ -160,10 +198,20 @@ export function useHistory(userId: string | undefined): HistoryStats {
   const derived = useMemo(() => {
     const totalSessions = completions.length;
     const totalDuration = completions.reduce((sum, c) => sum + (c.duration_seconds ?? 0), 0);
+    const avgDuration = totalSessions > 0 ? Math.round(totalDuration / totalSessions) : 0;
     const weekDots = computeWeekDots(completions);
     const weeklyChart = computeWeeklyChart(completions);
     const thisWeekSessions = weekDots.filter(Boolean).length;
-    return { totalSessions, totalDuration, weekDots, weeklyChart, thisWeekSessions };
+    const thisWeekDuration = computeThisWeekDuration(completions);
+    return {
+      totalSessions,
+      totalDuration,
+      avgDuration,
+      weekDots,
+      weeklyChart,
+      thisWeekSessions,
+      thisWeekDuration,
+    };
   }, [completions]);
 
   return { completions, ...derived, loading };

--- a/src/hooks/useSaveCompletion.ts
+++ b/src/hooks/useSaveCompletion.ts
@@ -8,6 +8,9 @@ interface SaveParams {
   durationSeconds: number;
   amrapRounds: number;
   sessionTitle?: string;
+  sessionDescription?: string;
+  sessionFocus?: string[];
+  blockTypes?: string[];
 }
 
 export function useSaveCompletion() {
@@ -15,39 +18,47 @@ export function useSaveCompletion() {
   const [error, setError] = useState(false);
   const inflightRef = useRef(false);
 
-  const save = useCallback(async (params: SaveParams) => {
-    if (!supabase || inflightRef.current || saved) return;
-    inflightRef.current = true;
-    setError(false);
+  const save = useCallback(
+    async (params: SaveParams) => {
+      if (!supabase || inflightRef.current || saved) return;
+      inflightRef.current = true;
+      setError(false);
 
-    try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) return;
 
-      const { error: insertError } = await supabase.from('session_completions').insert({
-        user_id: user.id,
-        session_date: params.sessionDate ?? null,
-        program_session_id: params.programSessionId ?? null,
-        custom_session_id: params.customSessionId ?? null,
-        duration_seconds: params.durationSeconds,
-        amrap_rounds: params.amrapRounds > 0 ? params.amrapRounds : null,
-        metadata: params.sessionTitle ? { session_title: params.sessionTitle } : {},
-      });
+        const { error: insertError } = await supabase.from('session_completions').insert({
+          user_id: user.id,
+          session_date: params.sessionDate ?? null,
+          program_session_id: params.programSessionId ?? null,
+          custom_session_id: params.customSessionId ?? null,
+          duration_seconds: params.durationSeconds,
+          amrap_rounds: params.amrapRounds > 0 ? params.amrapRounds : null,
+          metadata: {
+            ...(params.sessionTitle && { session_title: params.sessionTitle }),
+            ...(params.sessionDescription && { session_description: params.sessionDescription }),
+            ...(params.sessionFocus?.length && { session_focus: params.sessionFocus }),
+            ...(params.blockTypes?.length && { block_types: params.blockTypes }),
+          },
+        });
 
-      if (insertError) {
-        console.error('Save completion error:', insertError);
+        if (insertError) {
+          console.error('Save completion error:', insertError);
+          setError(true);
+        } else {
+          setSaved(true);
+        }
+      } catch {
         setError(true);
-      } else {
-        setSaved(true);
+      } finally {
+        inflightRef.current = false;
       }
-    } catch {
-      setError(true);
-    } finally {
-      inflightRef.current = false;
-    }
-  }, [saved]);
+    },
+    [saved],
+  );
 
   return { save, saved, error };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -461,12 +461,23 @@ body {
 .stagger-4 { animation-delay: 240ms; }
 .stagger-5 { animation-delay: 320ms; }
 .stagger-6 { animation-delay: 400ms; }
+.stagger-7 { animation-delay: 480ms; }
 
 @keyframes stagger-enter {
   to {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* Number pop animation for metric cards */
+@keyframes number-pop {
+  0% { transform: scale(0.8); opacity: 0; }
+  60% { transform: scale(1.05); }
+  100% { transform: scale(1); opacity: 1; }
+}
+.animate-number-pop {
+  animation: number-pop 0.5s ease-out;
 }
 
 /* ─── Skeleton loading ─── */

--- a/src/types/completion.ts
+++ b/src/types/completion.ts
@@ -5,6 +5,7 @@ export interface SessionCompletion {
   user_id: string;
   session_date: string | null;
   program_session_id: string | null;
+  custom_session_id: string | null;
   completed_at: string;
   duration_seconds: number | null;
   amrap_rounds: number | null;


### PR DESCRIPTION
## Summary

- **4 MetricCards animées** (séances, temps total, moy/séance, cette semaine) avec AnimatedNumber (rAF + easeOutCubic) et respect `prefers-reduced-motion`
- **Historique enrichi** : chaque séance affiche description, badges de type de bloc (HIIT, Circuit, Tabata…), tags focus, icônes contextuelles (Dumbbell/Zap/Sparkles), score AMRAP
- **Sauvegarde enrichie** : EndScreen stocke désormais `description`, `focus`, `blockTypes` dans `metadata` jsonb — toutes les futures séances (libres, programme, custom) remontent avec ces infos
- **WeeklyBarChart** : animations d'entrée stagger, tooltips inline, suppression code mort
- **WeekDots** : animations stagger par jour
- **ProgramCard** : donut SVG avec AnimatedNumber au centre + transition easeOutCubic
- Chunk StatsPage : **6.4KB gzip** (lazy-loaded)

## Test plan

- [ ] Naviguer sur `/suivi` connecté avec des séances existantes → 4 cartes animées, historique enrichi
- [ ] Vérifier dark mode + light mode
- [ ] Vérifier responsive mobile (320px → 1440px)
- [ ] Empty state (0 séance) inchangé
- [ ] Terminer une séance libre via le player → vérifier que description/focus/blockTypes apparaissent dans l'historique
- [ ] Terminer une séance programme → même vérification
- [ ] Activer `prefers-reduced-motion: reduce` → animations désactivées
- [ ] Bouton "Réessayer" sur EndScreen fonctionne avec les nouvelles metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)