### PR TITLE
fix: natural expert placeholder, independent card heights

### DIFF
--- a/src/components/CustomSessionPage.tsx
+++ b/src/components/CustomSessionPage.tsx
@@ -129,7 +129,7 @@ export function CustomSessionPage() {
             onChange={(e) => setPreferences(e.target.value)}
             maxLength={2000}
             rows={6}
-            placeholder={'Ex : Séance push 45min, haltères + banc. 5min échauffement mobilité épaules. Bloc principal développé couché 5x5, développé incliné 3x10, élévations latérales 4x12. Finir avec un AMRAP 6min pompes/dips. Cooldown stretching pecs et épaules.'}
+            placeholder="Je veux une séance haut du corps de 45min avec haltères. J'aimerais du développé couché en force et des supersets pour les épaules. Pas de dips, j'ai mal au coude."
             className="w-full rounded-xl border border-divider bg-surface-card px-4 py-3 text-sm text-heading placeholder:text-faint resize-none focus:outline-none focus:border-brand"
           />
           <p className="text-xs text-faint mt-1 text-right">{preferences.length}/2000</p>

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -62,7 +62,7 @@ export function ConnectedContent({
             Prêt à bouger ?
           </h3>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-stretch">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
             {/* 1 — Séance du jour */}
             <div className="flex flex-col rounded-2xl overflow-hidden border border-card-border transition-all hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10">
               <h4 className="font-display text-base font-bold text-heading px-5 py-4 bg-surface-card border-b border-divider">


### PR DESCRIPTION
## Summary
- Replace overly technical placeholder in expert mode custom session with a natural, conversational prompt
- Change home grid from `items-stretch` to `items-start` so accordion expansion doesn't resize sibling cards

## Test plan
- [ ] `/seance/custom` en mode expert : placeholder conversationnel visible
- [ ] Home connecté : ouvrir l'accordion d'une card, les autres ne changent pas de hauteur
- [ ] Rendu desktop 3 colonnes : hauteurs naturelles cohérentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)