### PR TITLE
fix: only show exercise video on exact match

### DIFF
--- a/src/utils/exerciseVideo.ts
+++ b/src/utils/exerciseVideo.ts
@@ -11,10 +11,7 @@ function normalize(name: string): string {
 /** Exact lookup: normalized name → video URL */
 const exactMap = new Map<string, string>();
 
-/** Prefix lookup: sorted longest-first for fuzzy matching */
-const prefixCandidates: { name: string; video: string }[] = [];
-
-// Build lookup tables once at module load
+// Build lookup table once at module load
 for (const ex of EXERCISES_DATA) {
   const mainVideo = ex.video;
 
@@ -26,53 +23,20 @@ for (const ex of EXERCISES_DATA) {
     }
   }
 
-  // Variants → variant video (or parent fallback)
+  // Variants → only if the variant has its own video
   for (const v of ex.variants) {
-    const video = v.video ?? mainVideo;
-    if (video) {
-      exactMap.set(normalize(v.name), video);
-    }
-  }
-
-  // Prefix candidates (aliases are typically short/generic, best for prefix matching)
-  if (mainVideo) {
-    prefixCandidates.push({ name: normalize(ex.name), video: mainVideo });
-    for (const a of ex.aliases) {
-      prefixCandidates.push({ name: normalize(a), video: mainVideo });
-    }
-  }
-  for (const v of ex.variants) {
-    const video = v.video ?? mainVideo;
-    if (video) {
-      prefixCandidates.push({ name: normalize(v.name), video });
+    if (v.video) {
+      exactMap.set(normalize(v.name), v.video);
     }
   }
 }
 
-prefixCandidates.sort((a, b) => b.name.length - a.name.length);
-
 /**
- * Returns the video URL for an exercise name by searching:
- * 1. Exact match on exercise name, alias, or variant → specific video
- * 2. Fuzzy prefix match (longest known name that is a prefix of input)
- *
- * Note: prefix matching can produce false positives for exercises sharing
- * a common prefix (e.g. "Planche laterale" matching "Planche"). This is
- * acceptable as a v1 heuristic since most session names match exactly.
+ * Returns the video URL for an exercise name.
+ * Only exact matches on exercise name, alias, or variant are returned.
+ * No fuzzy/prefix matching to avoid showing incorrect demos
+ * (e.g. "Pompes diamant" should not show "Pompes" video).
  */
 export function getExerciseVideoUrl(exerciseName: string): string | null {
-  const key = normalize(exerciseName);
-
-  // 1. Exact match (O(1))
-  const exact = exactMap.get(key);
-  if (exact) return exact;
-
-  // 2. Fuzzy prefix match
-  for (const c of prefixCandidates) {
-    if (key.startsWith(c.name) && (key.length === c.name.length || key[c.name.length] === ' ')) {
-      return c.video;
-    }
-  }
-
-  return null;
+  return exactMap.get(normalize(exerciseName)) ?? null;
 }


### PR DESCRIPTION
## Summary

- Remove fuzzy prefix matching in `getExerciseVideoUrl` — "Pompes diamant" no longer matches "Pompes"
- Remove parent video fallback for variants without their own video — prefer no video over an incorrect demo
- Simplifies `exerciseVideo.ts` from O(n) prefix scan to O(1) map lookup only

## Context

A variant like "Pompes diamant" was showing the "Pompes classiques" video because of two mechanisms:
1. Prefix matching: "pompes diamant" starts with "pompes" → match
2. Parent fallback: variant without `video` field inherited parent's video via `v.video ?? mainVideo`

Both removed. A video is only shown when the exercise name exactly matches a known name, alias, or variant that has its own video.

## Test plan

- [ ] Player: "Pompes diamant" → no video shown
- [ ] Player: "Pompes classiques" → video shown
- [ ] Player: alias "Push-ups" → video shown (resolves to Pompes classiques)
- [ ] Player: variant with own video (e.g. "Pompes scapulaires") → its own video shown
- [ ] ExercisePage: video buttons unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)