### PR TITLE
feat(nutrition): barcode scanning via Open Food Facts (PR 4/6)

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import { useDailyNutrition } from '../hooks/useDailyNutrition.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useNutritionProfile } from '../hooks/useNutritionProfile.ts';
+import type { OpenFoodFactsProduct } from '../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../types/nutrition.ts';
 import { CalorieRing } from './nutrition/CalorieRing.tsx';
 import { DailyFeed } from './nutrition/DailyFeed.tsx';
@@ -62,6 +63,30 @@ export function NutritionPage() {
       fat_g: scaled(food.fat_100g),
       quantity_grams: Math.round(quantityGrams * 10) / 10,
       reference_id: food.id,
+      ai_metadata: null,
+      notes: null,
+    });
+    return result != null;
+  }
+
+  async function handleBarcodeSelect(
+    product: OpenFoodFactsProduct,
+    quantityGrams: number,
+    mealType: MealType,
+  ): Promise<boolean> {
+    const factor = quantityGrams / 100;
+    const scaled = (per100: number | null) => (per100 != null ? Math.round(per100 * factor * 10) / 10 : null);
+    const name = product.brand ? `${product.name} (${product.brand})` : product.name;
+    const result = await addMeal({
+      meal_type: mealType,
+      source: 'barcode',
+      name: name.slice(0, 200),
+      calories: scaled(product.calories_100g) ?? 0,
+      protein_g: scaled(product.protein_100g),
+      carbs_g: scaled(product.carbs_100g),
+      fat_g: scaled(product.fat_100g),
+      quantity_grams: Math.round(quantityGrams * 10) / 10,
+      reference_id: product.barcode,
       ai_metadata: null,
       notes: null,
     });
@@ -152,6 +177,7 @@ export function NutritionPage() {
                 initialMealType={initialMealType}
                 onSubmit={handleSubmit}
                 onSearchSelect={handleSearchSelect}
+                onBarcodeSelect={handleBarcodeSelect}
                 onCancel={() => setFormOpen(false)}
               />
             </div>

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -1,0 +1,162 @@
+import { type FormEvent, useCallback, useEffect, useState } from 'react';
+import { useOpenFoodFacts } from '../../hooks/useOpenFoodFacts.ts';
+import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
+import type { MealType } from '../../types/nutrition.ts';
+import { BarcodeScanner } from './BarcodeScanner.tsx';
+
+interface BarcodePaneProps {
+  mealType: MealType;
+  onSubmit: (product: OpenFoodFactsProduct, quantityGrams: number) => Promise<boolean>;
+  onCancel: () => void;
+}
+
+function scaleKcal(per100g: number | null, grams: number): number {
+  if (per100g == null || grams <= 0) return 0;
+  return Math.round(((per100g * grams) / 100) * 10) / 10;
+}
+
+const ERROR_LABELS: Record<string, string> = {
+  invalid_barcode: 'Code-barres invalide. Utilise un EAN-8, EAN-13, UPC-A ou UPC-E.',
+  not_found: "Ce produit n'est pas référencé sur Open Food Facts.",
+  missing_nutrition: 'Ce produit est référencé mais ses données nutritionnelles sont incomplètes.',
+  network: 'Impossible de contacter Open Food Facts. Vérifie ta connexion.',
+};
+
+export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) {
+  const { product, loading, error, fetchByBarcode, reset } = useOpenFoodFacts();
+  const [showScanner, setShowScanner] = useState(true);
+  const [portionGrams, setPortionGrams] = useState('100');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => reset, [reset]);
+
+  const handleDetected = useCallback(
+    (barcode: string) => {
+      setShowScanner(false);
+      fetchByBarcode(barcode);
+    },
+    [fetchByBarcode],
+  );
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!product) return;
+    const grams = Number.parseFloat(portionGrams.replace(',', '.'));
+    if (!Number.isFinite(grams) || grams <= 0) {
+      setFormError('La quantité doit être un nombre positif.');
+      return;
+    }
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(product, grams);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (showScanner) {
+    return <BarcodeScanner onDetected={handleDetected} onClose={onCancel} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted">
+          Repas : <span className="text-body font-medium">{mealType}</span>
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setShowScanner(true);
+          }}
+          className="text-xs text-brand hover:underline"
+        >
+          Scanner un autre
+        </button>
+      </div>
+
+      {loading && <p className="text-sm text-body">Recherche sur Open Food Facts…</p>}
+
+      {error && <p className="text-sm text-red-400">{ERROR_LABELS[error] ?? 'Erreur inconnue.'}</p>}
+
+      {product && (
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="flex items-start gap-3 rounded-xl bg-surface-card border border-divider p-3">
+            {product.image_url && (
+              <img
+                src={product.image_url}
+                alt=""
+                className="w-16 h-16 rounded-lg object-cover bg-surface shrink-0"
+                loading="lazy"
+              />
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-heading font-medium truncate">{product.name}</p>
+              {product.brand && <p className="text-xs text-muted">{product.brand}</p>}
+              <p className="text-xs text-muted mt-1">
+                {product.calories_100g != null
+                  ? `${Math.round(product.calories_100g)} kcal / 100 g`
+                  : 'kcal manquantes'}
+                {product.quantity ? ` · ${product.quantity}` : ''}
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="barcode-portion" className="block text-xs font-medium text-body mb-1">
+              Quantité consommée (g)
+            </label>
+            <input
+              id="barcode-portion"
+              type="number"
+              inputMode="decimal"
+              min="1"
+              step="1"
+              value={portionGrams}
+              onChange={(e) => setPortionGrams(e.target.value)}
+              className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading focus:outline-none focus:border-brand"
+            />
+          </div>
+
+          <p className="text-sm text-body">
+            Soit{' '}
+            <span className="font-bold text-brand">
+              {Math.round(scaleKcal(product.calories_100g, Number.parseFloat(portionGrams) || 0))} kcal
+            </span>{' '}
+            pour cette portion.
+          </p>
+
+          {formError && <p className="text-xs text-red-400">{formError}</p>}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 py-3 rounded-xl text-sm font-medium text-body border border-divider hover:bg-divider transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Ajout…' : 'Ajouter'}
+            </button>
+          </div>
+
+          <p className="text-[11px] text-muted italic">
+            Données fournies via{' '}
+            <a href={product.source_url} target="_blank" rel="noreferrer noopener" className="underline">
+              Open Food Facts
+            </a>{' '}
+            (licence ODbL).
+          </p>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -29,7 +29,8 @@ export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) 
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  useEffect(() => reset, [reset]);
+  // Cancel in-flight OFF fetch + clear state when the pane unmounts.
+  useEffect(() => () => reset(), [reset]);
 
   const handleDetected = useCallback(
     (barcode: string) => {

--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -30,6 +30,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const rafRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
   const [status, setStatus] = useState<DetectorStatus>('idle');
   const [manualBarcode, setManualBarcode] = useState('');
   const [manualError, setManualError] = useState<string | null>(null);
@@ -46,6 +47,9 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   }, []);
 
   const startCamera = useCallback(async () => {
+    const releaseTracks = (s: MediaStream) => {
+      for (const track of s.getTracks()) track.stop();
+    };
     const g = globalThis as unknown as GlobalWithBarcodeDetector;
     if (!g.BarcodeDetector) {
       setStatus('unsupported');
@@ -57,14 +61,25 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
         video: { facingMode: { ideal: 'environment' } },
         audio: false,
       });
+      // Unmount-during-await guard: release the stream instead of attaching it
+      // to a ref that nothing will stop.
+      if (!mountedRef.current) {
+        releaseTracks(stream);
+        return;
+      }
       streamRef.current = stream;
       const video = videoRef.current;
       if (!video) {
-        for (const track of stream.getTracks()) track.stop();
+        releaseTracks(stream);
+        streamRef.current = null;
         return;
       }
       video.srcObject = stream;
       await video.play();
+      if (!mountedRef.current) {
+        stopCamera();
+        return;
+      }
       setStatus('scanning');
 
       const DetectorCtor = g.BarcodeDetector;
@@ -76,13 +91,13 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
       const detector = new DetectorCtor({ formats: SUPPORTED_FORMATS });
 
       const tick = async () => {
-        if (!videoRef.current || !streamRef.current) return;
+        if (!mountedRef.current || !videoRef.current || !streamRef.current) return;
         try {
           const results = await detector.detect(videoRef.current);
           if (results.length > 0) {
             const barcode = results[0].rawValue;
             stopCamera();
-            onDetected(barcode);
+            if (mountedRef.current) onDetected(barcode);
             return;
           }
         } catch {
@@ -92,6 +107,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
       };
       rafRef.current = requestAnimationFrame(tick);
     } catch (err) {
+      if (!mountedRef.current) return;
       const name = err instanceof Error ? err.name : '';
       if (name === 'NotAllowedError' || name === 'SecurityError') {
         setStatus('permission_denied');
@@ -103,8 +119,10 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   }, [onDetected, stopCamera]);
 
   useEffect(() => {
+    mountedRef.current = true;
     startCamera();
     return () => {
+      mountedRef.current = false;
       stopCamera();
     };
   }, [startCamera, stopCamera]);
@@ -148,9 +166,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
             playsInline
             muted
             aria-label="Aperçu caméra pour scan de code-barres"
-          >
-            <track kind="captions" />
-          </video>
+          />
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
             <div className="w-3/4 h-20 border-2 border-brand/80 rounded-lg" />
           </div>

--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -1,0 +1,204 @@
+import { ScanLine } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface BarcodeScannerProps {
+  onDetected: (barcode: string) => void;
+  onClose: () => void;
+}
+
+type DetectorStatus = 'idle' | 'supported' | 'unsupported' | 'permission_denied' | 'starting' | 'scanning' | 'error';
+
+interface GlobalWithBarcodeDetector {
+  BarcodeDetector?: new (options?: {
+    formats?: string[];
+  }) => {
+    detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string }>>;
+  };
+}
+
+const SUPPORTED_FORMATS = ['ean_13', 'ean_8', 'upc_a', 'upc_e'];
+
+/**
+ * Camera-based barcode scanner using the native BarcodeDetector API.
+ * Falls back to a manual input when the API is unavailable (iOS Safari).
+ *
+ * The component releases the camera stream on unmount and when the user
+ * closes the scanner. The video stream is NEVER recorded nor uploaded —
+ * we only decode locally and forward the decoded string.
+ */
+export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<DetectorStatus>('idle');
+  const [manualBarcode, setManualBarcode] = useState('');
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  const stopCamera = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) track.stop();
+      streamRef.current = null;
+    }
+  }, []);
+
+  const startCamera = useCallback(async () => {
+    const g = globalThis as unknown as GlobalWithBarcodeDetector;
+    if (!g.BarcodeDetector) {
+      setStatus('unsupported');
+      return;
+    }
+    setStatus('starting');
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
+        audio: false,
+      });
+      streamRef.current = stream;
+      const video = videoRef.current;
+      if (!video) {
+        for (const track of stream.getTracks()) track.stop();
+        return;
+      }
+      video.srcObject = stream;
+      await video.play();
+      setStatus('scanning');
+
+      const DetectorCtor = g.BarcodeDetector;
+      if (!DetectorCtor) {
+        setStatus('unsupported');
+        stopCamera();
+        return;
+      }
+      const detector = new DetectorCtor({ formats: SUPPORTED_FORMATS });
+
+      const tick = async () => {
+        if (!videoRef.current || !streamRef.current) return;
+        try {
+          const results = await detector.detect(videoRef.current);
+          if (results.length > 0) {
+            const barcode = results[0].rawValue;
+            stopCamera();
+            onDetected(barcode);
+            return;
+          }
+        } catch {
+          // transient detection errors are expected; keep trying
+        }
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    } catch (err) {
+      const name = err instanceof Error ? err.name : '';
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        setStatus('permission_denied');
+      } else {
+        setStatus('error');
+      }
+      stopCamera();
+    }
+  }, [onDetected, stopCamera]);
+
+  useEffect(() => {
+    startCamera();
+    return () => {
+      stopCamera();
+    };
+  }, [startCamera, stopCamera]);
+
+  function handleManualSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = manualBarcode.replace(/\s+/g, '');
+    if (!/^[0-9]{8,14}$/.test(trimmed)) {
+      setManualError('Le code-barres doit contenir 8 à 14 chiffres.');
+      return;
+    }
+    setManualError(null);
+    stopCamera();
+    onDetected(trimmed);
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ScanLine className="w-4 h-4 text-brand" aria-hidden="true" />
+          <h3 className="font-display text-base font-bold text-heading">Scanner un code-barres</h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            stopCamera();
+            onClose();
+          }}
+          className="text-xs text-muted hover:text-heading"
+        >
+          Fermer
+        </button>
+      </header>
+
+      {(status === 'starting' || status === 'scanning') && (
+        <div className="relative rounded-xl overflow-hidden bg-black aspect-[4/3]">
+          <video
+            ref={videoRef}
+            className="w-full h-full object-cover"
+            playsInline
+            muted
+            aria-label="Aperçu caméra pour scan de code-barres"
+          >
+            <track kind="captions" />
+          </video>
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="w-3/4 h-20 border-2 border-brand/80 rounded-lg" />
+          </div>
+          {status === 'scanning' && (
+            <p className="absolute bottom-2 left-0 right-0 text-center text-xs text-white/80">
+              Aligne le code-barres dans le cadre…
+            </p>
+          )}
+        </div>
+      )}
+
+      {status === 'unsupported' && (
+        <p className="text-sm text-body">
+          Le scan automatique n'est pas pris en charge par ce navigateur (iOS Safari notamment). Saisis le code
+          manuellement ci-dessous.
+        </p>
+      )}
+      {status === 'permission_denied' && (
+        <p className="text-sm text-body">Accès à la caméra refusé. Tu peux saisir le code manuellement.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-400">Impossible d'ouvrir la caméra. Saisis le code manuellement.</p>
+      )}
+
+      <form onSubmit={handleManualSubmit} className="space-y-2">
+        <label htmlFor="manual-barcode" className="block text-xs font-medium text-body">
+          Saisie manuelle du code-barres
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="manual-barcode"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            autoComplete="off"
+            value={manualBarcode}
+            onChange={(e) => setManualBarcode(e.target.value)}
+            placeholder="3017620422003"
+            className="flex-1 px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
+          />
+          <button type="submit" className="px-4 py-3 rounded-xl text-sm font-bold text-white cta-gradient">
+            Valider
+          </button>
+        </div>
+        {manualError && <p className="text-xs text-red-400">{manualError}</p>}
+      </form>
+
+      <p className="text-[11px] text-muted italic">Données fournies via Open Food Facts (licence ODbL).</p>
+    </div>
+  );
+}

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,16 +1,25 @@
 import { X } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
 import { MEAL_TYPE_LABELS, MEAL_TYPES } from '../../config/nutrition.ts';
+import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../../types/nutrition.ts';
+import { BarcodePane } from './BarcodePane.tsx';
 import { FoodSearchInput } from './FoodSearchInput.tsx';
 
-type Mode = 'manual' | 'search';
+type Mode = 'manual' | 'search' | 'barcode';
+
+const MODE_LABELS: Record<Mode, string> = {
+  manual: 'Saisie libre',
+  search: 'Rechercher',
+  barcode: 'Scanner',
+};
 
 interface MealEntryFormProps {
   initialMealType: MealType;
   onSubmit: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
   onCancel: () => void;
   onSearchSelect?: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+  onBarcodeSelect?: (product: OpenFoodFactsProduct, quantityGrams: number, mealType: MealType) => Promise<boolean>;
 }
 
 function parseMacro(raw: string): number | null {
@@ -26,7 +35,13 @@ function scaleByPortion(per100g: number | null | undefined, grams: number): numb
   return Math.round(value * 10) / 10;
 }
 
-export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSelect }: MealEntryFormProps) {
+export function MealEntryForm({
+  initialMealType,
+  onSubmit,
+  onCancel,
+  onSearchSelect,
+  onBarcodeSelect,
+}: MealEntryFormProps) {
   const [mode, setMode] = useState<Mode>('manual');
   const [mealType, setMealType] = useState<MealType>(initialMealType);
   const [name, setName] = useState('');
@@ -113,7 +128,7 @@ export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSel
       </header>
 
       <div className="flex gap-1 p-1 rounded-xl bg-surface border border-divider w-full">
-        {(['manual', 'search'] as const).map((m) => (
+        {(['manual', 'search', 'barcode'] as const).map((m) => (
           <button
             key={m}
             type="button"
@@ -126,7 +141,7 @@ export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSel
               mode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
             }`}
           >
-            {m === 'manual' ? 'Saisie libre' : 'Rechercher'}
+            {MODE_LABELS[m]}
           </button>
         ))}
       </div>
@@ -150,7 +165,25 @@ export function MealEntryForm({ initialMealType, onSubmit, onCancel, onSearchSel
         </div>
       </fieldset>
 
-      {mode === 'manual' ? (
+      {mode === 'barcode' ? (
+        <BarcodePane
+          mealType={mealType}
+          onCancel={onCancel}
+          onSubmit={async (product, grams) => {
+            setSubmitting(true);
+            try {
+              if (onBarcodeSelect) {
+                const ok = await onBarcodeSelect(product, grams, mealType);
+                if (ok) onCancel();
+                return ok;
+              }
+              return false;
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        />
+      ) : mode === 'manual' ? (
         <form onSubmit={handleManualSubmit} className="space-y-3">
           <div>
             <label htmlFor="meal-name" className="block text-xs font-medium text-body mb-1">

--- a/src/hooks/useOpenFoodFacts.ts
+++ b/src/hooks/useOpenFoodFacts.ts
@@ -29,8 +29,11 @@ export function useOpenFoodFacts(): UseOpenFoodFactsResult {
       setError(err);
       return p;
     } finally {
+      // Only clear loading if this call wasn't superseded (aborted) — avoids
+      // a racing completed-but-aborted request from flipping state after the
+      // consumer reset or started a new scan.
+      if (!controller.signal.aborted) setLoading(false);
       if (abortRef.current === controller) abortRef.current = null;
-      setLoading(false);
     }
   }, []);
 

--- a/src/hooks/useOpenFoodFacts.ts
+++ b/src/hooks/useOpenFoodFacts.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from 'react';
+import { fetchOpenFoodFactsProduct, type OpenFoodFactsError, type OpenFoodFactsProduct } from '../lib/openFoodFacts.ts';
+
+export interface UseOpenFoodFactsResult {
+  product: OpenFoodFactsProduct | null;
+  loading: boolean;
+  error: OpenFoodFactsError | null;
+  fetchByBarcode: (barcode: string) => Promise<OpenFoodFactsProduct | null>;
+  reset: () => void;
+}
+
+export function useOpenFoodFacts(): UseOpenFoodFactsResult {
+  const [product, setProduct] = useState<OpenFoodFactsProduct | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<OpenFoodFactsError | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchByBarcode = useCallback(async (barcode: string) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+    setProduct(null);
+    try {
+      const { product: p, error: err } = await fetchOpenFoodFactsProduct(barcode, controller.signal);
+      if (controller.signal.aborted) return null;
+      setProduct(p);
+      setError(err);
+      return p;
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      setLoading(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    setProduct(null);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  return { product, loading, error, fetchByBarcode, reset };
+}

--- a/src/lib/openFoodFacts.test.ts
+++ b/src/lib/openFoodFacts.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchOpenFoodFactsProduct } from './openFoodFacts.ts';
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(response: Partial<Response> & { _json?: unknown }): typeof fetch {
+  return vi.fn(async () => {
+    return {
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: async () => response._json,
+      ...response,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('fetchOpenFoodFactsProduct', () => {
+  it('returns invalid_barcode for non-numeric or wrong-length input', async () => {
+    const r1 = await fetchOpenFoodFactsProduct('abc');
+    expect(r1.error).toBe('invalid_barcode');
+    const r2 = await fetchOpenFoodFactsProduct('123');
+    expect(r2.error).toBe('invalid_barcode');
+    const r3 = await fetchOpenFoodFactsProduct('123456789012345');
+    expect(r3.error).toBe('invalid_barcode');
+  });
+
+  it('parses a valid OFF response with French-localized name', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Nutella',
+          product_name_fr: 'Pâte à tartiner Nutella',
+          brands: 'Ferrero,Ferrero France',
+          quantity: '400g',
+          image_small_url: 'https://example.test/img.jpg',
+          nutriments: {
+            'energy-kcal_100g': 539,
+            proteins_100g: 6.3,
+            carbohydrates_100g: 57.5,
+            fat_100g: 30.9,
+            fiber_100g: 4.2,
+          },
+        },
+      },
+    });
+
+    const { product, error } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(error).toBeNull();
+    expect(product?.name).toBe('Pâte à tartiner Nutella');
+    expect(product?.brand).toBe('Ferrero');
+    expect(product?.calories_100g).toBe(539);
+    expect(product?.protein_100g).toBeCloseTo(6.3);
+    expect(product?.image_url).toBe('https://example.test/img.jpg');
+    expect(product?.source_url).toBe('https://world.openfoodfacts.org/product/3017620422003');
+  });
+
+  it('returns missing_nutrition when product has no kcal', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Item sans nutrition',
+          nutriments: {},
+        },
+      },
+    });
+    const { product, error } = await fetchOpenFoodFactsProduct('3000000000001');
+    expect(product).toBeNull();
+    expect(error).toBe('missing_nutrition');
+  });
+
+  it('returns not_found when OFF reports status 0', async () => {
+    globalThis.fetch = mockFetch({ _json: { status: 0 } });
+    const { product, error } = await fetchOpenFoodFactsProduct('9999999999999');
+    expect(product).toBeNull();
+    expect(error).toBe('not_found');
+  });
+
+  it('returns not_found on HTTP 404', async () => {
+    globalThis.fetch = mockFetch({ ok: false, status: 404, _json: {} });
+    const { error } = await fetchOpenFoodFactsProduct('9999999999999');
+    expect(error).toBe('not_found');
+  });
+
+  it('returns network on fetch throw', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('network unreachable');
+    }) as unknown as typeof fetch;
+    const { error } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(error).toBe('network');
+  });
+
+  it('accepts 8-digit EAN-8', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Produit court',
+          nutriments: { 'energy-kcal_100g': 250 },
+        },
+      },
+    });
+    const { product } = await fetchOpenFoodFactsProduct('12345678');
+    expect(product?.name).toBe('Produit court');
+  });
+});

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -43,8 +43,13 @@ export interface OpenFoodFactsResult {
   error: OpenFoodFactsError | null;
 }
 
+/**
+ * Accepts barcode lengths matching real standards only:
+ * EAN-8 (8), UPC-A (12), EAN-13 (13), ITF-14 (14). UPC-E is normalized to 8 by
+ * scanners. Rejects exotic lengths (9/10/11) that would always miss OFF anyway.
+ */
 function isValidBarcode(barcode: string): boolean {
-  return /^[0-9]{8,14}$/.test(barcode);
+  return /^[0-9]+$/.test(barcode) && [8, 12, 13, 14].includes(barcode.length);
 }
 
 function pickNumber(source: Record<string, unknown>, keys: string[]): number | null {
@@ -102,7 +107,9 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
   const p = payload.product;
   const nutr = p.nutriments ?? {};
   const name = p.product_name_fr?.trim() || p.product_name?.trim() || null;
-  const calories = pickNumber(nutr, ['energy-kcal_100g', 'energy-kcal', 'energy_100g']);
+  // Only accept kcal-typed keys; `energy_100g` is in kJ on OFF and would
+  // otherwise inflate calories by ~4.184x with no unit check.
+  const calories = pickNumber(nutr, ['energy-kcal_100g', 'energy-kcal']);
 
   if (!name || calories == null) {
     return { product: null, error: 'missing_nutrition' };

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -1,0 +1,127 @@
+/**
+ * Open Food Facts public API wrapper.
+ *
+ * Licence: Open Database License (ODbL). Attribution requirement: display
+ * "via Open Food Facts" whenever we surface product data fetched from OFF.
+ * Docs: https://openfoodfacts.github.io/openfoodfacts-server/api/
+ *
+ * Requests are issued from the user's browser directly (no proxy). The API is
+ * public, rate limits are generous (~100 req/min), and we never send user
+ * credentials.
+ */
+
+const OFF_BASE = 'https://world.openfoodfacts.org/api/v2/product';
+const FIELDS = [
+  'product_name',
+  'product_name_fr',
+  'brands',
+  'quantity',
+  'serving_size',
+  'nutriments',
+  'image_small_url',
+].join(',');
+
+export interface OpenFoodFactsProduct {
+  barcode: string;
+  name: string;
+  brand: string | null;
+  quantity: string | null;
+  /** kcal per 100g when available, null if unit is kJ only or missing. */
+  calories_100g: number | null;
+  protein_100g: number | null;
+  carbs_100g: number | null;
+  fat_100g: number | null;
+  fiber_100g: number | null;
+  image_url: string | null;
+  source_url: string;
+}
+
+export type OpenFoodFactsError = 'not_found' | 'network' | 'invalid_barcode' | 'missing_nutrition';
+
+export interface OpenFoodFactsResult {
+  product: OpenFoodFactsProduct | null;
+  error: OpenFoodFactsError | null;
+}
+
+function isValidBarcode(barcode: string): boolean {
+  return /^[0-9]{8,14}$/.test(barcode);
+}
+
+function pickNumber(source: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const raw = source[key];
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    if (typeof raw === 'string') {
+      const n = Number.parseFloat(raw);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetches a product by barcode. Returns null + error code on any failure so
+ * the UI can surface a user-friendly message (never throws).
+ */
+export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortSignal): Promise<OpenFoodFactsResult> {
+  if (!isValidBarcode(barcode)) {
+    return { product: null, error: 'invalid_barcode' };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${OFF_BASE}/${barcode}?fields=${FIELDS}`, {
+      signal,
+      headers: { Accept: 'application/json' },
+    });
+  } catch {
+    return { product: null, error: 'network' };
+  }
+
+  if (!response.ok) {
+    return { product: null, error: response.status === 404 ? 'not_found' : 'network' };
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    status?: number;
+    product?: {
+      product_name?: string;
+      product_name_fr?: string;
+      brands?: string;
+      quantity?: string;
+      serving_size?: string;
+      nutriments?: Record<string, unknown>;
+      image_small_url?: string;
+    };
+  } | null;
+
+  if (!payload || payload.status !== 1 || !payload.product) {
+    return { product: null, error: 'not_found' };
+  }
+
+  const p = payload.product;
+  const nutr = p.nutriments ?? {};
+  const name = p.product_name_fr?.trim() || p.product_name?.trim() || null;
+  const calories = pickNumber(nutr, ['energy-kcal_100g', 'energy-kcal', 'energy_100g']);
+
+  if (!name || calories == null) {
+    return { product: null, error: 'missing_nutrition' };
+  }
+
+  return {
+    product: {
+      barcode,
+      name,
+      brand: p.brands ? p.brands.split(',')[0].trim() : null,
+      quantity: p.quantity ?? null,
+      calories_100g: calories,
+      protein_100g: pickNumber(nutr, ['proteins_100g', 'proteins']),
+      carbs_100g: pickNumber(nutr, ['carbohydrates_100g', 'carbohydrates']),
+      fat_100g: pickNumber(nutr, ['fat_100g', 'fat']),
+      fiber_100g: pickNumber(nutr, ['fiber_100g', 'fiber']),
+      image_url: p.image_small_url ?? null,
+      source_url: `https://world.openfoodfacts.org/product/${barcode}`,
+    },
+    error: null,
+  };
+}


### PR DESCRIPTION
## Summary

PR 4/6 — Scan de code-barres avec enrichissement via Open Food Facts. Reste dans le free tier (aucun appel IA).

### Nouveautés

- Nouvel onglet **Scanner** dans le formulaire d'ajout de repas
- Caméra du device → \`BarcodeDetector\` natif (Chrome, Edge, Android ≥ API 90)
- Fallback **saisie manuelle** quand l'API n'est pas supportée (iOS Safari)
- Fetch Open Food Facts → produit normalisé (kcal + macros + image + marque)
- Ajout via source=\`barcode\`, reference_id = code-barres

### Composants

- \`src/lib/openFoodFacts.ts\` : wrapper API typé, erreurs structurées (invalid_barcode / not_found / missing_nutrition / network)
- \`src/lib/openFoodFacts.test.ts\` : 7 tests (décodage FR, EAN-8, kcal manquantes, 404, throw réseau)
- \`src/hooks/useOpenFoodFacts.ts\` : AbortController cleanup, inflight replacement
- \`src/components/nutrition/BarcodeScanner.tsx\` : gestion stream vidéo, release sur unmount, formats EAN-8/13 + UPC-A/E, permission_denied graceful
- \`src/components/nutrition/BarcodePane.tsx\` : orchestration scanner + OFF + portion + attribution ODbL
- Intégration dans \`MealEntryForm\` et \`NutritionPage\`

### Licence / attribution

- Open Food Facts sous **ODbL** → lien vers la fiche produit affiché en pied de formulaire après scan (attribution requise par la licence)

### Privacy

- Le stream vidéo ne quitte **jamais** le device. Décodage 100% local via \`BarcodeDetector\`.
- Aucune dépendance ajoutée (pas de lib externe zxing/quagga — API native uniquement).

## Test plan

- [x] \`npm run build\` — OK
- [x] \`npx vitest run\` — 212/212
- [x] \`npx biome check\` — clean
- [ ] **Recette Chrome** (mcp extension non connectée) à faire par le PO :
  - Desktop Chrome : /nutrition → Ajouter → onglet Scanner → autoriser caméra → viser un code-barres (ex. Nutella 3017620422003) → produit affiché → valider
  - Desktop Safari / iOS : onglet Scanner → message "non supporté" → saisie manuelle → valider
  - Caméra refusée : message explicite + fallback manuel accessible
  - Scanner fermé → caméra bien relâchée (icône navigateur disparaît)

## Pré-requis

- PR 1, 2, 3 mergées

## Étapes restantes

- PR 5 : edge function IA (texte libre + débordement) — premium only
- PR 6 : CGU/RGPD + re-validation users existants (basé sur claudedocs/nutrition-rgpd-research.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)