### PR TITLE
feat: welcome email via Resend on new subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ VITE_STRIPE_PRICE_YEARLY=price_xxx
 # Sentry — error monitoring (optional: app works without)
 VITE_SENTRY_DSN=https://xxx@xxx.ingest.de.sentry.io/xxx
 # SENTRY_AUTH_TOKEN — sourcemap upload (build-time only, set in CI/Vercel, DO NOT commit)
+
+# Resend — transactional emails (set in Supabase Edge Functions secrets)
+# RESEND_API_KEY=re_xxx

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -266,6 +266,16 @@ async function handleCheckoutCompleted(
     .from("profiles")
     .update({ subscription_tier: tierFromStatus(sub.status) })
     .eq("id", userId);
+
+  // Send welcome email (non-blocking)
+  try {
+    const { data: { user } } = await supabase.auth.admin.getUserById(userId);
+    if (user?.email) {
+      await sendWelcomeEmail(user.email, user.user_metadata?.display_name ?? null);
+    }
+  } catch (emailErr) {
+    console.error("Welcome email failed (non-blocking):", emailErr);
+  }
 }
 
 async function handleSubscriptionUpdated(
@@ -398,5 +408,95 @@ async function handlePaymentSucceeded(
       .from("profiles")
       .update({ subscription_tier: "premium" })
       .eq("id", sub.user_id);
+  }
+}
+
+async function sendWelcomeEmail(email: string, displayName: string | null) {
+  const resendApiKey = Deno.env.get("RESEND_API_KEY");
+  if (!resendApiKey) {
+    console.error("RESEND_API_KEY not configured, skipping welcome email");
+    return;
+  }
+
+  const name = displayName || "sportif";
+
+  const html = `<!DOCTYPE html>
+<html lang="fr">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f5f5f7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:40px auto;background:#ffffff;border-radius:16px;overflow:hidden;">
+    <tr>
+      <td style="background:#0f0f17;padding:32px 40px;text-align:center;">
+        <img src="https://www.wan2fit.fr/logo-wan2fit.png" alt="Wan2Fit" width="48" height="48" style="display:inline-block;vertical-align:middle;">
+        <span style="color:#ffffff;font-size:24px;font-weight:800;margin-left:12px;vertical-align:middle;">Wan2Fit</span>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding:40px 40px 24px;">
+        <h1 style="margin:0 0 16px;font-size:22px;color:#1a1a2e;">Salut ${name} !</h1>
+        <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#444;">
+          Merci de ta confiance. Ton abonnement Wan2Fit est actif — tu as maintenant accès à tout ce qu'il faut pour progresser à ton rythme.
+        </p>
+        <h2 style="margin:0 0 12px;font-size:16px;color:#1a1a2e;">Ce qui t'attend :</h2>
+        <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+          <tr>
+            <td style="padding:8px 12px 8px 0;vertical-align:top;font-size:20px;">🎯</td>
+            <td style="padding:8px 0;font-size:14px;line-height:1.5;color:#444;">
+              <strong style="color:#1a1a2e;">Séances sur mesure</strong><br>L'IA crée ta séance selon tes envies et ton niveau.
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 12px 8px 0;vertical-align:top;font-size:20px;">📋</td>
+            <td style="padding:8px 0;font-size:14px;line-height:1.5;color:#444;">
+              <strong style="color:#1a1a2e;">Programmes personnalisés</strong><br>Un plan multi-semaines adapté à tes objectifs, avec progression intégrée.
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 12px 8px 0;vertical-align:top;font-size:20px;">📈</td>
+            <td style="padding:8px 0;font-size:14px;line-height:1.5;color:#444;">
+              <strong style="color:#1a1a2e;">Suivi de progression</strong><br>Chaque séance est enregistrée. Suis tes stats semaine après semaine.
+            </td>
+          </tr>
+        </table>
+        <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#444;">
+          Un conseil : commence par <strong>créer ton premier programme</strong>. C'est le meilleur moyen de rester régulier.
+        </p>
+        <a href="https://www.wan2fit.fr/programme/creer" style="display:inline-block;padding:14px 32px;background:#6366f1;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none;border-radius:12px;">
+          Créer mon programme →
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding:24px 40px 32px;border-top:1px solid #eee;">
+        <p style="margin:0 0 8px;font-size:13px;color:#888;line-height:1.5;">
+          Une question ou suggestion ? <a href="mailto:contact@wan2fit.fr" style="color:#6366f1;text-decoration:none;">contact@wan2fit.fr</a>
+        </p>
+        <p style="margin:0;font-size:13px;color:#888;">
+          À très vite sur le tapis,<br>L'équipe Wan2Fit 💪
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "Wan2Fit <noreply@wan2fit.fr>",
+      to: email,
+      subject: `Bienvenue ${name} ! Ton accès complet Wan2Fit est prêt`,
+      html,
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "Unknown");
+    console.error("Resend API error:", res.status, errText);
   }
 }

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -267,15 +267,17 @@ async function handleCheckoutCompleted(
     .update({ subscription_tier: tierFromStatus(sub.status) })
     .eq("id", userId);
 
-  // Send welcome email (non-blocking)
-  try {
-    const { data: { user } } = await supabase.auth.admin.getUserById(userId);
-    if (user?.email) {
-      await sendWelcomeEmail(user.email, user.user_metadata?.display_name ?? null);
+  // Send welcome email — fire-and-forget, failure logged but won't delay webhook response
+  void (async () => {
+    try {
+      const { data: { user } } = await supabase.auth.admin.getUserById(userId);
+      if (user?.email) {
+        await sendWelcomeEmail(user.email, user.user_metadata?.display_name ?? null);
+      }
+    } catch (emailErr) {
+      console.error("Welcome email failed:", emailErr);
     }
-  } catch (emailErr) {
-    console.error("Welcome email failed (non-blocking):", emailErr);
-  }
+  })();
 }
 
 async function handleSubscriptionUpdated(
@@ -418,7 +420,13 @@ async function sendWelcomeEmail(email: string, displayName: string | null) {
     return;
   }
 
-  const name = displayName || "sportif";
+  const rawName = (displayName || "sportif").replace(/[\r\n\t]/g, "").slice(0, 50);
+  const name = rawName
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  const subjectName = rawName;
 
   const html = `<!DOCTYPE html>
 <html lang="fr">
@@ -489,7 +497,7 @@ async function sendWelcomeEmail(email: string, displayName: string | null) {
     body: JSON.stringify({
       from: "Wan2Fit <noreply@wan2fit.fr>",
       to: email,
-      subject: `Bienvenue ${name} ! Ton accès complet Wan2Fit est prêt`,
+      subject: `Bienvenue ${subjectName} ! Ton accès complet Wan2Fit est prêt`,
       html,
     }),
     signal: AbortSignal.timeout(10_000),


### PR DESCRIPTION
## Summary
- Send branded welcome email when a user subscribes via Stripe checkout
- Uses Resend API (non-blocking, fire-and-forget in webhook handler)
- HTML email: warm tone, 3 features, CTA to create program, contact footer
- HTML-escapes display_name to prevent XSS, strips control chars for subject
- Documents RESEND_API_KEY in .env.example

## Manual setup required
- [ ] Create Resend account and verify domain `wan2fit.fr`
- [ ] Add `RESEND_API_KEY` in Supabase dashboard → Edge Functions → Secrets
- [ ] Configure Resend SMTP in Supabase → Authentication → SMTP Settings (for auth emails)
- [ ] Redeploy `stripe-webhook` edge function

## Test plan
- [ ] Trigger a test checkout → verify welcome email received
- [ ] Verify email renders correctly (logo, features, CTA, contact link)
- [ ] Test with special characters in display_name (HTML entities escaped)
- [ ] Confirm webhook still returns 200 quickly (email doesn't block)
- [ ] Verify auth emails (confirmation, reset) still work via Resend SMTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)