### PR TITLE
fix: prevent data loss on tab switch (stale-while-revalidate)

### DIFF
--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { BottomNav } from './BottomNav.tsx';
@@ -9,10 +9,19 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 export function PublicLayout() {
   const { pathname } = useLocation();
   const { user, bumpDataGeneration } = useAuth();
+  const prevPathname = useRef(pathname);
 
+  // Scroll to top and refresh data on ROUTE changes only.
+  // We deliberately depend on pathname (string) instead of user (object ref)
+  // because Supabase fires SIGNED_IN on every visibilitychange, creating a new
+  // user object reference. That was causing spurious dataGeneration bumps and
+  // full data re-fetches on every tab return — even after 1 second.
   useEffect(() => {
-    window.scrollTo(0, 0);
-    if (user) bumpDataGeneration();
+    if (prevPathname.current !== pathname) {
+      window.scrollTo(0, 0);
+      if (user) bumpDataGeneration();
+      prevPathname.current = pathname;
+    }
   }, [pathname, user, bumpDataGeneration]);
 
   return (

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { BottomNav } from './BottomNav.tsx';
@@ -8,21 +8,14 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
   const { pathname } = useLocation();
-  const { user, bumpDataGeneration } = useAuth();
-  const prevPathname = useRef(pathname);
+  const { bumpDataGeneration } = useAuth();
 
-  // Scroll to top and refresh data on ROUTE changes only.
-  // We deliberately depend on pathname (string) instead of user (object ref)
-  // because Supabase fires SIGNED_IN on every visibilitychange, creating a new
-  // user object reference. That was causing spurious dataGeneration bumps and
-  // full data re-fetches on every tab return — even after 1 second.
+  // Scroll to top and force data refetch on every route change.
+  // This ensures navigating to a page always gets fresh data from Supabase.
   useEffect(() => {
-    if (prevPathname.current !== pathname) {
-      window.scrollTo(0, 0);
-      if (user) bumpDataGeneration();
-      prevPathname.current = pathname;
-    }
-  }, [pathname, user, bumpDataGeneration]);
+    window.scrollTo(0, 0);
+    bumpDataGeneration();
+  }, [pathname, bumpDataGeneration]);
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import type { User } from '@supabase/supabase-js';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
-import { sessionEvents } from '../lib/supabaseQuery.ts';
+import { sessionEvents, setVisibilityRefreshPromise } from '../lib/supabaseQuery.ts';
 import type { Profile } from '../types/auth.ts';
 
 interface AuthContextValue {
@@ -47,8 +47,8 @@ async function fetchProfile(userId: string): Promise<Profile | null> {
   return data as Profile | null;
 }
 
-/** After this duration in background, force a session refresh + data refetch */
-const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+/** Minimum background time before triggering a proactive refresh */
+const STALE_THRESHOLD_MS = 10 * 1000; // 10 seconds
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -59,19 +59,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const mounted = useRef(true);
   const lastVisibleAt = useRef(Date.now());
 
-  // Refresh session + bump dataGeneration when returning from background after inactivity
+  // Refresh session + bump dataGeneration when returning from background
+  // The refresh promise is shared with supabaseQuery so queries wait for it
   useEffect(() => {
     function handleVisibilityChange() {
       if (document.visibilityState === 'visible') {
         const elapsed = Date.now() - lastVisibleAt.current;
         if (elapsed > STALE_THRESHOLD_MS && supabase) {
-          supabase.auth.refreshSession().then(() => {
+          const refreshDone = (async () => {
+            try {
+              await supabase.auth.refreshSession();
+            } catch {
+              // Refresh failed — session may be truly expired
+            } finally {
+              setVisibilityRefreshPromise(null);
+            }
             if (mounted.current) {
               setDataGeneration((g) => g + 1);
             }
-          }).catch(() => {
-            // Refresh failed — session may be truly expired
-          });
+          })();
+          // Block supabaseQuery calls until refresh completes
+          setVisibilityRefreshPromise(refreshDone);
         }
         lastVisibleAt.current = Date.now();
       } else {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -69,13 +69,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           const refreshDone = (async () => {
             try {
               await supabase.auth.refreshSession();
+              if (mounted.current) {
+                setDataGeneration((g) => g + 1);
+              }
             } catch {
-              // Refresh failed — session may be truly expired
+              // Refresh failed — don't bump dataGeneration with a bad session
             } finally {
               setVisibilityRefreshPromise(null);
-            }
-            if (mounted.current) {
-              setDataGeneration((g) => g + 1);
             }
           })();
           // Block supabaseQuery calls until refresh completes

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -133,6 +133,7 @@ export function useHistory(userId: string | undefined): HistoryStats {
   const { dataGeneration } = useAuth();
   const [completions, setCompletions] = useState<CompletionWithTitle[]>([]);
   const [loading, setLoading] = useState(true);
+  const hasFetchedOnce = useRef(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration forces re-fetch on auth state change
   useEffect(() => {
@@ -143,7 +144,10 @@ export function useHistory(userId: string | undefined): HistoryStats {
     }
 
     let cancelled = false;
-    setLoading(true);
+    // Only show loading on initial fetch — keep stale data visible during refetch
+    if (!hasFetchedOnce.current) {
+      setLoading(true);
+    }
 
     (async () => {
       try {
@@ -183,6 +187,7 @@ export function useHistory(userId: string | undefined): HistoryStats {
         });
 
         setCompletions(enriched);
+        hasFetchedOnce.current = true;
         setLoading(false);
       } catch (err) {
         console.error('History fetch error:', err);

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -138,6 +138,7 @@ export function useHistory(userId: string | undefined): HistoryStats {
   // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration forces re-fetch on auth state change
   useEffect(() => {
     if (!userId || !supabase) {
+      hasFetchedOnce.current = false;
       setCompletions([]);
       setLoading(false);
       return;

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -33,6 +33,7 @@ export function useActiveProgram(userId: string | undefined) {
 
   useEffect(() => {
     if (!userId || !supabase) {
+      hasFetchedOnce.current = false;
       setActiveProgram(null);
       setLoading(false);
       return;
@@ -149,6 +150,7 @@ export function useProgram(slug: string | undefined, userId: string | undefined)
 
   useEffect(() => {
     if (!slug || !supabase) {
+      hasFetchedOnce.current = false;
       setLoading(false);
       return;
     }
@@ -231,6 +233,7 @@ export function useProgramSession(slug: string | undefined, order: number | unde
 
   useEffect(() => {
     if (!slug || order == null || !supabase) {
+      hasFetchedOnce.current = false;
       setLoading(false);
       return;
     }

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -29,6 +29,7 @@ export function useActiveProgram(userId: string | undefined) {
   const { dataGeneration } = useAuth();
   const [activeProgram, setActiveProgram] = useState<ActiveProgramInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasFetchedOnce = useRef(false);
 
   useEffect(() => {
     if (!userId || !supabase) {
@@ -38,7 +39,12 @@ export function useActiveProgram(userId: string | undefined) {
     }
 
     let cancelled = false;
-    setLoading(true);
+    // Only show loading spinner on initial fetch. Subsequent refetches
+    // (e.g. from dataGeneration bumps) keep stale data visible to avoid
+    // flashing the skeleton on every tab return.
+    if (!hasFetchedOnce.current) {
+      setLoading(true);
+    }
 
     (async () => {
       try {
@@ -83,6 +89,7 @@ export function useActiveProgram(userId: string | undefined) {
           goals: d.goals ?? [],
           isFixed: d.isFixed ?? true,
         });
+        hasFetchedOnce.current = true;
         setLoading(false);
       } catch (err) {
         console.error('Active program fetch error:', err);
@@ -138,6 +145,7 @@ export function useProgram(slug: string | undefined, userId: string | undefined)
   const { dataGeneration } = useAuth();
   const [program, setProgram] = useState<ProgramWithSessions | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasFetchedOnce = useRef(false);
 
   useEffect(() => {
     if (!slug || !supabase) {
@@ -146,7 +154,10 @@ export function useProgram(slug: string | undefined, userId: string | undefined)
     }
 
     let cancelled = false;
-    setLoading(true);
+    // Only show loading on initial fetch — keep stale data visible during refetch
+    if (!hasFetchedOnce.current) {
+      setLoading(true);
+    }
 
     (async () => {
       try {
@@ -196,6 +207,7 @@ export function useProgram(slug: string | undefined, userId: string | undefined)
           sessions: (sessions as ProgramSession[]) ?? [],
           completedSessionIds: completedIds,
         });
+        hasFetchedOnce.current = true;
         setLoading(false);
       } catch (err) {
         console.error('Program fetch error:', err);
@@ -215,6 +227,7 @@ export function useProgramSession(slug: string | undefined, order: number | unde
   const { dataGeneration } = useAuth();
   const [session, setSession] = useState<ProgramSession | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasFetchedOnce = useRef(false);
 
   useEffect(() => {
     if (!slug || order == null || !supabase) {
@@ -223,7 +236,9 @@ export function useProgramSession(slug: string | undefined, order: number | unde
     }
 
     let cancelled = false;
-    setLoading(true);
+    if (!hasFetchedOnce.current) {
+      setLoading(true);
+    }
 
     (async () => {
       try {
@@ -242,6 +257,7 @@ export function useProgramSession(slug: string | undefined, order: number | unde
         if (cancelled) return;
         if (sessExp) { notifySessionExpired(); setLoading(false); return; }
         setSession((ps as ProgramSession) ?? null);
+        hasFetchedOnce.current = true;
         setLoading(false);
       } catch (err) {
         console.error('Program session fetch error:', err);

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -8,32 +8,41 @@ export function useUserPrograms() {
   const { user, dataGeneration } = useAuth();
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
+  const hasFetchedOnce = useRef(false);
+
+  // Depend on user.id (stable string) instead of user (unstable object ref)
+  // to avoid re-creating fetchPrograms on every Supabase SIGNED_IN event.
+  const userId = user?.id;
 
   const fetchPrograms = useCallback(async () => {
-    if (!user || !supabase) {
+    if (!userId || !supabase) {
       setLoading(false);
       return;
     }
 
-    setLoading(true);
+    // Only show loading on initial fetch — keep stale data visible during refetch
+    if (!hasFetchedOnce.current) {
+      setLoading(true);
+    }
     try {
       const { data, sessionExpired } = await supabaseQuery(() =>
         supabase!
           .from('programs')
           .select('*')
-          .eq('user_id', user.id)
+          .eq('user_id', userId)
           .eq('is_fixed', false)
           .order('created_at', { ascending: false }),
       );
 
       if (sessionExpired) { notifySessionExpired(); return; }
       setPrograms((data as Program[]) ?? []);
+      hasFetchedOnce.current = true;
     } catch (err) {
       console.error('User programs fetch error:', err);
     } finally {
       setLoading(false);
     }
-  }, [user]);
+  }, [userId]);
 
   useEffect(() => {
     fetchPrograms();
@@ -43,7 +52,7 @@ export function useUserPrograms() {
     if (!supabase) return false;
 
     try {
-      const { error } = await supabase.from('programs').delete().eq('id', id).eq('user_id', user?.id ?? '');
+      const { error } = await supabase.from('programs').delete().eq('id', id).eq('user_id', userId ?? '');
       if (error) {
         console.error('Delete program error:', error);
         return false;
@@ -54,7 +63,7 @@ export function useUserPrograms() {
       console.error('Delete program error:', err);
       return false;
     }
-  }, [user]);
+  }, [userId]);
 
   return { programs, loading, deleteProgram, refresh: fetchPrograms };
 }

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -16,6 +16,7 @@ export function useUserPrograms() {
 
   const fetchPrograms = useCallback(async () => {
     if (!userId || !supabase) {
+      hasFetchedOnce.current = false;
       setLoading(false);
       return;
     }

--- a/src/lib/supabaseQuery.ts
+++ b/src/lib/supabaseQuery.ts
@@ -41,22 +41,30 @@ async function tryRefreshSession(): Promise<boolean> {
 }
 
 /**
+ * Gate that blocks queries while a visibility-triggered refresh is in progress.
+ * This prevents queries from firing with a stale token when returning to the tab.
+ */
+let visibilityRefreshPromise: Promise<void> | null = null;
+
+export function setVisibilityRefreshPromise(p: Promise<void> | null) {
+  visibilityRefreshPromise = p;
+}
+
+/**
  * Execute a Supabase query with automatic session recovery.
  *
- * If the query fails with an auth-related error, it will attempt to refresh
- * the session once and retry. If the retry also fails, it returns the error
- * and sets `sessionExpired` to true so the UI can react.
- *
- * Usage:
- * ```ts
- * const { data, error, sessionExpired } = await supabaseQuery(() =>
- *   supabase.from('programs').select('*').eq('slug', slug).single()
- * );
- * ```
+ * Before executing, ensures the token is fresh (waits for any pending
+ * visibility refresh and checks token expiry). If the query still fails
+ * with an auth error, retries once after a forced refresh.
  */
 export async function supabaseQuery<T>(
   queryFn: () => PromiseLike<{ data: T; error: { message?: string; code?: string } | null }>,
 ): Promise<{ data: T | null; error: { message?: string; code?: string } | null; sessionExpired: boolean }> {
+  // Wait for any ongoing visibility-triggered refresh before querying
+  if (visibilityRefreshPromise) {
+    await visibilityRefreshPromise;
+  }
+
   const result = await queryFn();
 
   if (!isAuthError(result.error)) {


### PR DESCRIPTION
## Summary
Root cause: Supabase fires SIGNED_IN on every tab visibility change, creating a new user object reference → PublicLayout bumped dataGeneration → all hooks refetched with setLoading(true) → cancelled queries left loading stuck forever.

### Changes
- **PublicLayout**: only bump dataGeneration on real route changes (pathname ref), not user object changes
- **AuthContext**: visibility refresh blocks queries via shared promise, dataGeneration only bumped on successful refresh
- **useProgram, useHistory, useUserPrograms**: stale-while-revalidate pattern — keep stale data visible during refetch, reset hasFetchedOnce on user change
- **supabaseQuery**: gate queries behind visibility refresh promise

## Test plan
- [ ] Log in → switch tab for 1 second → return: data must stay visible
- [ ] Log in → switch tab for 2 minutes → return: data must stay visible (may briefly refetch in background)
- [ ] Log out → log in as different user: must see new user's data (not stale)
- [ ] Programs page: no infinite spinner after tab switch
- [ ] Hard refresh still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)