### PR TITLE
fix: clean CSP, add difficulty badge on home

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-8350548712670804, DIRECT, f08c47fec0942fa0

--- a/src/components/DifficultyBadge.tsx
+++ b/src/components/DifficultyBadge.tsx
@@ -1,0 +1,20 @@
+import { computeDifficulty } from '../utils/sessionDifficulty.ts';
+import type { Session } from '../types/session.ts';
+
+const COLORS: Record<string, string> = {
+  accessible: 'text-emerald-400',
+  modere: 'text-amber-400',
+  intense: 'text-red-400',
+};
+
+export function DifficultyBadge({ session, separator = true }: { session: Session; separator?: boolean }) {
+  const difficulty = computeDifficulty(session);
+  return (
+    <>
+      {separator && <span className="text-xs text-white/70">·</span>}
+      <span className={`text-xs font-semibold ${COLORS[difficulty.level]}`}>
+        {difficulty.label}
+      </span>
+    </>
+  );
+}

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -7,8 +7,8 @@ import {
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import type { Session } from '../../types/session.ts';
-import { computeDifficulty } from '../../utils/sessionDifficulty.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
+import { DifficultyBadge } from '../DifficultyBadge.tsx';
 import { getProgramImage } from '../../utils/programImage.ts';
 import { SessionAccordion } from '../SessionAccordion.tsx';
 import { TomorrowCard } from './TomorrowCard.tsx';
@@ -88,25 +88,7 @@ export function ConnectedContent({
                         {session.focus.slice(0, 2).map((f) => (
                           <span key={f} className="text-xs text-white/70">· {f}</span>
                         ))}
-                        {(() => {
-                          const difficulty = computeDifficulty(session);
-                          return (
-                            <>
-                              <span className="text-xs text-white/70">·</span>
-                              <span
-                                className={`text-xs font-semibold ${
-                                  difficulty.level === 'accessible'
-                                    ? 'text-emerald-300'
-                                    : difficulty.level === 'modere'
-                                      ? 'text-amber-300'
-                                      : 'text-red-300'
-                                }`}
-                              >
-                                {difficulty.label}
-                              </span>
-                            </>
-                          );
-                        })()}
+                        <DifficultyBadge session={session} />
                       </div>
                     </div>
                   </button>

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -7,6 +7,7 @@ import {
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import type { Session } from '../../types/session.ts';
+import { computeDifficulty } from '../../utils/sessionDifficulty.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
 import { getProgramImage } from '../../utils/programImage.ts';
 import { SessionAccordion } from '../SessionAccordion.tsx';
@@ -87,6 +88,25 @@ export function ConnectedContent({
                         {session.focus.slice(0, 2).map((f) => (
                           <span key={f} className="text-xs text-white/70">· {f}</span>
                         ))}
+                        {(() => {
+                          const difficulty = computeDifficulty(session);
+                          return (
+                            <>
+                              <span className="text-xs text-white/70">·</span>
+                              <span
+                                className={`text-xs font-semibold ${
+                                  difficulty.level === 'accessible'
+                                    ? 'text-emerald-300'
+                                    : difficulty.level === 'modere'
+                                      ? 'text-amber-300'
+                                      : 'text-red-300'
+                                }`}
+                              >
+                                {difficulty.label}
+                              </span>
+                            </>
+                          );
+                        })()}
                       </div>
                     </div>
                   </button>

--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase.ts';
 import type { Session } from '../../types/session.ts';
+import { computeDifficulty } from '../../utils/sessionDifficulty.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
 import { ScreenshotCarousel } from '../ScreenshotCarousel.tsx';
 import { SessionAccordion } from '../SessionAccordion.tsx';
@@ -185,6 +186,25 @@ export function VisitorContent({
                           {session.focus.slice(0, 2).map((f) => (
                             <span key={f} className="text-xs text-white/70">· {f}</span>
                           ))}
+                          {(() => {
+                            const difficulty = computeDifficulty(session);
+                            return (
+                              <>
+                                <span className="text-xs text-white/70">·</span>
+                                <span
+                                  className={`text-xs font-semibold ${
+                                    difficulty.level === 'accessible'
+                                      ? 'text-emerald-300'
+                                      : difficulty.level === 'modere'
+                                        ? 'text-amber-300'
+                                        : 'text-red-300'
+                                  }`}
+                                >
+                                  {difficulty.label}
+                                </span>
+                              </>
+                            );
+                          })()}
                         </div>
                       </div>
                     </button>

--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -16,8 +16,8 @@ import {
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase.ts';
 import type { Session } from '../../types/session.ts';
-import { computeDifficulty } from '../../utils/sessionDifficulty.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
+import { DifficultyBadge } from '../DifficultyBadge.tsx';
 import { ScreenshotCarousel } from '../ScreenshotCarousel.tsx';
 import { SessionAccordion } from '../SessionAccordion.tsx';
 import { TomorrowCard } from './TomorrowCard.tsx';
@@ -186,25 +186,7 @@ export function VisitorContent({
                           {session.focus.slice(0, 2).map((f) => (
                             <span key={f} className="text-xs text-white/70">· {f}</span>
                           ))}
-                          {(() => {
-                            const difficulty = computeDifficulty(session);
-                            return (
-                              <>
-                                <span className="text-xs text-white/70">·</span>
-                                <span
-                                  className={`text-xs font-semibold ${
-                                    difficulty.level === 'accessible'
-                                      ? 'text-emerald-300'
-                                      : difficulty.level === 'modere'
-                                        ? 'text-amber-300'
-                                        : 'text-red-300'
-                                  }`}
-                                >
-                                  {difficulty.label}
-                                </span>
-                              </>
-                            );
-                          })()}
+                          <DifficultyBadge session={session} />
                         </div>
                       </div>
                     </button>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "rewrites": [
-    { "source": "/((?!assets|sessions|images|icons|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|ads\\.txt|manifest\\.webmanifest|sw\\.js).*)", "destination": "/index.html" }
+    { "source": "/((?!assets|sessions|images|icons|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|manifest\\.webmanifest|sw\\.js).*)", "destination": "/index.html" }
   ],
   "headers": [
     {
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://pagead2.googlesyndication.com; frame-src https://js.stripe.com https://hooks.stripe.com https://pagead2.googlesyndication.com; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- Remove unused AdSense references from CSP (script-src, connect-src, frame-src) and delete orphan `ads.txt`
- Show difficulty badge (Accessible / Modéré / Intense) on session cards — home connected + visitor
- Extract shared `DifficultyBadge` component, aligned with existing `*-400` color palette

## Test plan
- [ ] Home connecté : card séance du jour affiche la difficulté en dernier
- [ ] Home visiteur : idem sur la preview séance
- [ ] Pas de régression CSP (Stripe iframe, Supabase, fonts)
- [ ] Build + tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)