### PR TITLE
fix: consignes highlight, hero mobile, AI timeout

### DIFF
--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -324,7 +324,7 @@ export function ProgramPage() {
 
               {consigne && !isCollapsed && (
                 <div className="flex gap-2.5 items-start rounded-lg bg-accent/10 border border-accent/20 px-3 py-2.5">
-                  <span className="text-accent text-sm mt-0.5" aria-hidden="true">💡</span>
+                  <span className="text-sm mt-0.5 shrink-0" aria-hidden="true">💡</span>
                   <p className="text-sm text-body leading-relaxed">{consigne}</p>
                 </div>
               )}

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -323,7 +323,10 @@ export function ProgramPage() {
               </button>
 
               {consigne && !isCollapsed && (
-                <p className="text-xs text-muted italic">{consigne}</p>
+                <div className="flex gap-2.5 items-start rounded-lg bg-accent/10 border border-accent/20 px-3 py-2.5">
+                  <span className="text-accent text-sm mt-0.5" aria-hidden="true">💡</span>
+                  <p className="text-sm text-body leading-relaxed">{consigne}</p>
+                </div>
               )}
 
               {!isCollapsed && (

--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -46,9 +46,9 @@ export function VisitorContent({
           <img
             src="/images/hero-landing-couple.webp"
             alt=""
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover object-[65%_center] md:object-center"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-black/50 to-black/30" />
+          <div className="absolute inset-0 bg-gradient-to-r from-black/65 via-black/35 to-black/15 md:from-black/80 md:via-black/50 md:to-black/30" />
         </div>
 
         <div className="relative z-10 w-full px-6 md:px-10 lg:px-14">

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -261,7 +261,8 @@ Deno.serve(async (req: Request) => {
   const userPrompt = buildUserPrompt(body);
 
   // Call Anthropic API
-  async function callAnthropic(extraMessages: { role: string; content: string }[] = []): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
+  // Sonnet with 12K tokens needs more time than Haiku session generation
+  async function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
     const messages = [
       { role: "user", content: userPrompt },
       ...extraMessages,
@@ -280,7 +281,7 @@ Deno.serve(async (req: Request) => {
         system: SYSTEM_PROMPT,
         messages,
       }),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!aiResponse.ok) {
@@ -332,7 +333,7 @@ Deno.serve(async (req: Request) => {
       const retryResult = await callAnthropic([
         { role: "assistant", content: truncatedPrev },
         { role: "user", content: `Ta reponse precedente etait invalide: ${validation.error}. Corrige et renvoie le JSON complet.` },
-      ]);
+      ], 30_000);
       programJson = retryResult.data;
       totalInputTokens += retryResult.inputTokens;
       totalOutputTokens += retryResult.outputTokens;

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -280,7 +280,7 @@ Deno.serve(async (req: Request) => {
         system: SYSTEM_PROMPT,
         messages,
       }),
-      signal: AbortSignal.timeout(60_000),
+      signal: AbortSignal.timeout(120_000),
     });
 
     if (!aiResponse.ok) {


### PR DESCRIPTION
## Summary
- Highlight weekly program consignes with accent card instead of muted italic text
- Improve hero image mobile framing (object-position 65%) and reduce overlay opacity
- Increase generate-program AI timeout to 120s (30s for retry) to prevent Sonnet timeouts

## Test plan
- [ ] Check program page: weekly consignes should be in a visible accent card with 💡
- [ ] Check hero on mobile: both subjects visible, text still readable
- [ ] Check hero on desktop: unchanged
- [ ] Test program generation: should not timeout anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)