### PR TITLE
feat(nutrition): UX manual entry + CIQUAL search (PR 3/6)

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -98,6 +98,26 @@ function UserIcon() {
   );
 }
 
+function UtensilsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2" />
+      <path d="M7 2v20" />
+      <path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3zm0 0v7" />
+    </svg>
+  );
+}
+
 function ChartIcon() {
   return (
     <svg
@@ -152,6 +172,7 @@ export function BottomNav() {
   const isPrograms = pathname.startsWith('/programme');
   const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
   const isSuivi = pathname === '/suivi';
+  const isNutrition = pathname.startsWith('/nutrition');
   const isLogin = pathname === '/login' || pathname === '/signup';
 
   return (
@@ -169,8 +190,8 @@ export function BottomNav() {
             <NavItem to="/programmes" label="Programmes" active={isPrograms}>
               <ProgramsIcon />
             </NavItem>
-            <NavItem to="/decouvrir" label="Explorer" active={isDiscover}>
-              <DiscoverIcon />
+            <NavItem to="/nutrition" label="Nutrition" active={isNutrition}>
+              <UtensilsIcon />
             </NavItem>
             <NavItem to="/suivi" label="Suivi" active={isSuivi}>
               <ChartIcon />

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -4,7 +4,12 @@ import { AuthButton } from './auth/AuthButton.tsx';
 
 const NAV_ITEMS = [
   { to: '/', label: 'Accueil', match: (p: string) => p === '/' },
-  { to: '/seances', label: 'Séances', match: (p: string) => p === '/seances' || p.startsWith('/seance'), requiresAuth: true },
+  {
+    to: '/seances',
+    label: 'Séances',
+    match: (p: string) => p === '/seances' || p.startsWith('/seance'),
+    requiresAuth: true,
+  },
   {
     to: '/decouvrir',
     label: 'Explorer',
@@ -12,6 +17,7 @@ const NAV_ITEMS = [
   },
   { to: '/programmes', label: 'Programmes', match: (p: string) => p.startsWith('/programme') },
   { to: '/tarifs', label: 'Tarifs', match: (p: string) => p === '/tarifs' },
+  { to: '/nutrition', label: 'Nutrition', match: (p: string) => p.startsWith('/nutrition'), requiresAuth: true },
   { to: '/suivi', label: 'Suivi', match: (p: string) => p === '/suivi', requiresAuth: true },
 ] as const;
 
@@ -24,11 +30,7 @@ export function BrandHeader() {
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         {/* Brand */}
         <Link to="/" className="flex items-center gap-2.5">
-          <img
-            src="/logo-wan2fit.png"
-            alt=""
-            className="w-7 h-7 md:w-8 md:h-8 shrink-0"
-          />
+          <img src="/logo-wan2fit.png" alt="" className="w-7 h-7 md:w-8 md:h-8 shrink-0" />
           <span className="font-display text-lg font-black tracking-tight gradient-text">Wan2Fit</span>
         </Link>
 

--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -1,0 +1,140 @@
+import { Settings2 } from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useDailyNutrition } from '../hooks/useDailyNutrition.ts';
+import { useDocumentHead } from '../hooks/useDocumentHead.ts';
+import { useNutritionProfile } from '../hooks/useNutritionProfile.ts';
+import type { FoodReference, MealLogInsert, MealType } from '../types/nutrition.ts';
+import { CalorieRing } from './nutrition/CalorieRing.tsx';
+import { DailyFeed } from './nutrition/DailyFeed.tsx';
+import { MealEntryForm } from './nutrition/MealEntryForm.tsx';
+
+export function NutritionPage() {
+  useDocumentHead({
+    title: 'Nutrition · Wan2Fit',
+    description: 'Suis tes apports caloriques et macros au fil de la journée.',
+  });
+
+  const { profile } = useNutritionProfile();
+  const { summary, loading, error, addMeal, deleteMeal } = useDailyNutrition();
+  const [formOpen, setFormOpen] = useState(false);
+  const [initialMealType, setInitialMealType] = useState<MealType>('breakfast');
+
+  function handleAdd(mealType: MealType) {
+    setInitialMealType(mealType);
+    setFormOpen(true);
+  }
+
+  async function handleSubmit(input: Omit<MealLogInsert, 'user_id' | 'logged_date'>): Promise<boolean> {
+    const result = await addMeal(input);
+    return result != null;
+  }
+
+  async function handleSearchSelect(food: FoodReference, quantityGrams: number): Promise<boolean> {
+    const factor = quantityGrams / 100;
+    const scaled = (per100: number | null) => (per100 != null ? Math.round(per100 * factor * 10) / 10 : null);
+    const result = await addMeal({
+      meal_type: initialMealType,
+      source: 'ciqual',
+      name: food.name_fr,
+      calories: scaled(food.calories_100g) ?? 0,
+      protein_g: scaled(food.protein_100g),
+      carbs_g: scaled(food.carbs_100g),
+      fat_g: scaled(food.fat_100g),
+      quantity_grams: Math.round(quantityGrams * 10) / 10,
+      reference_id: food.id,
+      ai_metadata: null,
+      notes: null,
+    });
+    return result != null;
+  }
+
+  const macroRow = [
+    { label: 'Protéines', value: summary.totals.protein_g, target: summary.target.protein_g, suffix: 'g' },
+    { label: 'Glucides', value: summary.totals.carbs_g, target: summary.target.carbs_g, suffix: 'g' },
+    { label: 'Lipides', value: summary.totals.fat_g, target: summary.target.fat_g, suffix: 'g' },
+  ];
+
+  return (
+    <div className="px-6 md:px-10 lg:px-14 py-8">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">Nutrition</h1>
+            <p className="text-sm text-muted mt-1">Ta journée en un coup d'œil.</p>
+          </div>
+          <Link
+            to="/nutrition/setup"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium text-body border border-divider hover:bg-divider transition-colors"
+          >
+            <Settings2 className="w-3.5 h-3.5" aria-hidden="true" />
+            {profile?.target_calories != null ? 'Modifier la cible' : 'Définir une cible'}
+          </Link>
+        </header>
+
+        <section className="flex flex-col sm:flex-row items-center sm:items-start gap-6 rounded-2xl bg-surface-card border border-card-border p-6">
+          <div className="shrink-0">
+            <CalorieRing
+              current={summary.totals.calories}
+              target={summary.target.calories}
+              size={160}
+              strokeWidth={12}
+            />
+          </div>
+          <div className="flex-1 w-full space-y-3">
+            {summary.target.calories == null && (
+              <p className="text-sm text-body">
+                Awareness mode : tu suis tes apports sans cible fixe. Active-la quand tu veux.
+              </p>
+            )}
+            <dl className="grid grid-cols-3 gap-3">
+              {macroRow.map((m) => (
+                <div key={m.label} className="rounded-xl bg-surface border border-divider p-3">
+                  <dt className="text-[10px] font-medium uppercase tracking-wider text-muted">{m.label}</dt>
+                  <dd className="mt-1 text-sm font-bold text-heading">
+                    {Math.round(m.value)}
+                    <span className="text-xs text-muted font-normal"> {m.suffix}</span>
+                    {m.target != null && (
+                      <span className="block text-[11px] text-muted font-normal mt-0.5">
+                        / {Math.round(m.target)} {m.suffix}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+
+        {loading ? (
+          <div className="space-y-3">
+            <div className="skeleton h-8 w-1/3 rounded-lg" />
+            <div className="skeleton h-16 rounded-xl" />
+            <div className="skeleton h-16 rounded-xl" />
+          </div>
+        ) : (
+          <DailyFeed byMealType={summary.byMealType} onAdd={handleAdd} onDelete={deleteMeal} />
+        )}
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {formOpen && (
+          <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-6 overflow-y-auto">
+            <div className="w-full max-w-lg rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-6 shadow-xl">
+              <MealEntryForm
+                initialMealType={initialMealType}
+                onSubmit={handleSubmit}
+                onSearchSelect={handleSearchSelect}
+                onCancel={() => setFormOpen(false)}
+              />
+            </div>
+          </div>
+        )}
+
+        <footer className="text-center text-[11px] text-muted">
+          Base d'aliments : ANSES — Table CIQUAL (licence Etalab 2.0)
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -1,5 +1,5 @@
 import { Settings2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { useDailyNutrition } from '../hooks/useDailyNutrition.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
@@ -19,6 +19,25 @@ export function NutritionPage() {
   const { summary, loading, error, addMeal, deleteMeal } = useDailyNutrition();
   const [formOpen, setFormOpen] = useState(false);
   const [initialMealType, setInitialMealType] = useState<MealType>('breakfast');
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!formOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFormOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    // Move focus into the modal so keyboard users land inside.
+    modalRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [formOpen]);
+
+  const target = {
+    calories: profile?.target_calories ?? null,
+    protein_g: profile?.target_protein_g ?? null,
+    carbs_g: profile?.target_carbs_g ?? null,
+    fat_g: profile?.target_fat_g ?? null,
+  };
 
   function handleAdd(mealType: MealType) {
     setInitialMealType(mealType);
@@ -30,11 +49,11 @@ export function NutritionPage() {
     return result != null;
   }
 
-  async function handleSearchSelect(food: FoodReference, quantityGrams: number): Promise<boolean> {
+  async function handleSearchSelect(food: FoodReference, quantityGrams: number, mealType: MealType): Promise<boolean> {
     const factor = quantityGrams / 100;
     const scaled = (per100: number | null) => (per100 != null ? Math.round(per100 * factor * 10) / 10 : null);
     const result = await addMeal({
-      meal_type: initialMealType,
+      meal_type: mealType,
       source: 'ciqual',
       name: food.name_fr,
       calories: scaled(food.calories_100g) ?? 0,
@@ -50,9 +69,9 @@ export function NutritionPage() {
   }
 
   const macroRow = [
-    { label: 'Protéines', value: summary.totals.protein_g, target: summary.target.protein_g, suffix: 'g' },
-    { label: 'Glucides', value: summary.totals.carbs_g, target: summary.target.carbs_g, suffix: 'g' },
-    { label: 'Lipides', value: summary.totals.fat_g, target: summary.target.fat_g, suffix: 'g' },
+    { label: 'Protéines', value: summary.totals.protein_g, target: target.protein_g, suffix: 'g' },
+    { label: 'Glucides', value: summary.totals.carbs_g, target: target.carbs_g, suffix: 'g' },
+    { label: 'Lipides', value: summary.totals.fat_g, target: target.fat_g, suffix: 'g' },
   ];
 
   return (
@@ -74,15 +93,10 @@ export function NutritionPage() {
 
         <section className="flex flex-col sm:flex-row items-center sm:items-start gap-6 rounded-2xl bg-surface-card border border-card-border p-6">
           <div className="shrink-0">
-            <CalorieRing
-              current={summary.totals.calories}
-              target={summary.target.calories}
-              size={160}
-              strokeWidth={12}
-            />
+            <CalorieRing current={summary.totals.calories} target={target.calories} size={160} strokeWidth={12} />
           </div>
           <div className="flex-1 w-full space-y-3">
-            {summary.target.calories == null && (
+            {target.calories == null && (
               <p className="text-sm text-body">
                 Awareness mode : tu suis tes apports sans cible fixe. Active-la quand tu veux.
               </p>
@@ -119,8 +133,21 @@ export function NutritionPage() {
         {error && <p className="text-sm text-red-400">{error}</p>}
 
         {formOpen && (
-          <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-6 overflow-y-auto">
-            <div className="w-full max-w-lg rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-6 shadow-xl">
+          <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-6 overflow-y-auto">
+            <button
+              type="button"
+              aria-label="Fermer la fenêtre d'ajout"
+              onClick={() => setFormOpen(false)}
+              className="absolute inset-0 bg-black/60 backdrop-blur-sm cursor-default"
+            />
+            <div
+              ref={modalRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Ajouter un repas"
+              tabIndex={-1}
+              className="relative w-full max-w-lg rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-6 shadow-xl focus:outline-none"
+            >
               <MealEntryForm
                 initialMealType={initialMealType}
                 onSubmit={handleSubmit}

--- a/src/components/NutritionSetupPage.tsx
+++ b/src/components/NutritionSetupPage.tsx
@@ -1,0 +1,148 @@
+import { ArrowLeft, Trash2 } from 'lucide-react';
+import { type FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useDocumentHead } from '../hooks/useDocumentHead.ts';
+import { useNutritionProfile } from '../hooks/useNutritionProfile.ts';
+import type { ActivityLevel, NutritionGoal, TdeeResult } from '../types/nutrition.ts';
+import { TdeeCalculatorForm } from './nutrition/TdeeCalculatorForm.tsx';
+
+export function NutritionSetupPage() {
+  useDocumentHead({
+    title: 'Cible nutritionnelle · Wan2Fit',
+    description: 'Définis ta cible calorique quotidienne sans partager tes données corporelles.',
+  });
+
+  const navigate = useNavigate();
+  const { profile, loading, upsert, clearTarget } = useNutritionProfile();
+  const [manualTarget, setManualTarget] = useState('');
+  const [manualError, setManualError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (profile?.target_calories != null && manualTarget === '') {
+      setManualTarget(String(profile.target_calories));
+    }
+  }, [profile?.target_calories, manualTarget]);
+
+  async function handleTdeeAccept(result: TdeeResult, activityLevel: ActivityLevel, goal: NutritionGoal) {
+    await upsert({
+      target_calories: result.targetCalories,
+      target_protein_g: result.targetProteinG,
+      target_carbs_g: result.targetCarbsG,
+      target_fat_g: result.targetFatG,
+      goal,
+      activity_level: activityLevel,
+    });
+    navigate('/nutrition');
+  }
+
+  async function handleManualSubmit(e: FormEvent) {
+    e.preventDefault();
+    setManualError(null);
+    const kcal = Number.parseInt(manualTarget.replace(/[^\d]/g, ''), 10);
+    if (!Number.isFinite(kcal) || kcal < 1000 || kcal > 5000) {
+      setManualError('La cible doit être entre 1000 et 5000 kcal.');
+      return;
+    }
+    setSaving(true);
+    try {
+      await upsert({ target_calories: kcal });
+      navigate('/nutrition');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    try {
+      await clearTarget();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="px-6 md:px-10 lg:px-14 py-8">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <Link
+          to="/nutrition"
+          className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-heading transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+          Retour au suivi
+        </Link>
+
+        <header>
+          <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">Ta cible calorique</h1>
+          <p className="text-sm text-body mt-2 leading-relaxed">
+            Définir une cible est <strong>facultatif</strong>. Le suivi marche très bien en awareness pur (tu regardes
+            ce que tu consommes, sans objectif). Si tu veux en avoir une, tu peux soit la calculer avec tes données
+            morphologiques (qui restent dans ton navigateur), soit taper directement un chiffre.
+          </p>
+        </header>
+
+        <section className="rounded-2xl bg-surface-card border border-card-border p-6 space-y-4">
+          <h2 className="font-display text-lg font-bold text-heading">Option 1 — Saisir un chiffre</h2>
+          <p className="text-sm text-muted">Tu sais déjà ce que tu vises. On stocke juste ce nombre, rien d'autre.</p>
+          <form onSubmit={handleManualSubmit} className="space-y-3">
+            <div>
+              <label htmlFor="manual-target" className="block text-xs font-medium text-body mb-1">
+                Cible quotidienne (kcal)
+              </label>
+              <input
+                id="manual-target"
+                type="number"
+                inputMode="numeric"
+                min="1000"
+                max="5000"
+                step="10"
+                value={manualTarget}
+                onChange={(e) => setManualTarget(e.target.value)}
+                placeholder="2100"
+                className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+              />
+            </div>
+            {manualError && <p className="text-xs text-red-400">{manualError}</p>}
+            <button
+              type="submit"
+              disabled={saving || loading}
+              className="w-full py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50"
+            >
+              {saving ? 'Sauvegarde…' : 'Enregistrer cette cible'}
+            </button>
+          </form>
+        </section>
+
+        <section className="rounded-2xl bg-surface-card border border-card-border p-6 space-y-4">
+          <h2 className="font-display text-lg font-bold text-heading">Option 2 — Calcul assisté (éphémère)</h2>
+          <TdeeCalculatorForm onAccept={handleTdeeAccept} onCancel={() => navigate('/nutrition')} />
+        </section>
+
+        {profile?.target_calories != null && (
+          <section className="rounded-2xl bg-surface-card border border-divider p-6 space-y-3">
+            <h2 className="font-display text-base font-bold text-heading">Cible actuelle</h2>
+            <p className="text-sm text-body">
+              {profile.target_calories} kcal / jour
+              {profile.goal && (
+                <span className="text-muted">
+                  {' '}
+                  · {profile.goal === 'loss' ? 'perte' : profile.goal === 'gain' ? 'prise' : 'maintien'}
+                </span>
+              )}
+            </p>
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={saving}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium text-red-400 border border-red-400/30 hover:bg-red-400/10 transition-colors disabled:opacity-50"
+            >
+              <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+              Supprimer la cible
+            </button>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -1,15 +1,12 @@
+import { Play, Sparkles, Target } from 'lucide-react';
 import { Link } from 'react-router';
-import {
-  Sparkles,
-  Play,
-  Target,
-} from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import type { Session } from '../../types/session.ts';
+import { getProgramImage } from '../../utils/programImage.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
 import { DifficultyBadge } from '../DifficultyBadge.tsx';
-import { getProgramImage } from '../../utils/programImage.ts';
+import { NutritionWidget } from '../nutrition/NutritionWidget.tsx';
 import { SessionAccordion } from '../SessionAccordion.tsx';
 import { TomorrowCard } from './TomorrowCard.tsx';
 
@@ -43,8 +40,7 @@ export function ConnectedContent({
       ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
       : 0;
 
-  const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '')
-    .split(' ')[0];
+  const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '').split(' ')[0];
 
   return (
     <div className="px-6 md:px-10 lg:px-14 py-8">
@@ -54,13 +50,9 @@ export function ConnectedContent({
         {/* ── Titre + 3 colonnes d'action ── */}
         <section>
           {firstName && (
-            <h2 className="font-display text-xl sm:text-2xl font-bold text-heading mb-1">
-              Salut {firstName}
-            </h2>
+            <h2 className="font-display text-xl sm:text-2xl font-bold text-heading mb-1">Salut {firstName}</h2>
           )}
-          <h3 className="font-display text-2xl sm:text-3xl font-black text-heading mb-6">
-            Prêt à bouger ?
-          </h3>
+          <h3 className="font-display text-2xl sm:text-3xl font-black text-heading mb-6">Prêt à bouger ?</h3>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
             {/* 1 — Séance du jour */}
@@ -77,7 +69,11 @@ export function ConnectedContent({
               ) : session ? (
                 <>
                   <button type="button" onClick={onStart} className="relative h-36 w-full cursor-pointer text-left">
-                    <img src={getSessionImage(session)} alt={`Séance du jour : ${session.title}`} className="w-full h-full object-cover object-[50%_30%]" />
+                    <img
+                      src={getSessionImage(session)}
+                      alt={`Séance du jour : ${session.title}`}
+                      className="w-full h-full object-cover object-[50%_30%]"
+                    />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
                     <div className="absolute bottom-3 left-4 right-4">
                       <p className="font-display text-lg font-bold text-white leading-tight">
@@ -86,16 +82,16 @@ export function ConnectedContent({
                       <div className="flex items-center gap-2 mt-1">
                         <span className="text-xs text-white/70">~{session.estimatedDuration} min</span>
                         {session.focus.slice(0, 2).map((f) => (
-                          <span key={f} className="text-xs text-white/70">· {f}</span>
+                          <span key={f} className="text-xs text-white/70">
+                            · {f}
+                          </span>
                         ))}
                         <DifficultyBadge session={session} />
                       </div>
                     </div>
                   </button>
                   <div className="flex-1 flex flex-col justify-end px-5 py-4 bg-surface-card space-y-3">
-                    {session.description && (
-                      <p className="text-sm text-muted leading-relaxed">{session.description}</p>
-                    )}
+                    {session.description && <p className="text-sm text-muted leading-relaxed">{session.description}</p>}
                     <button
                       type="button"
                       onClick={onStart}
@@ -117,7 +113,11 @@ export function ConnectedContent({
               ) : (
                 <div className="flex-1 p-6 flex items-center justify-center">
                   <div className="text-center">
-                    <img src="/images/illustration-empty-state.webp" alt="Pas de séance prévue" className="w-40 h-auto mx-auto mb-3 rounded-lg opacity-80" />
+                    <img
+                      src="/images/illustration-empty-state.webp"
+                      alt="Pas de séance prévue"
+                      className="w-40 h-auto mx-auto mb-3 rounded-lg opacity-80"
+                    />
                     <p className="text-sm text-muted">Pas de séance aujourd'hui</p>
                   </div>
                 </div>
@@ -134,10 +134,16 @@ export function ConnectedContent({
                   <h4 className="font-display text-base font-bold text-heading group-hover:text-accent transition-colors">
                     Séance sur-mesure
                   </h4>
-                  <span className="text-[10px] font-bold uppercase tracking-wider text-brand/60 bg-brand/8 px-2 py-0.5 rounded-full shrink-0">Premium</span>
+                  <span className="text-[10px] font-bold uppercase tracking-wider text-brand/60 bg-brand/8 px-2 py-0.5 rounded-full shrink-0">
+                    Premium
+                  </span>
                 </div>
                 <div className="relative h-36 overflow-hidden">
-                  <img src="/images/illustration-ai-session.webp" alt="Séance personnalisée par IA" className="w-full h-full object-cover object-center" />
+                  <img
+                    src="/images/illustration-ai-session.webp"
+                    alt="Séance personnalisée par IA"
+                    className="w-full h-full object-cover object-center"
+                  />
                 </div>
                 <div className="flex-1 flex flex-col justify-between px-5 py-4 bg-surface-card space-y-3">
                   <p className="text-sm text-muted leading-relaxed">
@@ -158,10 +164,16 @@ export function ConnectedContent({
                   <h4 className="font-display text-base font-bold text-heading group-hover:text-accent transition-colors">
                     Séance sur-mesure
                   </h4>
-                  <span className="text-[10px] font-bold uppercase tracking-wider text-accent/80 bg-accent/10 px-2 py-0.5 rounded-full shrink-0">Premium</span>
+                  <span className="text-[10px] font-bold uppercase tracking-wider text-accent/80 bg-accent/10 px-2 py-0.5 rounded-full shrink-0">
+                    Premium
+                  </span>
                 </div>
                 <div className="relative h-36 overflow-hidden">
-                  <img src="/images/illustration-ai-session.webp" alt="Séance personnalisée par IA" className="w-full h-full object-cover object-center" />
+                  <img
+                    src="/images/illustration-ai-session.webp"
+                    alt="Séance personnalisée par IA"
+                    className="w-full h-full object-cover object-center"
+                  />
                 </div>
                 <div className="flex-1 flex flex-col justify-between px-5 py-4 bg-surface-card space-y-3">
                   <p className="text-sm text-muted leading-relaxed">
@@ -192,7 +204,11 @@ export function ConnectedContent({
                   Mon programme
                 </h4>
                 <Link to={`/programme/${activeProgram.slug}/suivi`} className="block relative h-36 group">
-                  <img src={getProgramImage(activeProgram.slug, activeProgram.goals)} alt={activeProgram.title} className="w-full h-full object-cover object-[50%_30%]" />
+                  <img
+                    src={getProgramImage(activeProgram.slug, activeProgram.goals)}
+                    alt={activeProgram.title}
+                    className="w-full h-full object-cover object-[50%_30%]"
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
                   <div className="absolute bottom-3 left-4 right-4">
                     <p className="font-display text-lg font-bold text-white leading-tight group-hover:text-white/80 transition-colors">
@@ -203,11 +219,16 @@ export function ConnectedContent({
                 <div className="flex-1 flex flex-col justify-between px-5 py-4 bg-surface-card">
                   <div>
                     <div className="flex items-center justify-between text-xs text-muted mb-1.5">
-                      <span>{activeProgram.completedCount}/{activeProgram.totalSessions} séances</span>
+                      <span>
+                        {activeProgram.completedCount}/{activeProgram.totalSessions} séances
+                      </span>
                       <span>{progressPct}%</span>
                     </div>
                     <div className="h-1.5 rounded-full bg-divider overflow-hidden">
-                      <div className="h-full rounded-full bg-brand-secondary transition-all" style={{ width: `${progressPct}%` }} />
+                      <div
+                        className="h-full rounded-full bg-brand-secondary transition-all"
+                        style={{ width: `${progressPct}%` }}
+                      />
                     </div>
                   </div>
                   {activeProgram.nextSessionTitle && (
@@ -218,7 +239,11 @@ export function ConnectedContent({
                   {activeProgram.nextSessionOrder != null && (
                     <button
                       type="button"
-                      onClick={() => guardNavigation(`/programme/${activeProgram.slug}/seance/${activeProgram.nextSessionOrder}/play`)}
+                      onClick={() =>
+                        guardNavigation(
+                          `/programme/${activeProgram.slug}/seance/${activeProgram.nextSessionOrder}/play`,
+                        )
+                      }
                       className="cta-gradient flex items-center justify-center gap-2 w-full py-3 rounded-xl text-sm font-bold text-white mt-3 cursor-pointer"
                     >
                       <Play className="w-4 h-4" aria-hidden="true" />
@@ -226,9 +251,7 @@ export function ConnectedContent({
                     </button>
                   )}
                 </div>
-                {activeProgram.nextSessionData && (
-                  <SessionAccordion session={activeProgram.nextSessionData} />
-                )}
+                {activeProgram.nextSessionData && <SessionAccordion session={activeProgram.nextSessionData} />}
               </div>
             ) : (
               <Link
@@ -239,7 +262,11 @@ export function ConnectedContent({
                   Programmes
                 </h4>
                 <div className="relative h-36 overflow-hidden">
-                  <img src="/images/illustration-program.webp" alt="Programmes d'entraînement" className="w-full h-full object-cover object-center" />
+                  <img
+                    src="/images/illustration-program.webp"
+                    alt="Programmes d'entraînement"
+                    className="w-full h-full object-cover object-center"
+                  />
                 </div>
                 <div className="flex-1 flex flex-col justify-between px-5 py-4 bg-surface-card space-y-3">
                   <p className="text-sm text-muted leading-relaxed">
@@ -253,6 +280,11 @@ export function ConnectedContent({
               </Link>
             )}
           </div>
+        </section>
+
+        {/* ── Nutrition du jour ── */}
+        <section>
+          <NutritionWidget />
         </section>
 
         {/* ── Séance de demain ── */}

--- a/src/components/nutrition/CalorieRing.tsx
+++ b/src/components/nutrition/CalorieRing.tsx
@@ -1,0 +1,63 @@
+interface CalorieRingProps {
+  current: number;
+  target: number | null;
+  size?: number;
+  strokeWidth?: number;
+  label?: string;
+}
+
+/**
+ * Circular progress ring for daily calories vs target.
+ * Gracefully degrades to "Awareness" mode when no target is set.
+ */
+export function CalorieRing({ current, target, size = 160, strokeWidth = 12, label }: CalorieRingProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = target && target > 0 ? Math.min(current / target, 1) : 0;
+  const offset = circumference * (1 - progress);
+
+  const remaining = target != null ? Math.round(target - current) : null;
+  const roundedCurrent = Math.round(current);
+
+  return (
+    <div
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={
+        target != null
+          ? `${roundedCurrent} kilocalories sur ${target} aujourd'hui`
+          : `${roundedCurrent} kilocalories aujourd'hui`
+      }
+    >
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <title>{label ?? 'Progression calorique'}</title>
+        <circle cx={size / 2} cy={size / 2} r={radius} className="fill-none stroke-divider" strokeWidth={strokeWidth} />
+        {target != null && target > 0 && (
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            className="fill-none stroke-brand"
+            strokeWidth={strokeWidth}
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+          />
+        )}
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+        <span className="font-display text-2xl font-black text-heading leading-none">{roundedCurrent}</span>
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted mt-0.5">kcal</span>
+        {target != null ? (
+          <span className="text-xs text-body mt-1">
+            {remaining != null && remaining > 0 ? `reste ${remaining}` : 'objectif atteint'}
+          </span>
+        ) : (
+          <span className="text-xs text-muted mt-1">/ {target ?? '—'}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/nutrition/CalorieRing.tsx
+++ b/src/components/nutrition/CalorieRing.tsx
@@ -13,7 +13,7 @@ interface CalorieRingProps {
 export function CalorieRing({ current, target, size = 160, strokeWidth = 12, label }: CalorieRingProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
-  const progress = target && target > 0 ? Math.min(current / target, 1) : 0;
+  const progress = target != null && target > 0 ? Math.min(current / target, 1) : 0;
   const offset = circumference * (1 - progress);
 
   const remaining = target != null ? Math.round(target - current) : null;
@@ -50,12 +50,10 @@ export function CalorieRing({ current, target, size = 160, strokeWidth = 12, lab
       <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
         <span className="font-display text-2xl font-black text-heading leading-none">{roundedCurrent}</span>
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted mt-0.5">kcal</span>
-        {target != null ? (
+        {target != null && (
           <span className="text-xs text-body mt-1">
             {remaining != null && remaining > 0 ? `reste ${remaining}` : 'objectif atteint'}
           </span>
-        ) : (
-          <span className="text-xs text-muted mt-1">/ {target ?? '—'}</span>
         )}
       </div>
     </div>

--- a/src/components/nutrition/DailyFeed.tsx
+++ b/src/components/nutrition/DailyFeed.tsx
@@ -1,0 +1,56 @@
+import { Plus } from 'lucide-react';
+import { MEAL_TYPE_LABELS, MEAL_TYPES } from '../../config/nutrition.ts';
+import type { MealLog, MealType } from '../../types/nutrition.ts';
+import { MealCard } from './MealCard.tsx';
+
+interface DailyFeedProps {
+  byMealType: Partial<Record<MealType, MealLog[]>>;
+  onAdd: (mealType: MealType) => void;
+  onDelete: (id: string) => void;
+}
+
+function sumCalories(logs: MealLog[] | undefined): number {
+  if (!logs) return 0;
+  return Math.round(logs.reduce((acc, l) => acc + (l.calories ?? 0), 0));
+}
+
+export function DailyFeed({ byMealType, onAdd, onDelete }: DailyFeedProps) {
+  return (
+    <div className="space-y-6">
+      {MEAL_TYPES.map((mealType) => {
+        const logs = byMealType[mealType];
+        const kcal = sumCalories(logs);
+        return (
+          <section key={mealType} aria-labelledby={`meal-${mealType}`}>
+            <header className="flex items-center justify-between mb-2">
+              <h3 id={`meal-${mealType}`} className="font-display text-base font-bold text-heading">
+                {MEAL_TYPE_LABELS[mealType]}
+                {kcal > 0 && <span className="ml-2 text-xs font-medium text-muted">{kcal} kcal</span>}
+              </h3>
+              <button
+                type="button"
+                onClick={() => onAdd(mealType)}
+                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium text-brand hover:bg-brand/10 transition-colors"
+                aria-label={`Ajouter au ${MEAL_TYPE_LABELS[mealType].toLowerCase()}`}
+              >
+                <Plus className="w-4 h-4" aria-hidden="true" />
+                Ajouter
+              </button>
+            </header>
+            {logs && logs.length > 0 ? (
+              <ul className="space-y-2">
+                {logs.map((meal) => (
+                  <li key={meal.id}>
+                    <MealCard meal={meal} onDelete={onDelete} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-muted italic pl-1">Rien pour l'instant.</p>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/nutrition/FoodSearchInput.tsx
+++ b/src/components/nutrition/FoodSearchInput.tsx
@@ -1,0 +1,68 @@
+import { Search } from 'lucide-react';
+import { useState } from 'react';
+import { useFoodSearch } from '../../hooks/useFoodSearch.ts';
+import type { FoodReference } from '../../types/nutrition.ts';
+
+interface FoodSearchInputProps {
+  onSelect: (food: FoodReference) => void;
+  placeholder?: string;
+}
+
+export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps) {
+  const [query, setQuery] = useState('');
+  const { results, loading } = useFoodSearch(query);
+
+  return (
+    <div className="space-y-2">
+      <label className="relative block">
+        <span className="sr-only">Rechercher un aliment</span>
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none"
+          aria-hidden="true"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder ?? 'Pomme, pâtes cuites, yaourt…'}
+          className="w-full pl-10 pr-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+          autoComplete="off"
+        />
+      </label>
+
+      {query.trim().length > 0 && query.trim().length < 2 && (
+        <p className="text-xs text-muted">Tape au moins 2 caractères.</p>
+      )}
+
+      {query.trim().length >= 2 && (
+        <div className="rounded-xl bg-surface-card border border-divider max-h-72 overflow-y-auto">
+          {loading && results.length === 0 ? (
+            <p className="p-3 text-sm text-muted">Recherche…</p>
+          ) : results.length === 0 ? (
+            <p className="p-3 text-sm text-muted">Aucun résultat dans la base CIQUAL.</p>
+          ) : (
+            <ul>
+              {results.map((food) => (
+                <li key={food.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(food)}
+                    className="w-full text-left px-3 py-2 hover:bg-divider transition-colors border-b border-divider last:border-b-0"
+                  >
+                    <p className="text-sm text-heading truncate">{food.name_fr}</p>
+                    <p className="text-xs text-muted mt-0.5">
+                      {food.calories_100g != null
+                        ? `${Math.round(food.calories_100g)} kcal / 100 g`
+                        : 'Calories non disponibles'}
+                      {food.group_fr && <span className="ml-2">· {food.group_fr}</span>}
+                    </p>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/nutrition/FoodSearchInput.tsx
+++ b/src/components/nutrition/FoodSearchInput.tsx
@@ -14,13 +14,16 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
 
   return (
     <div className="space-y-2">
-      <label className="relative block">
-        <span className="sr-only">Rechercher un aliment</span>
+      <label htmlFor="food-search-input" className="sr-only">
+        Rechercher un aliment
+      </label>
+      <div className="relative block">
         <Search
           className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none"
           aria-hidden="true"
         />
         <input
+          id="food-search-input"
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
@@ -28,7 +31,7 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
           className="w-full pl-10 pr-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
           autoComplete="off"
         />
-      </label>
+      </div>
 
       {query.trim().length > 0 && query.trim().length < 2 && (
         <p className="text-xs text-muted">Tape au moins 2 caractères.</p>

--- a/src/components/nutrition/MealCard.tsx
+++ b/src/components/nutrition/MealCard.tsx
@@ -31,7 +31,9 @@ export function MealCard({ meal, onDelete }: MealCardProps) {
       <div className="flex-1 min-w-0">
         <div className="flex items-start justify-between gap-2">
           <p className="font-medium text-sm text-heading truncate">{meal.name}</p>
-          <span className="shrink-0 font-display text-sm font-bold text-brand">{Math.round(meal.calories)} kcal</span>
+          <span className="shrink-0 font-display text-sm font-bold text-brand">
+            {Math.round(meal.calories ?? 0)} kcal
+          </span>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-[11px] text-muted">
           <span className="uppercase tracking-wider">{SOURCE_LABEL[meal.source]}</span>

--- a/src/components/nutrition/MealCard.tsx
+++ b/src/components/nutrition/MealCard.tsx
@@ -1,0 +1,56 @@
+import { Trash2 } from 'lucide-react';
+import type { MealLog } from '../../types/nutrition.ts';
+
+interface MealCardProps {
+  meal: MealLog;
+  onDelete?: (id: string) => void;
+}
+
+const SOURCE_LABEL: Record<MealLog['source'], string> = {
+  manual: 'Saisie',
+  ciqual: 'CIQUAL',
+  barcode: 'Code-barres',
+  ai_text: 'IA',
+  overflow_insight: 'IA',
+};
+
+function formatMacro(value: number | null | undefined, suffix: string): string | null {
+  if (value == null) return null;
+  return `${Math.round(value)} ${suffix}`;
+}
+
+export function MealCard({ meal, onDelete }: MealCardProps) {
+  const macros = [
+    formatMacro(meal.protein_g, 'g P'),
+    formatMacro(meal.carbs_g, 'g G'),
+    formatMacro(meal.fat_g, 'g L'),
+  ].filter((v): v is string => v !== null);
+
+  return (
+    <article className="flex items-start gap-3 px-4 py-3 rounded-xl bg-surface-card border border-divider">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <p className="font-medium text-sm text-heading truncate">{meal.name}</p>
+          <span className="shrink-0 font-display text-sm font-bold text-brand">{Math.round(meal.calories)} kcal</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-[11px] text-muted">
+          <span className="uppercase tracking-wider">{SOURCE_LABEL[meal.source]}</span>
+          {meal.quantity_grams != null && <span>{Math.round(meal.quantity_grams)} g</span>}
+          {macros.map((m) => (
+            <span key={m}>{m}</span>
+          ))}
+        </div>
+      </div>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={() => onDelete(meal.id)}
+          aria-label={`Supprimer ${meal.name}`}
+          className="shrink-0 p-1.5 rounded-lg text-muted hover:text-heading hover:bg-divider transition-colors"
+        >
+          <Trash2 className="w-4 h-4" aria-hidden="true" />
+        </button>
+      )}
+    </article>
+  );
+}

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,0 +1,342 @@
+import { X } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+import { MEAL_TYPE_LABELS, MEAL_TYPES } from '../../config/nutrition.ts';
+import type { FoodReference, MealLogInsert, MealType } from '../../types/nutrition.ts';
+import { FoodSearchInput } from './FoodSearchInput.tsx';
+
+type Mode = 'manual' | 'search';
+
+interface MealEntryFormProps {
+  initialMealType: MealType;
+  onSubmit: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
+  onCancel: () => void;
+  searchSlot?: React.ReactNode;
+  onSearchSelect?: (food: FoodReference, quantityGrams: number) => Promise<boolean>;
+}
+
+function scaleByPortion(per100g: number | null | undefined, grams: number): number | null {
+  if (per100g == null) return null;
+  const value = (per100g * grams) / 100;
+  return Math.round(value * 10) / 10;
+}
+
+export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSelect }: MealEntryFormProps) {
+  const [mode, setMode] = useState<Mode>('manual');
+  const [mealType, setMealType] = useState<MealType>(initialMealType);
+  const [name, setName] = useState('');
+  const [calories, setCalories] = useState('');
+  const [protein, setProtein] = useState('');
+  const [carbs, setCarbs] = useState('');
+  const [fat, setFat] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Search tab state
+  const [selectedFood, setSelectedFood] = useState<FoodReference | null>(null);
+  const [portionGrams, setPortionGrams] = useState('100');
+
+  async function handleManualSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const kcal = Number.parseFloat(calories.replace(',', '.'));
+    if (!name.trim() || !Number.isFinite(kcal) || kcal < 0) {
+      setError('Nom et calories sont requis.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const ok = await onSubmit({
+        meal_type: mealType,
+        source: 'manual',
+        name: name.trim(),
+        calories: Math.round(kcal * 10) / 10,
+        protein_g: protein ? Number.parseFloat(protein.replace(',', '.')) : null,
+        carbs_g: carbs ? Number.parseFloat(carbs.replace(',', '.')) : null,
+        fat_g: fat ? Number.parseFloat(fat.replace(',', '.')) : null,
+        quantity_grams: null,
+        reference_id: null,
+        ai_metadata: null,
+        notes: notes.trim() || null,
+      });
+      if (ok) onCancel();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleSearchSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!selectedFood) {
+      setError('Sélectionne un aliment.');
+      return;
+    }
+    const grams = Number.parseFloat(portionGrams.replace(',', '.'));
+    if (!Number.isFinite(grams) || grams <= 0) {
+      setError('La quantité doit être un nombre positif.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (onSearchSelect) {
+        const ok = await onSearchSelect(selectedFood, grams);
+        if (ok) onCancel();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const scaledCalories = selectedFood
+    ? scaleByPortion(selectedFood.calories_100g, Number.parseFloat(portionGrams) || 0)
+    : null;
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-bold text-heading">Ajouter un repas</h2>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="p-2 rounded-lg text-muted hover:text-heading hover:bg-divider"
+          aria-label="Fermer"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <div className="flex gap-1 p-1 rounded-xl bg-surface border border-divider w-full">
+        {(['manual', 'search'] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => {
+              setMode(m);
+              setError(null);
+            }}
+            aria-pressed={mode === m}
+            className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+              mode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
+            }`}
+          >
+            {m === 'manual' ? 'Saisie libre' : 'Rechercher'}
+          </button>
+        ))}
+      </div>
+
+      <fieldset>
+        <legend className="block text-xs font-medium text-body mb-1">Repas</legend>
+        <div className="flex flex-wrap gap-1.5">
+          {MEAL_TYPES.map((mt) => (
+            <button
+              key={mt}
+              type="button"
+              onClick={() => setMealType(mt)}
+              aria-pressed={mealType === mt}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                mealType === mt ? 'bg-brand text-white' : 'bg-surface border border-divider text-body'
+              }`}
+            >
+              {MEAL_TYPE_LABELS[mt]}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {mode === 'manual' ? (
+        <form onSubmit={handleManualSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="meal-name" className="block text-xs font-medium text-body mb-1">
+              Nom du repas
+            </label>
+            <input
+              id="meal-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ex. pâtes bolo maison"
+              maxLength={200}
+              className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="meal-calories" className="block text-xs font-medium text-body mb-1">
+                Calories (kcal) <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="meal-calories"
+                type="number"
+                inputMode="decimal"
+                value={calories}
+                onChange={(e) => setCalories(e.target.value)}
+                min="0"
+                step="1"
+                placeholder="450"
+                className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+              />
+            </div>
+            <div>
+              <label htmlFor="meal-protein" className="block text-xs font-medium text-body mb-1">
+                Protéines (g)
+              </label>
+              <input
+                id="meal-protein"
+                type="number"
+                inputMode="decimal"
+                value={protein}
+                onChange={(e) => setProtein(e.target.value)}
+                min="0"
+                step="0.5"
+                placeholder="25"
+                className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+              />
+            </div>
+            <div>
+              <label htmlFor="meal-carbs" className="block text-xs font-medium text-body mb-1">
+                Glucides (g)
+              </label>
+              <input
+                id="meal-carbs"
+                type="number"
+                inputMode="decimal"
+                value={carbs}
+                onChange={(e) => setCarbs(e.target.value)}
+                min="0"
+                step="0.5"
+                className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+              />
+            </div>
+            <div>
+              <label htmlFor="meal-fat" className="block text-xs font-medium text-body mb-1">
+                Lipides (g)
+              </label>
+              <input
+                id="meal-fat"
+                type="number"
+                inputMode="decimal"
+                value={fat}
+                onChange={(e) => setFat(e.target.value)}
+                min="0"
+                step="0.5"
+                className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="meal-notes" className="block text-xs font-medium text-body mb-1">
+              Notes (optionnel)
+            </label>
+            <input
+              id="meal-notes"
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={500}
+              className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+            />
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 py-3 rounded-xl text-sm font-medium text-body border border-divider hover:bg-divider transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Ajout…' : 'Ajouter'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <form onSubmit={handleSearchSubmit} className="space-y-3">
+          <SearchPane
+            selectedFood={selectedFood}
+            onSelect={setSelectedFood}
+            portionGrams={portionGrams}
+            onPortionChange={setPortionGrams}
+            scaledCalories={scaledCalories}
+          />
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 py-3 rounded-xl text-sm font-medium text-body border border-divider hover:bg-divider transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !selectedFood}
+              className="flex-1 py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Ajout…' : 'Ajouter'}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+interface SearchPaneProps {
+  selectedFood: FoodReference | null;
+  onSelect: (food: FoodReference | null) => void;
+  portionGrams: string;
+  onPortionChange: (value: string) => void;
+  scaledCalories: number | null;
+}
+
+function SearchPane({ selectedFood, onSelect, portionGrams, onPortionChange, scaledCalories }: SearchPaneProps) {
+  if (selectedFood) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-xl bg-surface-card border border-divider p-4 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-sm text-heading font-medium">{selectedFood.name_fr}</p>
+            <button type="button" onClick={() => onSelect(null)} className="text-xs text-brand hover:underline">
+              Changer
+            </button>
+          </div>
+          <p className="text-xs text-muted">
+            Base :{' '}
+            {selectedFood.calories_100g != null
+              ? `${Math.round(selectedFood.calories_100g)} kcal / 100 g`
+              : 'calories indisponibles'}
+            {selectedFood.group_fr ? ` · ${selectedFood.group_fr}` : ''}
+          </p>
+        </div>
+        <div>
+          <label htmlFor="portion-grams" className="block text-xs font-medium text-body mb-1">
+            Quantité (g)
+          </label>
+          <input
+            id="portion-grams"
+            type="number"
+            inputMode="decimal"
+            min="1"
+            step="1"
+            value={portionGrams}
+            onChange={(e) => onPortionChange(e.target.value)}
+            className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+          />
+        </div>
+        {scaledCalories != null && (
+          <p className="text-sm text-body">
+            Soit <span className="font-bold text-brand">{Math.round(scaledCalories)} kcal</span> pour cette portion.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return <FoodSearchInput onSelect={onSelect} />;
+}

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -10,8 +10,14 @@ interface MealEntryFormProps {
   initialMealType: MealType;
   onSubmit: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
   onCancel: () => void;
-  searchSlot?: React.ReactNode;
-  onSearchSelect?: (food: FoodReference, quantityGrams: number) => Promise<boolean>;
+  onSearchSelect?: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+}
+
+function parseMacro(raw: string): number | null {
+  if (!raw) return null;
+  const n = Number.parseFloat(raw.replace(',', '.'));
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 10) / 10;
 }
 
 function scaleByPortion(per100g: number | null | undefined, grams: number): number | null {
@@ -51,9 +57,9 @@ export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSel
         source: 'manual',
         name: name.trim(),
         calories: Math.round(kcal * 10) / 10,
-        protein_g: protein ? Number.parseFloat(protein.replace(',', '.')) : null,
-        carbs_g: carbs ? Number.parseFloat(carbs.replace(',', '.')) : null,
-        fat_g: fat ? Number.parseFloat(fat.replace(',', '.')) : null,
+        protein_g: parseMacro(protein),
+        carbs_g: parseMacro(carbs),
+        fat_g: parseMacro(fat),
         quantity_grams: null,
         reference_id: null,
         ai_metadata: null,
@@ -80,7 +86,7 @@ export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSel
     setSubmitting(true);
     try {
       if (onSearchSelect) {
-        const ok = await onSearchSelect(selectedFood, grams);
+        const ok = await onSearchSelect(selectedFood, grams, mealType);
         if (ok) onCancel();
       }
     } finally {

--- a/src/components/nutrition/NutritionWidget.tsx
+++ b/src/components/nutrition/NutritionWidget.tsx
@@ -1,0 +1,46 @@
+import { ChevronRight, Utensils } from 'lucide-react';
+import { Link } from 'react-router';
+import { useDailyNutrition } from '../../hooks/useDailyNutrition.ts';
+import { CalorieRing } from './CalorieRing.tsx';
+
+/**
+ * Home widget. Summarizes today's calorie intake + remaining-vs-target and
+ * links to /nutrition. Hidden for visitors (no user → no fetch).
+ */
+export function NutritionWidget() {
+  const { summary, loading } = useDailyNutrition();
+
+  return (
+    <Link
+      to="/nutrition"
+      className="flex items-center gap-4 rounded-2xl border border-card-border bg-surface-card px-5 py-4 group hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10 transition-all"
+      aria-label="Suivi nutritionnel du jour"
+    >
+      <div className="shrink-0">
+        {loading ? (
+          <div className="w-20 h-20 rounded-full skeleton" />
+        ) : (
+          <CalorieRing current={summary.totals.calories} target={summary.target.calories} size={80} strokeWidth={8} />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <Utensils className="w-4 h-4 text-brand" aria-hidden="true" />
+          <h3 className="font-display text-base font-bold text-heading">Nutrition du jour</h3>
+        </div>
+        {summary.target.calories != null ? (
+          <p className="text-sm text-body">
+            {Math.round(summary.totals.calories)} kcal consommés — cible {summary.target.calories} kcal
+          </p>
+        ) : (
+          <p className="text-sm text-body">{Math.round(summary.totals.calories)} kcal consommés aujourd'hui</p>
+        )}
+        <p className="text-xs text-muted mt-1">Ajouter un repas →</p>
+      </div>
+      <ChevronRight
+        className="w-5 h-5 text-muted shrink-0 group-hover:text-brand transition-colors"
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}

--- a/src/components/nutrition/NutritionWidget.tsx
+++ b/src/components/nutrition/NutritionWidget.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, Utensils } from 'lucide-react';
 import { Link } from 'react-router';
 import { useDailyNutrition } from '../../hooks/useDailyNutrition.ts';
+import { useNutritionProfile } from '../../hooks/useNutritionProfile.ts';
 import { CalorieRing } from './CalorieRing.tsx';
 
 /**
@@ -8,7 +9,9 @@ import { CalorieRing } from './CalorieRing.tsx';
  * links to /nutrition. Hidden for visitors (no user → no fetch).
  */
 export function NutritionWidget() {
+  const { profile } = useNutritionProfile();
   const { summary, loading } = useDailyNutrition();
+  const targetCalories = profile?.target_calories ?? null;
 
   return (
     <Link
@@ -20,7 +23,7 @@ export function NutritionWidget() {
         {loading ? (
           <div className="w-20 h-20 rounded-full skeleton" />
         ) : (
-          <CalorieRing current={summary.totals.calories} target={summary.target.calories} size={80} strokeWidth={8} />
+          <CalorieRing current={summary.totals.calories} target={targetCalories} size={80} strokeWidth={8} />
         )}
       </div>
       <div className="flex-1 min-w-0">
@@ -28,9 +31,9 @@ export function NutritionWidget() {
           <Utensils className="w-4 h-4 text-brand" aria-hidden="true" />
           <h3 className="font-display text-base font-bold text-heading">Nutrition du jour</h3>
         </div>
-        {summary.target.calories != null ? (
+        {targetCalories != null ? (
           <p className="text-sm text-body">
-            {Math.round(summary.totals.calories)} kcal consommés — cible {summary.target.calories} kcal
+            {Math.round(summary.totals.calories)} kcal consommés — cible {targetCalories} kcal
           </p>
         ) : (
           <p className="text-sm text-body">{Math.round(summary.totals.calories)} kcal consommés aujourd'hui</p>

--- a/src/components/nutrition/TdeeCalculatorForm.tsx
+++ b/src/components/nutrition/TdeeCalculatorForm.tsx
@@ -72,7 +72,7 @@ export function TdeeCalculatorForm({ onAccept, onCancel }: TdeeCalculatorFormPro
   return (
     <div className="space-y-6">
       <div className="rounded-xl bg-surface-card border border-divider p-4 space-y-2">
-        <h2 className="font-display text-base font-bold text-heading">Calcul de ta cible calorique</h2>
+        <h3 className="font-display text-base font-bold text-heading">Calcul de ta cible calorique</h3>
         <p className="text-sm text-body leading-relaxed">
           Les informations ci-dessous sont utilisées <strong>uniquement dans ton navigateur</strong> pour estimer une
           cible calorique indicative. Elles ne sont jamais envoyées sur nos serveurs et seront oubliées dès que tu
@@ -200,7 +200,7 @@ export function TdeeCalculatorForm({ onAccept, onCancel }: TdeeCalculatorFormPro
 
       {preview && (
         <div className="rounded-xl bg-surface-card border border-brand/30 p-4 space-y-3">
-          <h3 className="font-display text-base font-bold text-heading">Ta cible estimée</h3>
+          <h4 className="font-display text-base font-bold text-heading">Ta cible estimée</h4>
           <p className="text-sm text-body">
             Métabolisme de base : <strong className="text-heading">{preview.bmr} kcal</strong>
             <br />

--- a/src/components/nutrition/TdeeCalculatorForm.tsx
+++ b/src/components/nutrition/TdeeCalculatorForm.tsx
@@ -1,0 +1,251 @@
+import { type FormEvent, useState } from 'react';
+import {
+  ACTIVITY_LEVEL_LABELS,
+  ACTIVITY_LEVELS,
+  NUTRITION_GOAL_LABELS,
+  NUTRITION_GOALS,
+  TDEE_BOUNDS,
+} from '../../config/nutrition.ts';
+import type { ActivityLevel, BiologicalSex, NutritionGoal, TdeeResult } from '../../types/nutrition.ts';
+import { computeTdee, validateTdeeInputs } from '../../utils/tdee.ts';
+
+interface TdeeCalculatorFormProps {
+  onAccept: (result: TdeeResult, activityLevel: ActivityLevel, goal: NutritionGoal) => Promise<void>;
+  onCancel: () => void;
+}
+
+const SEX_OPTIONS: { value: BiologicalSex; label: string }[] = [
+  { value: 'female', label: 'Femme' },
+  { value: 'male', label: 'Homme' },
+];
+
+/**
+ * Ephemeral onboarding form. Inputs (age, height, weight, sex) are kept in
+ * React state ONLY and are never sent to the server. Only the derived
+ * `targetCalories` and `activityLevel`/`goal` are persisted via onAccept.
+ */
+export function TdeeCalculatorForm({ onAccept, onCancel }: TdeeCalculatorFormProps) {
+  const [sex, setSex] = useState<BiologicalSex>('female');
+  const [ageYears, setAge] = useState('');
+  const [heightCm, setHeight] = useState('');
+  const [weightKg, setWeight] = useState('');
+  const [activityLevel, setActivity] = useState<ActivityLevel>('moderate');
+  const [goal, setGoal] = useState<NutritionGoal>('maintenance');
+  const [preview, setPreview] = useState<TdeeResult | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function parsed() {
+    return {
+      sex,
+      ageYears: Number.parseFloat(ageYears),
+      heightCm: Number.parseFloat(heightCm),
+      weightKg: Number.parseFloat(weightKg),
+      activityLevel,
+      goal,
+    };
+  }
+
+  function handleComputePreview(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const inputs = parsed();
+    const validation = validateTdeeInputs(inputs);
+    if (validation) {
+      setError(errorLabel(validation));
+      setPreview(null);
+      return;
+    }
+    setPreview(computeTdee(inputs));
+  }
+
+  async function handleAccept() {
+    if (!preview) return;
+    setSubmitting(true);
+    try {
+      await onAccept(preview, activityLevel, goal);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl bg-surface-card border border-divider p-4 space-y-2">
+        <h2 className="font-display text-base font-bold text-heading">Calcul de ta cible calorique</h2>
+        <p className="text-sm text-body leading-relaxed">
+          Les informations ci-dessous sont utilisées <strong>uniquement dans ton navigateur</strong> pour estimer une
+          cible calorique indicative. Elles ne sont jamais envoyées sur nos serveurs et seront oubliées dès que tu
+          fermes cette page.
+        </p>
+        <p className="text-xs text-muted italic">
+          Formule : Mifflin-St Jeor. Estimation ±150 kcal. Ajuste après 2 semaines selon ton ressenti.
+        </p>
+      </div>
+
+      <form onSubmit={handleComputePreview} className="space-y-4">
+        <div>
+          <fieldset>
+            <legend className="block text-xs font-medium text-body mb-1">Sexe biologique</legend>
+            <div className="flex gap-2">
+              {SEX_OPTIONS.map((opt) => (
+                <button
+                  type="button"
+                  key={opt.value}
+                  onClick={() => setSex(opt.value)}
+                  aria-pressed={sex === opt.value}
+                  className={`flex-1 px-3 py-2 rounded-xl text-sm font-medium border transition-colors ${
+                    sex === opt.value ? 'border-brand bg-brand/10 text-heading' : 'border-divider text-body'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label htmlFor="tdee-age" className="block text-xs font-medium text-body mb-1">
+              Âge (ans)
+            </label>
+            <input
+              id="tdee-age"
+              type="number"
+              inputMode="numeric"
+              min={TDEE_BOUNDS.age.min}
+              max={TDEE_BOUNDS.age.max}
+              value={ageYears}
+              onChange={(e) => setAge(e.target.value)}
+              className="w-full px-3 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+            />
+          </div>
+          <div>
+            <label htmlFor="tdee-height" className="block text-xs font-medium text-body mb-1">
+              Taille (cm)
+            </label>
+            <input
+              id="tdee-height"
+              type="number"
+              inputMode="decimal"
+              min={TDEE_BOUNDS.heightCm.min}
+              max={TDEE_BOUNDS.heightCm.max}
+              value={heightCm}
+              onChange={(e) => setHeight(e.target.value)}
+              className="w-full px-3 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+            />
+          </div>
+          <div>
+            <label htmlFor="tdee-weight" className="block text-xs font-medium text-body mb-1">
+              Poids (kg)
+            </label>
+            <input
+              id="tdee-weight"
+              type="number"
+              inputMode="decimal"
+              min={TDEE_BOUNDS.weightKg.min}
+              max={TDEE_BOUNDS.weightKg.max}
+              step="0.5"
+              value={weightKg}
+              onChange={(e) => setWeight(e.target.value)}
+              className="w-full px-3 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="tdee-activity" className="block text-xs font-medium text-body mb-1">
+            Niveau d'activité
+          </label>
+          <select
+            id="tdee-activity"
+            value={activityLevel}
+            onChange={(e) => setActivity(e.target.value as ActivityLevel)}
+            className="w-full px-3 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+          >
+            {ACTIVITY_LEVELS.map((lvl) => (
+              <option key={lvl} value={lvl}>
+                {ACTIVITY_LEVEL_LABELS[lvl]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <fieldset>
+          <legend className="block text-xs font-medium text-body mb-1">Objectif</legend>
+          <div className="flex flex-wrap gap-2">
+            {NUTRITION_GOALS.map((g) => (
+              <button
+                key={g}
+                type="button"
+                onClick={() => setGoal(g)}
+                aria-pressed={goal === g}
+                className={`flex-1 min-w-[120px] px-3 py-2 rounded-xl text-xs font-medium border transition-colors ${
+                  goal === g ? 'border-brand bg-brand/10 text-heading' : 'border-divider text-body'
+                }`}
+              >
+                {NUTRITION_GOAL_LABELS[g]}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+
+        <button type="submit" className="w-full py-3 rounded-xl text-sm font-bold text-white cta-gradient">
+          Calculer ma cible
+        </button>
+      </form>
+
+      {preview && (
+        <div className="rounded-xl bg-surface-card border border-brand/30 p-4 space-y-3">
+          <h3 className="font-display text-base font-bold text-heading">Ta cible estimée</h3>
+          <p className="text-sm text-body">
+            Métabolisme de base : <strong className="text-heading">{preview.bmr} kcal</strong>
+            <br />
+            Dépense totale estimée : <strong className="text-heading">{preview.tdee} kcal</strong>
+          </p>
+          <div className="rounded-lg bg-brand/10 border border-brand/30 p-3">
+            <p className="text-xs text-muted uppercase tracking-wider mb-1">Cible quotidienne</p>
+            <p className="font-display text-3xl font-black text-brand">{preview.targetCalories} kcal</p>
+            <p className="text-xs text-body mt-1">
+              Répartition indicative : {preview.targetProteinG} g protéines · {preview.targetCarbsG} g glucides ·{' '}
+              {preview.targetFatG} g lipides
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 py-3 rounded-xl text-sm font-medium text-body border border-divider hover:bg-divider transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="button"
+              onClick={handleAccept}
+              disabled={submitting}
+              className="flex-1 py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50"
+            >
+              {submitting ? 'Sauvegarde…' : 'Valider cette cible'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function errorLabel(err: string): string {
+  switch (err) {
+    case 'invalid_age':
+      return `L'âge doit être entre ${TDEE_BOUNDS.age.min} et ${TDEE_BOUNDS.age.max} ans.`;
+    case 'invalid_height':
+      return `La taille doit être entre ${TDEE_BOUNDS.heightCm.min} et ${TDEE_BOUNDS.heightCm.max} cm.`;
+    case 'invalid_weight':
+      return `Le poids doit être entre ${TDEE_BOUNDS.weightKg.min} et ${TDEE_BOUNDS.weightKg.max} kg.`;
+    default:
+      return 'Vérifie les informations saisies.';
+  }
+}

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type {
+  DailyNutritionSummary,
+  DailyNutritionTotals,
+  MealLog,
+  MealLogInsert,
+  MealType,
+} from '../types/nutrition.ts';
+import { todayYYYYMMDD } from '../utils/nutritionDate.ts';
+import { useNutritionProfile } from './useNutritionProfile.ts';
+
+const EMPTY_TOTALS: DailyNutritionTotals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 };
+
+function sumTotals(logs: MealLog[]): DailyNutritionTotals {
+  return logs.reduce(
+    (acc, log) => ({
+      calories: acc.calories + (log.calories ?? 0),
+      protein_g: acc.protein_g + (log.protein_g ?? 0),
+      carbs_g: acc.carbs_g + (log.carbs_g ?? 0),
+      fat_g: acc.fat_g + (log.fat_g ?? 0),
+    }),
+    EMPTY_TOTALS,
+  );
+}
+
+function groupByMealType(logs: MealLog[]): Partial<Record<MealType, MealLog[]>> {
+  const grouped: Partial<Record<MealType, MealLog[]>> = {};
+  for (const log of logs) {
+    let list = grouped[log.meal_type];
+    if (!list) {
+      list = [];
+      grouped[log.meal_type] = list;
+    }
+    list.push(log);
+  }
+  return grouped;
+}
+
+export interface UseDailyNutritionResult {
+  summary: DailyNutritionSummary;
+  logs: MealLog[];
+  loading: boolean;
+  error: string | null;
+  addMeal: (input: Omit<MealLogInsert, 'logged_date'> & { logged_date?: string }) => Promise<MealLog | null>;
+  deleteMeal: (id: string) => Promise<boolean>;
+  refresh: () => void;
+}
+
+export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNutritionResult {
+  const { user, dataGeneration } = useAuth();
+  const userId = user?.id;
+  const { profile } = useNutritionProfile();
+  const [logs, setLogs] = useState<MealLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [localGeneration, setLocalGeneration] = useState(0);
+  const inflightRef = useRef(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration + localGeneration force re-fetch
+  useEffect(() => {
+    if (!userId || !supabase) {
+      setLogs([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const {
+          data,
+          error: err,
+          sessionExpired,
+        } = await supabaseQuery(() =>
+          supabase!
+            .from('meal_logs')
+            .select('*')
+            .eq('user_id', userId)
+            .eq('logged_date', dateKey)
+            .order('created_at', { ascending: true }),
+        );
+        if (cancelled) return;
+        if (sessionExpired) {
+          notifySessionExpired();
+          setLoading(false);
+          return;
+        }
+        if (err) {
+          setError(err.message ?? 'Erreur de chargement des repas');
+          setLoading(false);
+          return;
+        }
+        setLogs((data ?? []) as MealLog[]);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Erreur inconnue');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, dateKey, dataGeneration, localGeneration]);
+
+  const addMeal = useCallback(
+    async (input: Omit<MealLogInsert, 'logged_date'> & { logged_date?: string }) => {
+      if (!userId || !supabase) return null;
+      if (inflightRef.current) return null;
+      inflightRef.current = true;
+      try {
+        const payload = { ...input, user_id: userId, logged_date: input.logged_date ?? dateKey };
+        const {
+          data,
+          error: err,
+          sessionExpired,
+        } = await supabaseQuery(() => supabase!.from('meal_logs').insert(payload).select().single());
+        if (sessionExpired) {
+          notifySessionExpired();
+          return null;
+        }
+        if (err) {
+          setError(err.message ?? "Erreur lors de l'ajout du repas");
+          return null;
+        }
+        const inserted = data as MealLog;
+        setLogs((prev) => [...prev, inserted]);
+        return inserted;
+      } finally {
+        inflightRef.current = false;
+      }
+    },
+    [userId, dateKey],
+  );
+
+  const deleteMeal = useCallback(
+    async (id: string) => {
+      if (!userId || !supabase) return false;
+      const { error: err, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('meal_logs').delete().eq('id', id).eq('user_id', userId).select().single(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return false;
+      }
+      if (err) {
+        setError(err.message ?? 'Erreur lors de la suppression');
+        return false;
+      }
+      setLogs((prev) => prev.filter((l) => l.id !== id));
+      return true;
+    },
+    [userId],
+  );
+
+  const refresh = useCallback(() => {
+    setLocalGeneration((g) => g + 1);
+  }, []);
+
+  const summary = useMemo<DailyNutritionSummary>(() => {
+    const totals = sumTotals(logs);
+    const byMealType = groupByMealType(logs);
+    return {
+      date: dateKey,
+      totals,
+      byMealType,
+      target: {
+        calories: profile?.target_calories ?? null,
+        protein_g: profile?.target_protein_g ?? null,
+        carbs_g: profile?.target_carbs_g ?? null,
+        fat_g: profile?.target_fat_g ?? null,
+      },
+    };
+  }, [logs, profile, dateKey]);
+
+  return { summary, logs, loading, error, addMeal, deleteMeal, refresh };
+}

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -10,7 +10,6 @@ import type {
   MealType,
 } from '../types/nutrition.ts';
 import { todayYYYYMMDD } from '../utils/nutritionDate.ts';
-import { useNutritionProfile } from './useNutritionProfile.ts';
 
 const EMPTY_TOTALS: DailyNutritionTotals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 };
 
@@ -52,7 +51,6 @@ export interface UseDailyNutritionResult {
 export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNutritionResult {
   const { user, dataGeneration } = useAuth();
   const userId = user?.id;
-  const { profile } = useNutritionProfile();
   const [logs, setLogs] = useState<MealLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -169,14 +167,11 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
       date: dateKey,
       totals,
       byMealType,
-      target: {
-        calories: profile?.target_calories ?? null,
-        protein_g: profile?.target_protein_g ?? null,
-        carbs_g: profile?.target_carbs_g ?? null,
-        fat_g: profile?.target_fat_g ?? null,
-      },
+      // Target is resolved at the consumer level via useNutritionProfile to
+      // avoid duplicate fetches when both hooks are used on the same page.
+      target: { calories: null, protein_g: null, carbs_g: null, fat_g: null },
     };
-  }, [logs, profile, dateKey]);
+  }, [logs, dateKey]);
 
   return { summary, logs, loading, error, addMeal, deleteMeal, refresh };
 }

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -30,6 +30,12 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
       return;
     }
 
+    // Escape PostgreSQL LIKE wildcards so user-typed % or _ are treated as
+    // literals. PostgREST has no parameterized escape for ilike patterns, so
+    // we prepend a backslash to both special chars and use `\\` as the escape
+    // character — still trigram-indexable for the surrounding `%...%` part.
+    const escaped = trimmed.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+
     let cancelled = false;
     setLoading(true);
     const timer = setTimeout(async () => {
@@ -42,7 +48,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
           supabase!
             .from('food_reference')
             .select('*')
-            .ilike('name_fr', `%${trimmed}%`)
+            .ilike('name_fr', `%${escaped}%`)
             .order('name_fr', { ascending: true })
             .limit(RESULTS_LIMIT),
         );

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type { FoodReference } from '../types/nutrition.ts';
+
+const DEBOUNCE_MS = 200;
+const RESULTS_LIMIT = 12;
+
+export interface UseFoodSearchResult {
+  results: FoodReference[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Debounced fuzzy search over public.food_reference (CIQUAL).
+ * Uses the `ilike` operator over the trigram-indexed `name_fr` column.
+ */
+export function useFoodSearch(query: string): UseFoodSearchResult {
+  const [results, setResults] = useState<FoodReference[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2 || !supabase) {
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      try {
+        const {
+          data,
+          error: err,
+          sessionExpired,
+        } = await supabaseQuery(() =>
+          supabase!
+            .from('food_reference')
+            .select('*')
+            .ilike('name_fr', `%${trimmed}%`)
+            .order('name_fr', { ascending: true })
+            .limit(RESULTS_LIMIT),
+        );
+        if (cancelled) return;
+        if (sessionExpired) {
+          notifySessionExpired();
+          setLoading(false);
+          return;
+        }
+        if (err) {
+          setError(err.message ?? 'Erreur de recherche');
+          setLoading(false);
+          return;
+        }
+        setResults((data ?? []) as FoodReference[]);
+        setError(null);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Erreur inconnue');
+          setLoading(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  return { results, loading, error };
+}

--- a/src/hooks/useNutritionProfile.ts
+++ b/src/hooks/useNutritionProfile.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type { NutritionProfile, NutritionProfileUpsert } from '../types/nutrition.ts';
+
+export interface UseNutritionProfileResult {
+  profile: NutritionProfile | null;
+  loading: boolean;
+  error: string | null;
+  upsert: (patch: NutritionProfileUpsert) => Promise<NutritionProfile | null>;
+  clearTarget: () => Promise<void>;
+  refresh: () => void;
+}
+
+export function useNutritionProfile(): UseNutritionProfileResult {
+  const { user, dataGeneration } = useAuth();
+  const userId = user?.id;
+  const [profile, setProfile] = useState<NutritionProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [localGeneration, setLocalGeneration] = useState(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration + localGeneration force re-fetch
+  useEffect(() => {
+    if (!userId || !supabase) {
+      setProfile(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const {
+          data,
+          error: err,
+          sessionExpired,
+        } = await supabaseQuery(() =>
+          supabase!.from('nutrition_profiles').select('*').eq('user_id', userId).maybeSingle(),
+        );
+        if (cancelled) return;
+        if (sessionExpired) {
+          notifySessionExpired();
+          setLoading(false);
+          return;
+        }
+        if (err) {
+          setError(err.message ?? 'Erreur de chargement du profil');
+          setLoading(false);
+          return;
+        }
+        setProfile((data as NutritionProfile | null) ?? null);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Erreur inconnue');
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, dataGeneration, localGeneration]);
+
+  const upsert = useCallback(
+    async (patch: NutritionProfileUpsert) => {
+      if (!userId || !supabase) return null;
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('nutrition_profiles')
+          .upsert({ user_id: userId, ...patch }, { onConflict: 'user_id' })
+          .select()
+          .single(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return null;
+      }
+      if (err) {
+        setError(err.message ?? 'Erreur de sauvegarde');
+        return null;
+      }
+      const next = data as NutritionProfile | null;
+      setProfile(next);
+      return next;
+    },
+    [userId],
+  );
+
+  const clearTarget = useCallback(async () => {
+    await upsert({
+      target_calories: null,
+      target_protein_g: null,
+      target_carbs_g: null,
+      target_fat_g: null,
+      goal: null,
+      activity_level: null,
+    });
+  }, [upsert]);
+
+  const refresh = useCallback(() => {
+    setLocalGeneration((g) => g + 1);
+  }, []);
+
+  return { profile, loading, error, upsert, clearTarget, refresh };
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,9 +11,7 @@ const LazyHome = lazy(() => import('./components/Home.tsx').then((m) => ({ defau
 const LazyFormats = lazy(() => import('./components/Formats.tsx').then((m) => ({ default: m.Formats })));
 const LazyExercises = lazy(() => import('./components/Exercises.tsx').then((m) => ({ default: m.Exercises })));
 const LazyPlayerPage = lazy(() => import('./components/Player.tsx').then((m) => ({ default: m.PlayerPage })));
-const LazyNotFoundPage = lazy(() =>
-  import('./components/NotFoundPage.tsx').then((m) => ({ default: m.NotFoundPage })),
-);
+const LazyNotFoundPage = lazy(() => import('./components/NotFoundPage.tsx').then((m) => ({ default: m.NotFoundPage })));
 const LazyLegal = lazy(() => import('./components/Legal.tsx').then((m) => ({ default: m.Legal })));
 const LazyFormatPage = lazy(() => import('./components/FormatPage.tsx').then((m) => ({ default: m.FormatPage })));
 const LazyExercisePage = lazy(() => import('./components/ExercisePage.tsx').then((m) => ({ default: m.ExercisePage })));
@@ -22,9 +20,7 @@ const LazySignupPage = lazy(() => import('./components/auth/SignupPage.tsx').the
 const LazyAuthCallback = lazy(() =>
   import('./components/auth/AuthCallback.tsx').then((m) => ({ default: m.AuthCallback })),
 );
-const LazyStatsPage = lazy(() =>
-  import('./components/auth/StatsPage.tsx').then((m) => ({ default: m.StatsPage })),
-);
+const LazyStatsPage = lazy(() => import('./components/auth/StatsPage.tsx').then((m) => ({ default: m.StatsPage })));
 const LazySettingsPage = lazy(() =>
   import('./components/auth/SettingsPage.tsx').then((m) => ({ default: m.SettingsPage })),
 );
@@ -55,17 +51,17 @@ const LazyCustomSessionPreviewPage = lazy(() =>
 const LazyCustomPlayerPage = lazy(() =>
   import('./components/CustomPlayerPage.tsx').then((m) => ({ default: m.CustomPlayerPage })),
 );
-const LazyPricingPage = lazy(() =>
-  import('./components/PricingPage.tsx').then((m) => ({ default: m.PricingPage })),
-);
+const LazyPricingPage = lazy(() => import('./components/PricingPage.tsx').then((m) => ({ default: m.PricingPage })));
 const LazyPremiumPromoPage = lazy(() =>
   import('./components/PremiumPromoPage.tsx').then((m) => ({ default: m.PremiumPromoPage })),
 );
-const LazyAboutPage = lazy(() =>
-  import('./components/AboutPage.tsx').then((m) => ({ default: m.AboutPage })),
+const LazyAboutPage = lazy(() => import('./components/AboutPage.tsx').then((m) => ({ default: m.AboutPage })));
+const LazySeancesPage = lazy(() => import('./components/SeancesPage.tsx').then((m) => ({ default: m.SeancesPage })));
+const LazyNutritionPage = lazy(() =>
+  import('./components/NutritionPage.tsx').then((m) => ({ default: m.NutritionPage })),
 );
-const LazySeancesPage = lazy(() =>
-  import('./components/SeancesPage.tsx').then((m) => ({ default: m.SeancesPage })),
+const LazyNutritionSetupPage = lazy(() =>
+  import('./components/NutritionSetupPage.tsx').then((m) => ({ default: m.NutritionSetupPage })),
 );
 
 function Lazy({ children }: { children: React.ReactNode }) {
@@ -191,6 +187,26 @@ export const router = createBrowserRouter([
           <Lazy>
             <RequireAuth>
               <LazySeancesPage />
+            </RequireAuth>
+          </Lazy>
+        ),
+      },
+      {
+        path: 'nutrition',
+        element: (
+          <Lazy>
+            <RequireAuth>
+              <LazyNutritionPage />
+            </RequireAuth>
+          </Lazy>
+        ),
+      },
+      {
+        path: 'nutrition/setup',
+        element: (
+          <Lazy>
+            <RequireAuth>
+              <LazyNutritionSetupPage />
             </RequireAuth>
           </Lazy>
         ),

--- a/src/utils/nutritionDate.test.ts
+++ b/src/utils/nutritionDate.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { formatDateLabel, formatLocalYYYYMMDD, parseYYYYMMDD, shiftYYYYMMDD } from './nutritionDate.ts';
+
+describe('formatLocalYYYYMMDD', () => {
+  it('uses local getters, not UTC', () => {
+    // Construct a local date; explicit fields to pin the result.
+    const d = new Date(2026, 3, 17); // 2026-04-17 local
+    expect(formatLocalYYYYMMDD(d)).toBe('20260417');
+  });
+
+  it('pads month and day', () => {
+    const d = new Date(2026, 0, 5); // 2026-01-05 local
+    expect(formatLocalYYYYMMDD(d)).toBe('20260105');
+  });
+});
+
+describe('parseYYYYMMDD', () => {
+  it('parses a valid date', () => {
+    const d = parseYYYYMMDD('20260417');
+    expect(d?.getFullYear()).toBe(2026);
+    expect(d?.getMonth()).toBe(3);
+    expect(d?.getDate()).toBe(17);
+  });
+
+  it('rejects invalid format', () => {
+    expect(parseYYYYMMDD('2026-04-17')).toBeNull();
+    expect(parseYYYYMMDD('abc')).toBeNull();
+    expect(parseYYYYMMDD('')).toBeNull();
+  });
+
+  it('rejects overflowed day (e.g. Feb 30)', () => {
+    expect(parseYYYYMMDD('20260230')).toBeNull();
+  });
+});
+
+describe('shiftYYYYMMDD', () => {
+  it('shifts forward and backward', () => {
+    expect(shiftYYYYMMDD('20260417', 1)).toBe('20260418');
+    expect(shiftYYYYMMDD('20260417', -1)).toBe('20260416');
+  });
+
+  it('rolls over month boundaries', () => {
+    expect(shiftYYYYMMDD('20260430', 1)).toBe('20260501');
+    expect(shiftYYYYMMDD('20260301', -1)).toBe('20260228');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(shiftYYYYMMDD('bad', 1)).toBeNull();
+  });
+});
+
+describe('formatDateLabel', () => {
+  const now = new Date(2026, 3, 17); // 2026-04-17
+
+  it('returns today/yesterday/tomorrow', () => {
+    expect(formatDateLabel('20260417', now)).toBe("aujourd'hui");
+    expect(formatDateLabel('20260416', now)).toBe('hier');
+    expect(formatDateLabel('20260418', now)).toBe('demain');
+  });
+
+  it('falls back to French short date', () => {
+    const label = formatDateLabel('20260410', now);
+    expect(label).toMatch(/avr/i);
+  });
+});

--- a/src/utils/nutritionDate.ts
+++ b/src/utils/nutritionDate.ts
@@ -1,0 +1,59 @@
+/**
+ * YYYYMMDD helpers for meal_logs.logged_date.
+ *
+ * Critical: we MUST format using the user's LOCAL date. Using `toISOString()`
+ * would use UTC and drift by ±1 day for users outside UTC±1h (e.g. a 23h dinner
+ * in Paris would land on the next day). This convention matches the existing
+ * `session_completions.session_date` format.
+ */
+export function formatLocalYYYYMMDD(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}${m}${d}`;
+}
+
+export function parseYYYYMMDD(value: string): Date | null {
+  if (!/^\d{8}$/.test(value)) return null;
+  const y = Number.parseInt(value.slice(0, 4), 10);
+  const m = Number.parseInt(value.slice(4, 6), 10) - 1;
+  const d = Number.parseInt(value.slice(6, 8), 10);
+  const date = new Date(y, m, d);
+  // Sanity: did the Date constructor roll over? e.g. 20260230 → March 2
+  if (date.getFullYear() !== y || date.getMonth() !== m || date.getDate() !== d) return null;
+  return date;
+}
+
+export function todayYYYYMMDD(): string {
+  return formatLocalYYYYMMDD(new Date());
+}
+
+/**
+ * Shifts a YYYYMMDD string by `days` (positive or negative) in the local
+ * timezone. Returns a new YYYYMMDD string, or null if the input is invalid.
+ */
+export function shiftYYYYMMDD(value: string, days: number): string | null {
+  const parsed = parseYYYYMMDD(value);
+  if (!parsed) return null;
+  parsed.setDate(parsed.getDate() + days);
+  return formatLocalYYYYMMDD(parsed);
+}
+
+/**
+ * Human-readable label like "aujourd'hui", "hier", or "lun. 17 avr.".
+ * Locale-aware French.
+ */
+export function formatDateLabel(value: string, now: Date = new Date()): string {
+  const parsed = parseYYYYMMDD(value);
+  if (!parsed) return value;
+
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((today.getTime() - parsed.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "aujourd'hui";
+  if (diffDays === 1) return 'hier';
+  if (diffDays === -1) return 'demain';
+
+  return parsed.toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric', month: 'short' });
+}


### PR DESCRIPTION
## Summary

PR 3/6 — UX nutrition free tier complète sans IA. Les utilisateurs peuvent désormais :

- Logger leurs repas manuellement (nom + kcal + macros optionnelles)
- Rechercher dans la base CIQUAL (~3 000 aliments FR) avec portion personnalisée
- Définir une cible calorique (optionnelle) soit en saisie directe, soit via un calculateur Mifflin-St Jeor **100% éphémère** (âge/poids/taille ne quittent jamais le navigateur)
- Consulter leur journée : ring de progression + macros + feed groupé par repas

## Privacy by design — vérification

Le formulaire \`TdeeCalculatorForm\` garde \`sex\`, \`ageYears\`, \`heightCm\`, \`weightKg\` dans le state React exclusivement. Seuls \`target_calories\` + \`target_protein_g\` + \`target_carbs_g\` + \`target_fat_g\` + \`goal\` + \`activity_level\` sont persistés via \`upsert\`. Les données brutes sont perdues dès que l'utilisateur quitte la page.

## Navigation

- Desktop (\`BrandHeader\`) : nouvel item "Nutrition" entre Tarifs et Suivi
- Mobile (\`BottomNav\`, user connecté) : remplace "Explorer" par "Nutrition"
- Home (\`ConnectedContent\`) : \`NutritionWidget\` inséré entre les 3 colonnes d'action et la TomorrowCard

## Test plan

- [x] \`npm run build\` — OK
- [x] \`npx vitest run\` — 205/205 (incluant 10 nouveaux tests nutritionDate)
- [x] \`npx biome check\` sur les fichiers nouveaux — clean (a11y labels + noAssignInExpressions corrigés)
- [ ] **Recette Chrome non effectuée** (extension MCP non connectée dans l'env de dev). Vérifications manuelles à faire par le PO :
  - Connecté : \`/nutrition\` affiche le ring + macros + feed vide avec CTA "Ajouter" par repas
  - Saisie manuelle : ajout d'un repas met à jour les totaux sans rechargement
  - Recherche CIQUAL : taper "pomme" déclenche autocomplete après 200ms ; sélection + portion → kcal scalé correctement
  - Onboarding \`/nutrition/setup\` : vérifier via DevTools Network que seuls \`target_*\` + \`goal\` + \`activity_level\` partent vers Supabase (jamais \`ageYears\`, \`heightCm\`, \`weightKg\`, \`sex\`)
  - Widget Home : clic → redirige sur \`/nutrition\`
  - Mobile : BottomNav affiche bien "Nutrition" à la place d'"Explorer" pour user connecté

## Pré-requis

- Migration 014 appliquée (PR 1 mergée)
- Seed CIQUAL effectué (PR 2 mergée) — sinon la recherche retourne vide mais ne casse pas l'UX

## Étapes suivantes

- PR 4 : scan code-barres Open Food Facts
- PR 5 : edge function IA (texte libre + débordement)
- PR 6 : CGU/RGPD + re-validation users existants

🤖 Generated with [Claude Code](https://claude.com/claude-code)