### PR TITLE
feat: no-video message, accordion videos, AMRAP/EMOM explanations

### DIFF
--- a/src/components/AMRAPView.tsx
+++ b/src/components/AMRAPView.tsx
@@ -15,8 +15,11 @@ interface Props {
 export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound, showVideos, onToggleShowVideos }: Props) {
   return (
     <div className="flex flex-col items-center justify-center flex-1 gap-5 px-6 text-center">
-      {/* Block name */}
-      <h2 className="text-2xl font-bold text-white">{step.blockName}</h2>
+      {/* Block name + explanation */}
+      <div className="space-y-1">
+        <h2 className="text-2xl font-bold text-white">{step.blockName}</h2>
+        <p className="text-white/60 text-sm">Enchaîne les exercices en boucle. Fais un max de tours dans le temps imparti.</p>
+      </div>
 
       {/* Timer */}
       <TimerDisplay remaining={remaining} progress={progress} color={step.blockColor} />
@@ -32,22 +35,25 @@ export function AMRAPView({ step, remaining, progress, rounds, onIncrementRound,
       )}
 
       {/* Round counter + button */}
-      <div className="flex items-center gap-6">
-        <div className="text-center">
-          <div className="text-4xl font-bold" style={{ color: step.blockColor }}>
-            {rounds}
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex items-center gap-6">
+          <div className="text-center">
+            <div className="text-4xl font-bold" style={{ color: step.blockColor }}>
+              {rounds}
+            </div>
+            <div className="text-white/50 text-xs">rounds</div>
           </div>
-          <div className="text-white/50 text-xs">rounds</div>
-        </div>
 
-        <button
-          type="button"
-          onClick={onIncrementRound}
-          className="h-16 px-8 rounded-2xl font-bold text-lg text-white transition-all active:scale-95"
-          style={{ backgroundColor: step.blockColor }}
-        >
-          +1 Round
-        </button>
+          <button
+            type="button"
+            onClick={onIncrementRound}
+            className="h-16 px-8 rounded-2xl font-bold text-lg text-white transition-all active:scale-95"
+            style={{ backgroundColor: step.blockColor }}
+          >
+            +1 Round
+          </button>
+        </div>
+        <p className="text-white/60 text-sm">Appuie à chaque tour complété pour suivre ta progression</p>
       </div>
     </div>
   );

--- a/src/components/EMOMView.tsx
+++ b/src/components/EMOMView.tsx
@@ -18,8 +18,11 @@ export function EMOMView({ step, remaining, progress, showVideos, onToggleShowVi
         {step.roundInfo && `Minute ${step.roundInfo.current}/${step.roundInfo.total}`}
       </div>
 
-      {/* Block name */}
-      <h2 className="text-2xl font-bold text-white">{step.blockName}</h2>
+      {/* Block name + explanation */}
+      <div className="space-y-1">
+        <h2 className="text-2xl font-bold text-white">{step.blockName}</h2>
+        <p className="text-white/60 text-sm">Réalise les exercices dans la minute. Le temps restant est ta récupération.</p>
+      </div>
 
       {/* Timer */}
       <TimerDisplay remaining={remaining} progress={progress} color={step.blockColor} />
@@ -34,7 +37,6 @@ export function EMOMView({ step, remaining, progress, showVideos, onToggleShowVi
         />
       )}
 
-      <p className="text-white/40 text-xs">Faites les exercices puis récupérez jusqu'à la prochaine minute</p>
     </div>
   );
 }

--- a/src/components/ExerciseListWithVideos.tsx
+++ b/src/components/ExerciseListWithVideos.tsx
@@ -17,8 +17,10 @@ interface Props {
 }
 
 export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onToggleShowVideos }: Props) {
-  const firstVideoIndex = exercises.findIndex((ex) => getExerciseVideoUrl(ex.name));
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(firstVideoIndex >= 0 ? firstVideoIndex : null);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(() => {
+    const idx = exercises.findIndex((ex) => getExerciseVideoUrl(ex.name));
+    return idx >= 0 ? idx : null;
+  });
 
   const hasAnyVideo = exercises.some((ex) => getExerciseVideoUrl(ex.name));
 
@@ -35,14 +37,14 @@ export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onTo
 
           return (
             <div key={`${i}-${ex.name}`} className="space-y-2">
-              <button
-                type="button"
-                onClick={() => videoUrl && toggleExercise(i)}
-                className={`flex items-center justify-between w-full px-4 py-3 rounded-xl bg-white/10 ${videoUrl ? 'cursor-pointer' : ''}`}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{ex.name}</span>
-                  {videoUrl && (
+              {videoUrl ? (
+                <button
+                  type="button"
+                  onClick={() => toggleExercise(i)}
+                  className="flex items-center justify-between w-full px-4 py-3 rounded-xl bg-white/10 cursor-pointer"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-white font-medium">{ex.name}</span>
                     <span className="p-1 rounded-md bg-white/5 text-white/40">
                       {isExpanded ? (
                         <X className="w-3.5 h-3.5" aria-hidden="true" />
@@ -50,14 +52,21 @@ export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onTo
                         <Play className="w-3.5 h-3.5" aria-hidden="true" />
                       )}
                     </span>
-                  )}
+                  </div>
+                  <span className="text-lg font-bold" style={{ color: blockColor }}>
+                    x{ex.reps}
+                  </span>
+                </button>
+              ) : (
+                <div className="flex items-center justify-between w-full px-4 py-3 rounded-xl bg-white/10">
+                  <span className="text-white font-medium">{ex.name}</span>
+                  <span className="text-lg font-bold" style={{ color: blockColor }}>
+                    x{ex.reps}
+                  </span>
                 </div>
-                <span className="text-lg font-bold" style={{ color: blockColor }}>
-                  x{ex.reps}
-                </span>
-              </button>
+              )}
               {isExpanded && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
-              {!videoUrl && <NoVideoTag className="ml-4" />}
+              {!videoUrl && showVideos && <NoVideoTag className="ml-4" />}
             </div>
           );
         })}

--- a/src/components/ExerciseListWithVideos.tsx
+++ b/src/components/ExerciseListWithVideos.tsx
@@ -17,45 +17,47 @@ interface Props {
 }
 
 export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onToggleShowVideos }: Props) {
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+  const firstVideoIndex = exercises.findIndex((ex) => getExerciseVideoUrl(ex.name));
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(firstVideoIndex >= 0 ? firstVideoIndex : null);
 
   const hasAnyVideo = exercises.some((ex) => getExerciseVideoUrl(ex.name));
+
+  const toggleExercise = (i: number) => {
+    setExpandedIndex(expandedIndex === i ? null : i);
+  };
 
   return (
     <>
       <div className="w-full max-w-sm space-y-3">
         {exercises.map((ex, i) => {
           const videoUrl = getExerciseVideoUrl(ex.name);
-          const visible = videoUrl && (showVideos || expandedIndex === i);
+          const isExpanded = expandedIndex === i;
 
           return (
             <div key={`${i}-${ex.name}`} className="space-y-2">
-              <div className="flex items-center justify-between px-4 py-3 rounded-xl bg-white/10">
+              <button
+                type="button"
+                onClick={() => videoUrl && toggleExercise(i)}
+                className={`flex items-center justify-between w-full px-4 py-3 rounded-xl bg-white/10 ${videoUrl ? 'cursor-pointer' : ''}`}
+              >
                 <div className="flex items-center gap-2">
                   <span className="text-white font-medium">{ex.name}</span>
                   {videoUrl && (
-                    <button
-                      type="button"
-                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
-                      className="p-1 rounded-md bg-white/5 text-white/40 hover:text-white/70 transition-colors"
-                      aria-label={visible ? "Masquer l'exemple" : "Voir l'exemple"}
-                    >
-                      {visible ? (
+                    <span className="p-1 rounded-md bg-white/5 text-white/40">
+                      {isExpanded ? (
                         <X className="w-3.5 h-3.5" aria-hidden="true" />
                       ) : (
                         <Play className="w-3.5 h-3.5" aria-hidden="true" />
                       )}
-                    </button>
+                    </span>
                   )}
                 </div>
                 <span className="text-lg font-bold" style={{ color: blockColor }}>
                   x{ex.reps}
                 </span>
-              </div>
-              {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
-              {!videoUrl && showVideos && (
-                <NoVideoTag className="ml-4" />
-              )}
+              </button>
+              {isExpanded && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
+              {!videoUrl && <NoVideoTag className="ml-4" />}
             </div>
           );
         })}

--- a/src/components/ExerciseListWithVideos.tsx
+++ b/src/components/ExerciseListWithVideos.tsx
@@ -52,6 +52,9 @@ export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onTo
                 </span>
               </div>
               {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
+              {!videoUrl && showVideos && (
+                <span className="inline-flex items-center gap-1 ml-4 px-2.5 py-1 rounded-full text-[11px] bg-amber-500/10 text-white/50">🚧 Pas encore de vidéo pour cet exercice</span>
+              )}
             </div>
           );
         })}

--- a/src/components/ExerciseListWithVideos.tsx
+++ b/src/components/ExerciseListWithVideos.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Play, X } from 'lucide-react';
 import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { NoVideoTag } from './NoVideoTag.tsx';
 import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
 
 interface Exercise {
@@ -53,7 +54,7 @@ export function ExerciseListWithVideos({ exercises, blockColor, showVideos, onTo
               </div>
               {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={ex.name} />}
               {!videoUrl && showVideos && (
-                <span className="inline-flex items-center gap-1 ml-4 px-2.5 py-1 rounded-full text-[11px] bg-amber-500/10 text-white/50">🚧 Pas encore de vidéo pour cet exercice</span>
+                <NoVideoTag className="ml-4" />
               )}
             </div>
           );

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Play, X } from 'lucide-react';
 import { getExerciseVideoUrl } from '../utils/exerciseVideo.ts';
+import { NoVideoTag } from './NoVideoTag.tsx';
 import { PlayerVideoDemo } from './PlayerVideoDemo.tsx';
 
 interface Props {
@@ -16,7 +17,7 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
   if (!videoUrl) {
     if (!alwaysShow) return null;
     return (
-      <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] bg-amber-500/10 text-white/50">🚧 Pas encore de vidéo pour cet exercice</span>
+      <NoVideoTag />
     );
   }
 

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -14,18 +14,11 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
   const videoUrl = getExerciseVideoUrl(exerciseName);
   const [expanded, setExpanded] = useState(false);
 
-  if (!videoUrl) {
-    if (!alwaysShow) return null;
-    return (
-      <NoVideoTag />
-    );
-  }
-
   const visible = expanded || alwaysShow;
 
   return (
     <div className="w-full max-w-sm flex flex-col items-center gap-3">
-      {/* Toggle button — hidden when alwaysShow is active (video is auto-displayed) */}
+      {/* Toggle button — hidden when alwaysShow is active */}
       {!alwaysShow && (
         <button
           type="button"
@@ -46,11 +39,12 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
         </button>
       )}
 
-      {/* Video */}
-      {visible && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={exerciseName} />}
+      {/* Video or no-video tag */}
+      {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={exerciseName} />}
+      {visible && !videoUrl && <NoVideoTag />}
 
       {/* Always-show toggle — only shown when video is visible */}
-      {visible && (
+      {visible && videoUrl && (
         <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
           <input
             type="checkbox"

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -14,6 +14,8 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
   const videoUrl = getExerciseVideoUrl(exerciseName);
   const [expanded, setExpanded] = useState(false);
 
+  if (!videoUrl) return <NoVideoTag />;
+
   const visible = expanded || alwaysShow;
 
   return (
@@ -39,12 +41,11 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
         </button>
       )}
 
-      {/* Video or no-video tag */}
-      {visible && videoUrl && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={exerciseName} />}
-      {visible && !videoUrl && <NoVideoTag />}
+      {/* Video */}
+      {visible && <PlayerVideoDemo videoUrl={videoUrl} exerciseName={exerciseName} />}
 
       {/* Always-show toggle — only shown when video is visible */}
-      {visible && videoUrl && (
+      {visible && (
         <label className="inline-flex items-center gap-2 text-white/40 text-xs cursor-pointer select-none">
           <input
             type="checkbox"

--- a/src/components/ExerciseVideoButton.tsx
+++ b/src/components/ExerciseVideoButton.tsx
@@ -13,7 +13,12 @@ export function ExerciseVideoButton({ exerciseName, alwaysShow, onToggleAlwaysSh
   const videoUrl = getExerciseVideoUrl(exerciseName);
   const [expanded, setExpanded] = useState(false);
 
-  if (!videoUrl) return null;
+  if (!videoUrl) {
+    if (!alwaysShow) return null;
+    return (
+      <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] bg-amber-500/10 text-white/50">🚧 Pas encore de vidéo pour cet exercice</span>
+    );
+  }
 
   const visible = expanded || alwaysShow;
 

--- a/src/components/NoVideoTag.tsx
+++ b/src/components/NoVideoTag.tsx
@@ -1,0 +1,8 @@
+export function NoVideoTag({ className }: { className?: string }) {
+  return (
+    <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] bg-amber-500/10 text-white/50 ${className ?? ''}`}>
+      <span aria-hidden="true">🚧</span>
+      Pas encore de vidéo pour cet exercice
+    </span>
+  );
+}

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -329,11 +329,12 @@ export function Player({
       />
 
       {/* Health reminder */}
-      <div className="px-6 pb-3 text-center">
-        <p className="text-xs text-white inline-flex items-center gap-1.5">
-          <HeartPulse className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Écoute ton corps. En cas de douleur, arrête immédiatement.
+      <div className="px-6 pb-3 text-center space-y-0.5">
+        <p className="text-sm text-white/70 inline-flex items-center gap-1.5">
+          <HeartPulse className="w-4 h-4 shrink-0" aria-hidden="true" />
+          Écoute ton corps. Adapte l'effort, la qualité prime sur la quantité.
         </p>
+        <p className="text-sm text-white/70">En cas de douleur, arrête immédiatement.</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Show 🚧 tag when no video exists for an exercise (ExerciseVideoButton + ExerciseListWithVideos)
- Accordion behavior in AMRAP/EMOM: one video at a time, first auto-expanded
- Add format explanations below AMRAP/EMOM block titles for new users
- Add +1 Round instruction for AMRAP
- Improve player health disclaimer wording and readability
- Extract shared NoVideoTag component with aria-hidden emoji

## Test plan
- [ ] Player: exercise with video → "Voir l'exemple" button works, video plays
- [ ] Player: exercise without video → 🚧 tag shown directly (no button)
- [ ] AMRAP/EMOM: click exercise row → video expands, previous collapses
- [ ] AMRAP/EMOM: first exercise with video is auto-expanded
- [ ] AMRAP: block explanation + "+1 Round" instruction visible
- [ ] EMOM: block explanation visible
- [ ] Health disclaimer readable on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)