### PR TITLE
fix(nutrition): QA feedback — aria-label FR, scanner label, CIQUAL seed dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 
 # Working files
 work/
+tmp/
 
 # Environment variables
 .env

--- a/scripts/seed-food-reference.ts
+++ b/scripts/seed-food-reference.ts
@@ -38,12 +38,16 @@ async function main() {
   const idx = buildColumnIndex(headers);
   console.log(`Parsed ${rows.length} rows with ${headers.length} columns`);
 
-  const records: FoodReferenceRow[] = [];
+  // CIQUAL 2020 contains a duplicate alim_code (9621 "Son de blé"); dedupe by id
+  // so the per-batch UPSERT doesn't trip Postgres's "ON CONFLICT DO UPDATE
+  // command cannot affect row a second time" error.
+  const recordsById = new Map<string, FoodReferenceRow>();
   for (const row of rows) {
     const record = mapRow(row, idx);
-    if (record) records.push(record);
+    if (record) recordsById.set(record.id, record);
   }
-  console.log(`Mapped ${records.length} valid food entries`);
+  const records: FoodReferenceRow[] = [...recordsById.values()];
+  console.log(`Mapped ${records.length} unique food entries (${rows.length} raw rows)`);
 
   const supabase = createClient(url, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },

--- a/scripts/seed-food-reference.ts
+++ b/scripts/seed-food-reference.ts
@@ -41,13 +41,19 @@ async function main() {
   // CIQUAL 2020 contains a duplicate alim_code (9621 "Son de blé"); dedupe by id
   // so the per-batch UPSERT doesn't trip Postgres's "ON CONFLICT DO UPDATE
   // command cannot affect row a second time" error.
+  // Last-occurrence-wins: acceptable because the known 9621 duplicate has
+  // identical nutrition values. If a future CIQUAL release ships a duplicate
+  // with diverging values, the trailing CSV row will silently win — revisit
+  // this policy (or raise) when it happens.
   const recordsById = new Map<string, FoodReferenceRow>();
   for (const row of rows) {
     const record = mapRow(row, idx);
     if (record) recordsById.set(record.id, record);
   }
   const records: FoodReferenceRow[] = [...recordsById.values()];
-  console.log(`Mapped ${records.length} unique food entries (${rows.length} raw rows)`);
+  const duplicates = rows.length - records.length;
+  const dupNote = duplicates > 0 ? `, ${duplicates} duplicate(s) collapsed` : '';
+  console.log(`Mapped ${records.length} unique food entries (${rows.length} raw rows${dupNote})`);
 
   const supabase = createClient(url, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react';
+import { MEAL_TYPE_LABELS } from '../../config/nutrition.ts';
 import { useOpenFoodFacts } from '../../hooks/useOpenFoodFacts.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
-import { MEAL_TYPE_LABELS } from '../../config/nutrition.ts';
 import type { MealType } from '../../types/nutrition.ts';
 import { BarcodeScanner } from './BarcodeScanner.tsx';
 

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react';
 import { useOpenFoodFacts } from '../../hooks/useOpenFoodFacts.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
+import { MEAL_TYPE_LABELS } from '../../config/nutrition.ts';
 import type { MealType } from '../../types/nutrition.ts';
 import { BarcodeScanner } from './BarcodeScanner.tsx';
 
@@ -65,7 +66,7 @@ export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) 
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted">
-          Repas : <span className="text-body font-medium">{mealType}</span>
+          Repas : <span className="text-body font-medium">{MEAL_TYPE_LABELS[mealType]}</span>
         </p>
         <button
           type="button"

--- a/src/components/nutrition/DailyFeed.tsx
+++ b/src/components/nutrition/DailyFeed.tsx
@@ -31,7 +31,7 @@ export function DailyFeed({ byMealType, onAdd, onDelete }: DailyFeedProps) {
                 type="button"
                 onClick={() => onAdd(mealType)}
                 className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium text-brand hover:bg-brand/10 transition-colors"
-                aria-label={`Ajouter au ${MEAL_TYPE_LABELS[mealType].toLowerCase()}`}
+                aria-label={`Ajouter un repas — ${MEAL_TYPE_LABELS[mealType]}`}
               >
                 <Plus className="w-4 h-4" aria-hidden="true" />
                 Ajouter


### PR DESCRIPTION
## Contexte

Recette Chrome end-to-end sur la feature Nutrition (6 PRs mergées récemment). 3 écarts trouvés, tous traités ici.

## Fixes

### 1. `DailyFeed.tsx` — aria-label français
`"Ajouter au ${label.toLowerCase()}"` produisait **« Ajouter au autre »** (solécisme FR). Remplacé par `"Ajouter un repas — ${label}"` uniforme sur les 5 types de repas.

### 2. `BarcodePane.tsx` — i18n label repas
Le bandeau scanner affichait la clé enum brute (`dinner`, `breakfast`…) au lieu du label français. Passe désormais par `MEAL_TYPE_LABELS[mealType]`.

### 3. `scripts/seed-food-reference.ts` — dedup CIQUAL
CIQUAL 2020 contient un doublon `alim_code=9621` (« Son de blé ») qui fait planter l'upsert Postgres sur le dernier batch :
```
ON CONFLICT DO UPDATE command cannot affect row a second time
```
Fix : dédup via `Map<string, FoodReferenceRow>` avant les batches (last-occurrence-wins, commenté). Testé en live → 3185 rows seedées, 1 doublon collapsé, 0 échec.

### NITs
- Ordre d'imports `BarcodePane.tsx` (valeur avant type)
- Log seed explicite le nb de doublons collapsés
- `.gitignore`: ajout de `tmp/`

## Tests
- `npm run build` ✅ (3.24 s)
- `npm test -- --run` ✅ 212/212 verts
- Recette Chrome ✅ saisie manuelle, recherche CIQUAL (« pomme » → 12 résultats, Chausson 338 kcal/100g × 150g = 507 kcal), scanner Nutella, onboarding éphémère Mifflin (H/30/180/80/modérée/maintien = 2759 kcal), widget Home synchro, CGU modal OK.

## Test plan
- [ ] Build CI vert
- [ ] Tests CI verts
- [ ] Manual sanity-check sur staging (saisie repas, recherche CIQUAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)