### PR TITLE
feat(nutrition): RGPD — CGU update + re-validation modal (PR 6/6)

### DIFF
--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -20,7 +20,8 @@ const TAB_TITLES: Record<Tab, string> = {
 export function Legal() {
   const { tab: tabParam } = useParams<{ tab: string }>();
   const navigate = useNavigate();
-  const tab: Tab = tabParam && ['mentions', 'privacy', 'cgu', 'cgv'].includes(tabParam) ? (tabParam as Tab) : 'mentions';
+  const tab: Tab =
+    tabParam && ['mentions', 'privacy', 'cgu', 'cgv'].includes(tabParam) ? (tabParam as Tab) : 'mentions';
 
   useDocumentHead({
     title: TAB_TITLES[tab],
@@ -171,7 +172,7 @@ function PolitiqueConfidentialite() {
     <>
       <h1 className="text-2xl font-bold text-heading mb-6">Politique de confidentialité</h1>
 
-      <p className="text-sm text-faint mb-6">Dernière mise à jour : mars 2026</p>
+      <p className="text-sm text-faint mb-6">Dernière mise à jour : avril 2026 (version 2026-04)</p>
 
       <Section title="Responsable du traitement">
         <p>
@@ -204,8 +205,8 @@ function PolitiqueConfidentialite() {
             (traitées par Stripe, voir ci-dessous)
           </li>
           <li>
-            <strong className="text-strong">Photo de profil (avatar)</strong> — pour personnaliser votre compte
-            (stockée sur Supabase Storage)
+            <strong className="text-strong">Photo de profil (avatar)</strong> — pour personnaliser votre compte (stockée
+            sur Supabase Storage)
           </li>
           <li>
             <strong className="text-strong">Préférences d'entraînement</strong> — pour la génération IA de séances et
@@ -215,26 +216,98 @@ function PolitiqueConfidentialite() {
           </li>
         </ul>
         <p>
-          <strong className="text-strong">Wan2Fit ne stocke jamais vos données bancaires.</strong> Les informations
-          de paiement (numéro de carte, IBAN) sont collectées et traitées exclusivement par Stripe. Nous ne conservons
-          que l'identifiant client Stripe et le statut de votre abonnement.
+          <strong className="text-strong">Wan2Fit ne stocke jamais vos données bancaires.</strong> Les informations de
+          paiement (numéro de carte, IBAN) sont collectées et traitées exclusivement par Stripe. Nous ne conservons que
+          l'identifiant client Stripe et le statut de votre abonnement.
         </p>
         <p>
-          Les déclarations de blessures renseignées lors de la création d'un programme IA ne constituent pas des
-          données de santé au sens de l'article 9 du RGPD — il s'agit de déclarations volontaires de l'utilisateur
-          à des fins de personnalisation. Vos données ne sont jamais revendues à des tiers.
+          Les déclarations de blessures renseignées lors de la création d'un programme IA ne constituent pas des données
+          de santé au sens de l'article 9 du RGPD — il s'agit de déclarations volontaires de l'utilisateur à des fins de
+          personnalisation. Vos données ne sont jamais revendues à des tiers.
+        </p>
+      </Section>
+
+      <Section title="Suivi nutritionnel (feature optionnel)">
+        <p>
+          Lorsque vous activez le suivi nutritionnel, Wan2Fit collecte et conserve les informations que vous saisissez
+          manuellement :{' '}
+          <strong className="text-strong">
+            nom du repas, calories, macronutriments éventuels, date et type de repas (petit-déjeuner, déjeuner, etc.)
+          </strong>
+          . Une <strong className="text-strong">cible calorique quotidienne</strong> peut également être persistée, sous
+          la forme d'un simple nombre.
+        </p>
+        <p>
+          <strong className="text-strong">Privacy by design :</strong> si vous utilisez le calculateur de cible
+          (formulaire d'onboarding éphémère), vos données morphologiques (âge, sexe, taille, poids, niveau d'activité)
+          <strong className="text-strong"> ne sont jamais envoyées sur nos serveurs</strong>. Elles sont utilisées
+          uniquement dans votre navigateur pour calculer le nombre-cible selon la formule de Mifflin-St Jeor, puis
+          oubliées lorsque vous quittez la page. Seul le nombre-cible est persisté.
+        </p>
+        <p>
+          <strong className="text-strong">Qualification juridique :</strong> conformément à l'interprétation de la Cour
+          de justice de l'Union européenne (arrêt <em>Lindenapotheke</em> C‑21/23 du 4 octobre 2024), nous considérons
+          par prudence que votre journal alimentaire et votre cible calorique peuvent constituer des données concernant
+          la santé au sens de l'article 9 du RGPD. Leur traitement repose sur votre{' '}
+          <strong className="text-strong">consentement explicite</strong> (art. 9.2.a RGPD), matérialisé par
+          l'activation volontaire du suivi nutritionnel, complété par l'exécution du contrat d'utilisation du service
+          (art. 6.1.b). Vous pouvez retirer ce consentement à tout moment en supprimant votre journal et votre cible.
+        </p>
+        <p>
+          <strong className="text-strong">Estimation IA (abonnés premium) :</strong> lorsque vous utilisez l'estimation
+          automatique des calories via une description texte libre, la description saisie et l'heure de la demande sont
+          transmises à Anthropic pour traitement (voir « Services tiers » ci-dessous). L'analyse quotidienne optionnelle
+          (« Analyser ma journée ») transmet également un résumé des repas saisis et votre cible calorique si définie.
+          Anthropic ne réutilise pas ces données pour l'entraînement de ses modèles.
+        </p>
+        <p>
+          <strong className="text-strong">Scan de code-barres :</strong> lorsque vous scannez un produit, le code-barres
+          est envoyé directement depuis votre navigateur à l'API publique{' '}
+          <a href="https://openfoodfacts.org" target="_blank" rel="noopener noreferrer" className="text-link underline">
+            Open Food Facts
+          </a>{' '}
+          (base collaborative libre sous licence ODbL). Wan2Fit ne voit ni ne stocke ce code-barres tant que vous n'avez
+          pas confirmé l'ajout du produit à votre journal. Open Food Facts ne reçoit aucune donnée permettant de vous
+          identifier.
+        </p>
+        <p>
+          <strong className="text-strong">Base de référence CIQUAL :</strong> la recherche d'aliments dans la base
+          CIQUAL (ANSES, licence Etalab 2.0) s'effectue sur nos serveurs. Seule la requête de recherche est traitée ;
+          elle n'est pas associée à votre identité au-delà de votre session.
         </p>
       </Section>
 
       <Section title="Finalités du traitement et bases légales">
         <p>Vos données sont utilisées pour les finalités suivantes :</p>
         <ul className="list-disc list-inside space-y-1">
-          <li>Gérer votre compte et votre authentification — <em>exécution du contrat (art. 6.1.b RGPD)</em></li>
-          <li>Sauvegarder votre progression et votre historique de séances — <em>exécution du contrat (art. 6.1.b RGPD)</em></li>
-          <li>Vous envoyer des emails transactionnels (confirmation, réinitialisation) — <em>exécution du contrat (art. 6.1.b RGPD)</em></li>
-          <li>Gérer votre abonnement Premium et traiter les paiements — <em>exécution du contrat (art. 6.1.b RGPD)</em></li>
-          <li>Générer des séances et programmes personnalisés par IA — <em>exécution du contrat (art. 6.1.b RGPD)</em></li>
-          <li>Conserver les factures et données de facturation — <em>obligation légale (art. 6.1.c RGPD)</em></li>
+          <li>
+            Gérer votre compte et votre authentification — <em>exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Sauvegarder votre progression et votre historique de séances —{' '}
+            <em>exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Vous envoyer des emails transactionnels (confirmation, réinitialisation) —{' '}
+            <em>exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Gérer votre abonnement Premium et traiter les paiements — <em>exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Générer des séances et programmes personnalisés par IA — <em>exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Gérer votre journal nutritionnel et votre cible calorique (feature optionnel) —{' '}
+            <em>consentement explicite (art. 9.2.a RGPD) + exécution du contrat (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Fournir une estimation IA des calories et une analyse quotidienne (abonnés premium) —{' '}
+            <em>consentement explicite (art. 9.2.a RGPD) + exécution du contrat premium (art. 6.1.b RGPD)</em>
+          </li>
+          <li>
+            Conserver les factures et données de facturation — <em>obligation légale (art. 6.1.c RGPD)</em>
+          </li>
         </ul>
         <p>Nous n'envoyons aucun email marketing ni newsletter.</p>
       </Section>
@@ -250,8 +323,8 @@ function PolitiqueConfidentialite() {
       <Section title="Cookies">
         <p>
           Le Site utilise uniquement des <strong className="text-strong">cookies techniques</strong> strictement
-          nécessaires au fonctionnement de l'authentification. Aucun cookie publicitaire, analytique ou de suivi
-          n'est déposé.
+          nécessaires au fonctionnement de l'authentification. Aucun cookie publicitaire, analytique ou de suivi n'est
+          déposé.
         </p>
       </Section>
 
@@ -271,10 +344,17 @@ function PolitiqueConfidentialite() {
             (sous-traitant RGPD, données hébergées en UE). Stripe est certifié PCI-DSS niveau 1.
           </li>
           <li>
-            <strong className="text-strong">Anthropic</strong> — génération de séances et programmes personnalisés par
-            intelligence artificielle (modèles Claude). Les données de personnalisation (objectifs, équipement,
-            blessures déclarées, âge et sexe si renseignés) sont transmises à l'API Anthropic pour la génération du
-            contenu. Anthropic ne réutilise pas ces données pour l'entraînement de ses modèles. Siège aux États-Unis.
+            <strong className="text-strong">Anthropic</strong> — génération de séances et programmes personnalisés et
+            estimation nutritionnelle IA (modèles Claude). Les données transmises comprennent : (a) les paramètres de
+            personnalisation fitness (objectifs, équipement, blessures déclarées, âge et sexe si renseignés) pour les
+            séances et programmes ; (b) la description texte d'un repas pour l'estimation calorique premium ; (c) le
+            récapitulatif des repas saisis du jour et la cible calorique si définie, pour l'analyse quotidienne premium.
+            Anthropic ne réutilise pas ces données pour l'entraînement de ses modèles. Siège aux États-Unis.
+          </li>
+          <li>
+            <strong className="text-strong">Open Food Facts</strong> — base collaborative libre de produits alimentaires
+            (licence ODbL). Utilisée lors du scan de code-barres côté client uniquement. Aucune donnée identifiante
+            n'est transmise — seul le code-barres scanné l'est.
           </li>
         </ul>
         <p>
@@ -300,19 +380,26 @@ function PolitiqueConfidentialite() {
             l'entraînement des modèles d'IA.
           </li>
         </ul>
-        <p>
-          Stripe héberge les données de paiement dans l'Union européenne.
-        </p>
+        <p>Stripe héberge les données de paiement dans l'Union européenne.</p>
       </Section>
 
       <Section title="Durée de conservation">
         <p>
-          Vos données sont conservées tant que votre compte est actif. En cas de suppression de compte, vos données
-          personnelles sont effacées dans un délai de 30 jours.
+          Vos données de compte (identifiants, préférences, historique de séances) sont conservées tant que votre compte
+          est actif. En cas d'inactivité prolongée (plus de 2 ans sans connexion), nous pouvons supprimer votre compte
+          après vous avoir notifié par email, conformément aux recommandations CNIL.
         </p>
         <p>
-          Les données de facturation et justificatifs de paiement sont conservés pendant 6 ans conformément aux
-          obligations fiscales et comptables, même en cas de suppression de compte.
+          Vos données de <strong className="text-strong">suivi nutritionnel</strong> (journal alimentaire, cible
+          calorique, insights IA, estimations) sont conservées tant que le feature est activé et votre compte actif.
+          Vous pouvez les supprimer à tout moment depuis la page de suivi nutritionnel.
+        </p>
+        <p>
+          En cas de suppression de compte, l'ensemble de vos données personnelles est effacé dans un délai de 30 jours.
+        </p>
+        <p>
+          Les données de facturation et justificatifs de paiement sont conservés pendant 10 ans conformément à l'article
+          L.123-22 du Code de commerce, même en cas de suppression de compte.
         </p>
       </Section>
 
@@ -362,7 +449,7 @@ function CGU() {
     <>
       <h1 className="text-2xl font-bold text-heading mb-6">Conditions Générales d'Utilisation</h1>
 
-      <p className="text-sm text-faint mb-6">Dernière mise à jour : mars 2026</p>
+      <p className="text-sm text-faint mb-6">Dernière mise à jour : avril 2026 (version 2026-04)</p>
 
       <Section title="Objet">
         <p>
@@ -374,14 +461,69 @@ function CGU() {
 
       <Section title="Description du service">
         <p>
-          Wan2Fit propose une offre gratuite de séances d'exercices physiques quotidiennes et une offre Premium
-          payante donnant accès à des fonctionnalités avancées (séances et programmes personnalisés par IA). Le Site
-          met à disposition des suggestions d'exercices guidées avec minuteur intégré, sans équipement nécessaire.
+          Wan2Fit propose une offre gratuite de séances d'exercices physiques quotidiennes et une offre Premium payante
+          donnant accès à des fonctionnalités avancées (séances et programmes personnalisés par IA, estimation IA des
+          calories, analyse nutritionnelle quotidienne). Le Site met à disposition des suggestions d'exercices guidées
+          avec minuteur intégré, sans équipement nécessaire, ainsi qu'un suivi nutritionnel optionnel.
         </p>
         <p>
-          La création d'un compte est optionnelle. Elle permet de sauvegarder son historique de séances et de suivre sa
-          progression. Les conditions de l'abonnement Premium sont détaillées dans les{' '}
-          <Link to="/legal/cgv" className="text-link underline">Conditions Générales de Vente</Link>.
+          La création d'un compte est optionnelle. Elle permet de sauvegarder son historique de séances, son suivi
+          nutritionnel et de suivre sa progression. Les conditions de l'abonnement Premium sont détaillées dans les{' '}
+          <Link to="/legal/cgv" className="text-link underline">
+            Conditions Générales de Vente
+          </Link>
+          .
+        </p>
+      </Section>
+
+      <Section title="Suivi nutritionnel (feature optionnel)">
+        <p>
+          Le suivi nutritionnel vous permet de consigner vos repas, de rechercher des aliments dans la base CIQUAL
+          (ANSES), de scanner des produits via Open Food Facts, et, pour les abonnés Premium, d'estimer les calories
+          d'un repas via IA et d'obtenir une analyse quotidienne de votre équilibre alimentaire.
+        </p>
+        <p>
+          <strong className="text-strong">Activation volontaire :</strong> le suivi nutritionnel est désactivé par
+          défaut. Son utilisation est strictement volontaire et relève de votre choix. En l'activant et en saisissant
+          votre premier repas, vous consentez explicitement au traitement des données nutritionnelles décrit dans la{' '}
+          <Link to="/legal/privacy" className="text-link underline">
+            Politique de Confidentialité
+          </Link>{' '}
+          (art. 9.2.a RGPD).
+        </p>
+        <p>
+          <strong className="text-strong">Nature indicative des estimations :</strong> les calories et macronutriments
+          proposés par la base CIQUAL, Open Food Facts ou l'estimation IA sont <strong>indicatifs</strong> (marge
+          d'erreur typiquement ±20% pour l'IA, dépendante de la précision de la description). Wan2Fit n'offre aucune
+          garantie de précision absolue. Ces estimations ne doivent pas se substituer à un suivi nutritionnel
+          professionnel.
+        </p>
+        <p>
+          <strong className="text-strong">Transparence sur l'IA :</strong> conformément au règlement (UE) 2024/1689 (AI
+          Act), article 50, vous êtes informé que les fonctionnalités « Estimation IA » et « Analyse de ta journée »
+          sont générées par un modèle d'intelligence artificielle (Claude, éditeur Anthropic). Les résultats affichés
+          sont annotés avec un niveau de confiance lorsque pertinent.
+        </p>
+        <p>
+          <strong className="text-strong">Public et restrictions :</strong> cette fonctionnalité est réservée aux
+          utilisateurs majeurs (18 ans et plus). Nous recommandons de ne pas l'activer en cas de grossesse, de
+          pathologie médicale (diabète, troubles du comportement alimentaire, maladies métaboliques), ou si vous êtes
+          suivi par un professionnel de santé qui vous a prescrit un régime particulier. En cas de doute, consultez
+          votre médecin avant d'utiliser le suivi calorique.
+        </p>
+        <p>
+          <strong className="text-strong">Non-substitution à un avis médical :</strong> les informations fournies
+          (cibles, estimations, suggestions) ne constituent pas un conseil médical, un diagnostic ou une prescription.
+          Elles ne peuvent remplacer l'avis d'un professionnel de santé qualifié (médecin, nutritionniste, diététicien).
+        </p>
+      </Section>
+
+      <Section title="Évolution des présentes conditions">
+        <p>
+          Les présentes CGU peuvent être mises à jour pour refléter des évolutions du service. En cas de modification
+          substantielle (nouvelle finalité, nouveau sous-traitant, nouvelle catégorie de données), vous serez informé
+          lors de votre prochaine connexion par une fenêtre vous invitant à prendre connaissance et à accepter la
+          nouvelle version. La version en vigueur est indiquée en haut de cette page.
         </p>
       </Section>
 
@@ -420,14 +562,19 @@ function CGU() {
         </p>
         <p>Le contenu généré par IA :</p>
         <ul className="list-disc list-inside space-y-1">
-          <li>Constitue des suggestions d'exercices à caractère général, au même titre que le contenu éditorial du Site</li>
-          <li>Ne constitue en aucun cas un programme de coaching sportif personnalisé au sens de l'article L.212-1 du Code du sport, ni un avis médical</li>
+          <li>
+            Constitue des suggestions d'exercices à caractère général, au même titre que le contenu éditorial du Site
+          </li>
+          <li>
+            Ne constitue en aucun cas un programme de coaching sportif personnalisé au sens de l'article L.212-1 du Code
+            du sport, ni un avis médical
+          </li>
           <li>Peut contenir des imperfections ou des suggestions inadaptées à une situation particulière</li>
           <li>Ne se substitue pas aux conseils d'un professionnel de santé ou d'un éducateur sportif diplômé</li>
         </ul>
         <p>
-          L'utilisateur reste entièrement responsable de l'adaptation et de l'exécution des exercices suggérés par
-          l'IA. L'avertissement santé s'applique de la même manière au contenu généré par IA et au contenu éditorial.
+          L'utilisateur reste entièrement responsable de l'adaptation et de l'exécution des exercices suggérés par l'IA.
+          L'avertissement santé s'applique de la même manière au contenu généré par IA et au contenu éditorial.
         </p>
       </Section>
 
@@ -442,8 +589,8 @@ function CGU() {
 
       <Section title="Compte utilisateur">
         <p>
-          Le Site s'adresse exclusivement aux personnes majeures (18 ans et plus). En créant un compte,
-          l'utilisateur déclare être âgé d'au moins 18 ans.
+          Le Site s'adresse exclusivement aux personnes majeures (18 ans et plus). En créant un compte, l'utilisateur
+          déclare être âgé d'au moins 18 ans.
         </p>
         <p>
           La création d'un compte est facultative et gratuite. Elle nécessite une adresse email valide et un mot de
@@ -575,8 +722,7 @@ function CGV() {
           d'utilisation de l'abonnement Premium proposé par WAN SOFT sur le site Wan2Fit.
         </p>
         <p>
-          Toute souscription à l'offre Premium implique l'acceptation pleine et entière des présentes CGV, ainsi que
-          des{' '}
+          Toute souscription à l'offre Premium implique l'acceptation pleine et entière des présentes CGV, ainsi que des{' '}
           <Link to="/legal/cgu" className="text-link underline">
             Conditions Générales d'Utilisation
           </Link>
@@ -596,28 +742,28 @@ function CGV() {
             séances IA sur-mesure + programmes IA personnalisés
           </li>
           <li>
-            <strong className="text-strong">Premium annuel</strong> — 99,99 € TTC/an (soit ~8,33 €/mois, environ 17%
-            de remise) — Contenu identique au mensuel
+            <strong className="text-strong">Premium annuel</strong> — 99,99 € TTC/an (soit ~8,33 €/mois, environ 17% de
+            remise) — Contenu identique au mensuel
           </li>
         </ul>
-        <p>Les prix sont indiqués toutes taxes comprises (TVA 20% incluse). WAN SOFT se réserve le droit de modifier
-          ses tarifs à tout moment. Toute modification tarifaire n'affecte pas les abonnements en cours et prend effet
-          au prochain renouvellement.</p>
+        <p>
+          Les prix sont indiqués toutes taxes comprises (TVA 20% incluse). WAN SOFT se réserve le droit de modifier ses
+          tarifs à tout moment. Toute modification tarifaire n'affecte pas les abonnements en cours et prend effet au
+          prochain renouvellement.
+        </p>
       </Section>
 
       <Section title="Souscription et paiement">
         <p>
-          La souscription à l'offre Premium nécessite la création d'un compte sur Wan2Fit. Le paiement est effectué
-          en ligne par carte bancaire, Apple Pay, Google Pay ou prélèvement SEPA, via la plateforme de paiement
-          sécurisée <strong className="text-strong">Stripe</strong>.
+          La souscription à l'offre Premium nécessite la création d'un compte sur Wan2Fit. Le paiement est effectué en
+          ligne par carte bancaire, Apple Pay, Google Pay ou prélèvement SEPA, via la plateforme de paiement sécurisée{' '}
+          <strong className="text-strong">Stripe</strong>.
         </p>
         <p>
           WAN SOFT ne collecte ni ne stocke aucune donnée bancaire. L'ensemble des transactions est géré par Stripe
           (certifié PCI-DSS niveau 1).
         </p>
-        <p>
-          L'accès aux fonctionnalités Premium est activé immédiatement après confirmation du paiement par Stripe.
-        </p>
+        <p>L'accès aux fonctionnalités Premium est activé immédiatement après confirmation du paiement par Stripe.</p>
       </Section>
 
       <Section title="Durée et renouvellement">
@@ -631,23 +777,21 @@ function CGV() {
       <Section title="Droit de rétractation">
         <p>
           Conformément aux articles L.221-18 et L.221-28-1° du Code de la consommation, le consommateur dispose d'un
-          droit de rétractation de 14 jours. Toutefois, en souscrivant à l'offre Premium, l'abonné demande
-          expressément l'exécution immédiate du service et reconnaît renoncer à son droit de rétractation pour la
-          période en cours, dès lors que l'exécution a commencé avec son accord préalable exprès.
+          droit de rétractation de 14 jours. Toutefois, en souscrivant à l'offre Premium, l'abonné demande expressément
+          l'exécution immédiate du service et reconnaît renoncer à son droit de rétractation pour la période en cours,
+          dès lors que l'exécution a commencé avec son accord préalable exprès.
         </p>
-        <p>
-          Un email de confirmation de souscription rappelant cette renonciation est adressé à l'abonné par Stripe.
-        </p>
+        <p>Un email de confirmation de souscription rappelant cette renonciation est adressé à l'abonné par Stripe.</p>
       </Section>
 
       <Section title="Résiliation">
         <p>
-          L'abonné peut résilier son abonnement à tout moment depuis le portail client accessible dans ses paramètres
-          de compte (bouton « Gérer mon abonnement »).
+          L'abonné peut résilier son abonnement à tout moment depuis le portail client accessible dans ses paramètres de
+          compte (bouton « Gérer mon abonnement »).
         </p>
         <p>
-          La résiliation prend effet à la fin de la période de facturation en cours. L'accès aux fonctionnalités
-          Premium est maintenu jusqu'à cette date. Aucun remboursement au prorata n'est effectué.
+          La résiliation prend effet à la fin de la période de facturation en cours. L'accès aux fonctionnalités Premium
+          est maintenu jusqu'à cette date. Aucun remboursement au prorata n'est effectué.
         </p>
       </Section>
 

--- a/src/components/Legal.tsx
+++ b/src/components/Legal.tsx
@@ -395,7 +395,8 @@ function PolitiqueConfidentialite() {
           Vous pouvez les supprimer à tout moment depuis la page de suivi nutritionnel.
         </p>
         <p>
-          En cas de suppression de compte, l'ensemble de vos données personnelles est effacé dans un délai de 30 jours.
+          En cas de suppression de compte, l'ensemble de vos données personnelles — y compris le journal alimentaire, la
+          cible calorique, les insights IA et toute estimation associée — est effacé dans un délai de 30 jours.
         </p>
         <p>
           Les données de facturation et justificatifs de paiement sont conservés pendant 10 ans conformément à l'article

--- a/src/components/PlayerLayout.tsx
+++ b/src/components/PlayerLayout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
+import { CguRevalidationModal } from './legal/CguRevalidationModal.tsx';
 
 export function PlayerLayout() {
   const { pathname } = useLocation();
@@ -12,6 +13,7 @@ export function PlayerLayout() {
   return (
     <main>
       <Outlet />
+      <CguRevalidationModal />
     </main>
   );
 }

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext.tsx';
 import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
 import { Footer } from './Footer.tsx';
+import { CguRevalidationModal } from './legal/CguRevalidationModal.tsx';
 import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
@@ -29,6 +30,7 @@ export function PublicLayout() {
       </main>
       <Footer />
       <BottomNav />
+      <CguRevalidationModal />
     </div>
   );
 }

--- a/src/components/legal/CguRevalidationModal.tsx
+++ b/src/components/legal/CguRevalidationModal.tsx
@@ -1,9 +1,12 @@
 import { AlertTriangle } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { CGU_VERSION_CHANGES, CURRENT_CGU_VERSION } from '../../config/legal.ts';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useCguStatus } from '../../hooks/useCguStatus.ts';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Blocking modal shown at login when `profiles.cgu_version_accepted` does not
@@ -25,6 +28,38 @@ export function CguRevalidationModal() {
     if (!needsRevalidation) return;
     dialogRef.current?.focus();
   }, [needsRevalidation]);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== 'Tab') return;
+    // Keyboard focus trap: WCAG 2.1.2 requires no keyboard trap in general, but
+    // for modal dialogs the WAI-ARIA practice is to confine focus inside the
+    // dialog until dismissed. We cycle Tab / Shift+Tab between the first and
+    // last focusable elements of the dialog.
+    const root = dialogRef.current;
+    if (!root) return;
+    const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (el) => !el.hasAttribute('disabled'),
+    );
+    if (focusable.length === 0) {
+      event.preventDefault();
+      root.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (event.shiftKey) {
+      if (active === first || active === root) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  }
 
   if (!needsRevalidation) return null;
 
@@ -55,6 +90,7 @@ export function CguRevalidationModal() {
         aria-modal="true"
         aria-labelledby="cgu-revalidation-title"
         tabIndex={-1}
+        onKeyDown={handleKeyDown}
         className="w-full max-w-lg rounded-2xl bg-surface border border-card-border p-6 shadow-2xl space-y-5 focus:outline-none"
       >
         <div className="flex items-center gap-2">
@@ -86,11 +122,11 @@ export function CguRevalidationModal() {
 
         <p className="text-xs text-muted">
           Consulte le détail dans les{' '}
-          <Link to="/legal/cgu" className="text-link underline" target="_blank" rel="noopener">
+          <Link to="/legal/cgu" className="text-link underline" target="_blank" rel="noopener noreferrer">
             CGU
           </Link>{' '}
           et la{' '}
-          <Link to="/legal/privacy" className="text-link underline" target="_blank" rel="noopener">
+          <Link to="/legal/privacy" className="text-link underline" target="_blank" rel="noopener noreferrer">
             Politique de confidentialité
           </Link>
           .

--- a/src/components/legal/CguRevalidationModal.tsx
+++ b/src/components/legal/CguRevalidationModal.tsx
@@ -1,0 +1,122 @@
+import { AlertTriangle } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router';
+import { CGU_VERSION_CHANGES, CURRENT_CGU_VERSION } from '../../config/legal.ts';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { useCguStatus } from '../../hooks/useCguStatus.ts';
+
+/**
+ * Blocking modal shown at login when `profiles.cgu_version_accepted` does not
+ * match `CURRENT_CGU_VERSION`. Mounted at the top of the app tree so it
+ * prevents interactions with any page until the user either accepts the new
+ * terms or signs out.
+ *
+ * Accessibility: role=dialog + aria-modal, Escape does NOT close (blocking),
+ * focus trapped inside, body scroll not needed since it fills the viewport.
+ */
+export function CguRevalidationModal() {
+  const { needsRevalidation, acceptCurrentVersion } = useCguStatus();
+  const { signOut } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!needsRevalidation) return;
+    dialogRef.current?.focus();
+  }, [needsRevalidation]);
+
+  if (!needsRevalidation) return null;
+
+  async function handleAccept() {
+    setSubmitting(true);
+    setError(null);
+    const ok = await acceptCurrentVersion();
+    if (!ok) {
+      setError("Impossible d'enregistrer. Vérifie ta connexion et réessaie.");
+    }
+    setSubmitting(false);
+  }
+
+  async function handleSignOut() {
+    setSubmitting(true);
+    try {
+      await signOut();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm flex items-center justify-center p-4 overflow-y-auto">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cgu-revalidation-title"
+        tabIndex={-1}
+        className="w-full max-w-lg rounded-2xl bg-surface border border-card-border p-6 shadow-2xl space-y-5 focus:outline-none"
+      >
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="w-5 h-5 text-brand" aria-hidden="true" />
+          <h2 id="cgu-revalidation-title" className="font-display text-lg font-black text-heading">
+            Mise à jour des conditions
+          </h2>
+        </div>
+
+        <p className="text-sm text-body leading-relaxed">
+          Nos <strong>Conditions Générales d'Utilisation</strong> et notre <strong>Politique de Confidentialité</strong>{' '}
+          ont été mises à jour (version {CURRENT_CGU_VERSION}). L'accès à l'app est suspendu le temps que tu les
+          acceptes.
+        </p>
+
+        <div className="rounded-xl bg-surface-card border border-divider p-4">
+          <p className="text-xs font-medium text-muted uppercase tracking-wider mb-2">Principales évolutions</p>
+          <ul className="space-y-1.5 text-sm text-body">
+            {CGU_VERSION_CHANGES.map((change) => (
+              <li key={change} className="flex gap-2">
+                <span className="text-brand" aria-hidden="true">
+                  •
+                </span>
+                <span className="flex-1">{change}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <p className="text-xs text-muted">
+          Consulte le détail dans les{' '}
+          <Link to="/legal/cgu" className="text-link underline" target="_blank" rel="noopener">
+            CGU
+          </Link>{' '}
+          et la{' '}
+          <Link to="/legal/privacy" className="text-link underline" target="_blank" rel="noopener">
+            Politique de confidentialité
+          </Link>
+          .
+        </p>
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+
+        <div className="flex flex-col-reverse sm:flex-row gap-2 pt-2">
+          <button
+            type="button"
+            onClick={handleSignOut}
+            disabled={submitting}
+            className="flex-1 py-3 rounded-xl text-sm font-medium text-body border border-divider hover:bg-divider transition-colors disabled:opacity-50"
+          >
+            Me déconnecter
+          </button>
+          <button
+            type="button"
+            onClick={handleAccept}
+            disabled={submitting}
+            className="flex-1 py-3 rounded-xl text-sm font-bold text-white cta-gradient disabled:opacity-50"
+          >
+            {submitting ? 'Enregistrement…' : 'Accepter et continuer'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/config/legal.ts
+++ b/src/config/legal.ts
@@ -13,6 +13,10 @@ export const CURRENT_CGU_VERSION = '2026-04';
 /**
  * Short human-readable summary of what changed in the current version.
  * Rendered inside the re-validation modal so users know why they are prompted.
+ *
+ * IMPORTANT: this list MUST be rewritten from scratch at every bump of
+ * CURRENT_CGU_VERSION. Stale items from previous versions would mislead users
+ * and undermine the informed-consent requirement (art. 7 RGPD).
  */
 export const CGU_VERSION_CHANGES: string[] = [
   "Ajout d'un suivi nutritionnel (journal des repas, cible calorique optionnelle).",

--- a/src/config/legal.ts
+++ b/src/config/legal.ts
@@ -1,0 +1,22 @@
+/**
+ * Current CGU/Politique de Confidentialité version.
+ *
+ * Bump this value every time the documents change in a way that affects the
+ * user's consent (new finality, new data processor, new data category).
+ * Users whose `profiles.cgu_version_accepted` does not match will see the
+ * CguRevalidationModal at login until they accept the new version.
+ *
+ * Format: ISO date `YYYY-MM` to make re-validation cycles explicit.
+ */
+export const CURRENT_CGU_VERSION = '2026-04';
+
+/**
+ * Short human-readable summary of what changed in the current version.
+ * Rendered inside the re-validation modal so users know why they are prompted.
+ */
+export const CGU_VERSION_CHANGES: string[] = [
+  "Ajout d'un suivi nutritionnel (journal des repas, cible calorique optionnelle).",
+  "Élargissement du sous-traitant Anthropic pour l'estimation IA des calories (abonnés premium).",
+  'Nouveau sous-traitant applicatif : Open Food Facts (scan code-barres, appel direct côté client).',
+  'Nouvelles finalités et bases légales détaillées dans la Politique de Confidentialité.',
+];

--- a/src/config/nutrition.ts
+++ b/src/config/nutrition.ts
@@ -73,11 +73,13 @@ export const GOAL_MACRO_SPLIT: Record<NutritionGoal, { protein: number; carbs: n
 
 /**
  * Safety bounds for the ephemeral TDEE form (client-only validation).
- * age.min = 16 aligns with French RGPD digital-consent age (15+1 buffer) and
- * avoids exposing minors to calorie tracking without a dedicated onboarding.
+ * age.min = 18 aligns with the CGU section "Suivi nutritionnel" which restricts
+ * the feature to adults; calorie tracking may qualify as art. 9 RGPD health
+ * data under Lindenapotheke C-21/23 and CNIL guidance for minors is much
+ * stricter.
  */
 export const TDEE_BOUNDS = {
-  age: { min: 16, max: 100 },
+  age: { min: 18, max: 100 },
   heightCm: { min: 120, max: 230 },
   weightKg: { min: 30, max: 250 },
   targetCalories: { min: 1000, max: 5000 },

--- a/src/hooks/useCguStatus.ts
+++ b/src/hooks/useCguStatus.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+import { CURRENT_CGU_VERSION } from '../config/legal.ts';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+
+export interface UseCguStatusResult {
+  /** True while auth is still resolving. The modal MUST wait before rendering. */
+  loading: boolean;
+  /** True when the user is authenticated and their recorded version is stale. */
+  needsRevalidation: boolean;
+  /** Persist the current version for the authenticated user. */
+  acceptCurrentVersion: () => Promise<boolean>;
+}
+
+/**
+ * Computes whether the currently authenticated user needs to re-validate the
+ * CGU / Privacy Policy because the version constant bumped.
+ *
+ * Visitors (no user) are never prompted. New accounts created *after* the bump
+ * get `cgu_version_accepted=NULL` by default; the modal prompts them on first
+ * login so we always have a paper trail of the version they accepted.
+ */
+export function useCguStatus(): UseCguStatusResult {
+  const { user, profile, loading, refreshProfile } = useAuth();
+
+  const acceptCurrentVersion = useCallback(async () => {
+    if (!user || !supabase) return false;
+    const { error, sessionExpired } = await supabaseQuery(() =>
+      supabase!
+        .from('profiles')
+        .update({ cgu_version_accepted: CURRENT_CGU_VERSION })
+        .eq('id', user.id)
+        .select()
+        .single(),
+    );
+    if (sessionExpired) {
+      notifySessionExpired();
+      return false;
+    }
+    if (error) return false;
+    await refreshProfile();
+    return true;
+  }, [user, refreshProfile]);
+
+  const accepted = profile?.cgu_version_accepted ?? null;
+  const needsRevalidation = !!user && !loading && accepted !== CURRENT_CGU_VERSION;
+
+  return { loading, needsRevalidation, acceptCurrentVersion };
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,6 +6,7 @@ export interface Profile {
   avatar_url: string | null;
   organization_id: string | null;
   subscription_tier: SubscriptionTier;
+  cgu_version_accepted: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/017_cgu_revalidation.sql
+++ b/supabase/migrations/017_cgu_revalidation.sql
@@ -1,0 +1,13 @@
+-- Phase 6: CGU re-validation tracking
+--
+-- Adds a column to profiles to record which CGU version the user has accepted.
+-- When the current version constant in the app is bumped (src/config/legal.ts),
+-- existing users see a blocking modal at login until they accept the new
+-- version. This handles the RGPD obligation to re-inform users when the
+-- processing finalities change substantially (nutrition tracking triggers it).
+
+alter table public.profiles
+  add column if not exists cgu_version_accepted text;
+
+-- All existing rows get NULL → the client will treat them as needing re-validation.
+-- No backfill: forcing the prompt is the desired behaviour for this release.


### PR DESCRIPTION
## Summary

**PR 6/6 — Dernière PR de la feature suivi calorique.** Conformité RGPD : mise à jour CGU + Politique de Confidentialité, mécanisme de re-validation des users existants, alignement sur l'arrêt CJUE *Lindenapotheke* (oct. 2024) + AI Act art. 50.

### Contenu

- **Migration 017** : ajoute \`profiles.cgu_version_accepted\` (text nullable). Les users existants voient NULL → modale au prochain login.
- **\`src/config/legal.ts\`** : \`CURRENT_CGU_VERSION = '2026-04'\` + liste des changements affichés. À bumper quand la PCD/CGU change substantiellement.
- **\`useCguStatus\`** : hook qui compare la version acceptée vs actuelle + \`acceptCurrentVersion\` pour persister.
- **\`CguRevalidationModal\`** : modale bloquante (role=dialog, aria-modal, focus trap, non-fermable par Escape) montée dans \`PublicLayout\`. L'utilisateur accepte ou se déconnecte.
- **Legal.tsx** :
  - PCD : nouvelle section **"Suivi nutritionnel"** couvrant l'architecture privacy-by-design (Mifflin client-only), la position art. 9 RGPD (consent explicite 9.2.a + contrat 6.1.b), la disclosure IA, OFF, CIQUAL. Enrichissement des finalités, services tiers (Anthropic scope élargi + OFF ajouté), durées alignées CNIL (10 ans comptable, 2 ans inactivité).
  - CGU : nouvelle section **"Suivi nutritionnel"** avec consentement à l'activation (art. 9.2.a), disclaimer ±20%, notice AI Act art. 50 (transparence IA), restriction 18+, mise en garde grossesse/TCA, non-substitution médicale. Section **"Évolution des conditions"** documentant le mécanisme de re-validation.
- **\`types/auth.Profile\`** : champ \`cgu_version_accepted\` ajouté.

### Sources juridiques

Implémente les recommandations du document \`claudedocs/nutrition-rgpd-research.md\` produit par le deep-research agent. Ne se substitue PAS à un avis avocat — nécessite une passe juridique avant la mise en prod.

**Alertes documentées dans la recherche** :
- AIPD (DPIA) recommandée (potentiellement obligatoire) — à lancer via l'outil PIA CNIL avant rollout
- TIA Anthropic à documenter (post-Schrems II)
- AI Act art. 50 applicable au 2 août 2026 — label "Estimation IA" + marge d'erreur ±20% déjà affichés côté UX

## Test plan

- [x] \`npm run build\` — OK
- [x] \`npx vitest run\` — 212/212
- [x] \`npx biome check\` — clean sur les nouveaux fichiers
- [ ] Migration 017 à appliquer : \`supabase migration up\`
- [ ] **Recette Chrome** (extension non connectée — PO) :
  - User existant : login → modale bloquante "Mise à jour des conditions" → liste des changements → "Accepter et continuer" → modale disparait, profile.cgu_version_accepted = '2026-04'
  - Retour /login → login → pas de modale (déjà à jour)
  - User existant : login → modale → "Me déconnecter" → retour /login
  - User nouveau : signup → login → modale (puisque NULL au départ) → accepter → OK
  - /legal/privacy et /legal/cgu : vérifier que les nouvelles sections "Suivi nutritionnel" sont visibles et lisibles
  - Vérifier la date "avril 2026 (version 2026-04)" affichée sur les 2 pages

## Pré-requis

- PRs 1 à 5 mergées
- Migration 017 à appliquer en base (dev + prod)

## Post-merge

- [ ] Avis avocat (idéalement spécialisé numérique/santé) avant annonce
- [ ] Lancer l'AIPD sur l'outil CNIL PIA
- [ ] Ajouter l'AIPD finalisée à \`claudedocs/\` ou dossier DPO interne

Feature entièrement livrée 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)