### PR TITLE
fix(security): SEC-01 — strip age/sexe from programs.onboarding_data (RGPD minimization)

### DIFF
--- a/src/types/completion.ts
+++ b/src/types/completion.ts
@@ -27,7 +27,7 @@ export interface Program {
   note_coach: string | null;
   progression: import('./custom-program.ts').ProgramProgression | null;
   consignes_semaine: Record<string, string> | null;
-  onboarding_data: import('./custom-program.ts').ProgramOnboardingInput | null;
+  onboarding_data: import('./custom-program.ts').PersistedProgramOnboarding | null;
 }
 
 export interface ProgramSession {

--- a/src/types/custom-program.ts
+++ b/src/types/custom-program.ts
@@ -3,6 +3,12 @@ import type { Equipment } from './equipment.ts';
 export type ExperienceDuree = 'debutant' | 'six_mois_deux_ans' | 'plus_deux_ans';
 export type FrequenceActuelle = 'jamais' | 'une_deux' | 'trois_quatre' | 'cinq_plus';
 
+/**
+ * What the UI collects and sends to the `generate-program` edge function.
+ * `age` and `sexe` are transmitted to Anthropic at generation time (disclosed
+ * in the Privacy Policy) but are NOT persisted afterwards — see
+ * `PersistedProgramOnboarding` below and `supabase/functions/generate-program/sanitize.ts`.
+ */
 export interface ProgramOnboardingInput {
   objectifs: string[];
   objectif_detail?: string;
@@ -17,6 +23,15 @@ export interface ProgramOnboardingInput {
   materiel: Equipment[];
   duree_semaines: 4 | 8 | 12;
 }
+
+/**
+ * What is actually stored at rest in `programs.onboarding_data`. Mirrors
+ * `ProgramOnboardingInput` minus `age` and `sexe` (RGPD minimization).
+ * Keep this in sync with `PersistableOnboarding` in
+ * `supabase/functions/generate-program/sanitize.ts` — same shape, duplicated
+ * because Deno edge functions cannot import from `src/`.
+ */
+export type PersistedProgramOnboarding = Omit<ProgramOnboardingInput, 'age' | 'sexe'>;
 
 export interface ProgramProgression {
   logique: string;

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -1,6 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
+import { sanitizeOnboardingForPersistence } from "./sanitize.ts";
 import { validateProgram } from "./validate.ts";
 
 const PROD_ORIGINS = [
@@ -379,7 +380,10 @@ Deno.serve(async (req: Request) => {
       note_coach: pgm.note_coach,
       progression: pgm.progression,
       consignes_semaine: pgm.consignes_semaine,
-      onboarding_data: body,
+      // Strip age/sexe before persistence — RGPD art. 5(1)(c) minimization.
+      // Both are still sent to Anthropic at generation time (declared in the
+      // Privacy Policy) but never re-read by the app afterwards.
+      onboarding_data: sanitizeOnboardingForPersistence(body),
       generation_metadata: pgm,
       input_tokens: totalInputTokens,
       output_tokens: totalOutputTokens,

--- a/supabase/functions/generate-program/sanitize.test.ts
+++ b/supabase/functions/generate-program/sanitize.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeOnboardingForPersistence } from './sanitize.ts';
+
+const baseInput = {
+  objectifs: ['perte_poids'],
+  experience_duree: 'debutant',
+  frequence_actuelle: 'une_deux',
+  blessures: [],
+  seances_par_semaine: 3,
+  duree_seance_minutes: 45,
+  materiel: ['poids_du_corps'],
+  duree_semaines: 8,
+};
+
+describe('sanitizeOnboardingForPersistence', () => {
+  it('strips age and sexe from the payload', () => {
+    const sanitized = sanitizeOnboardingForPersistence({ ...baseInput, age: 32, sexe: 'femme' });
+    expect(sanitized).not.toHaveProperty('age');
+    expect(sanitized).not.toHaveProperty('sexe');
+  });
+
+  it('preserves the fields that are still useful at rest', () => {
+    const sanitized = sanitizeOnboardingForPersistence({
+      ...baseInput,
+      objectif_detail: 'perdre 3kg',
+      blessure_detail: 'dos parfois sensible',
+      age: 40,
+      sexe: 'homme',
+    });
+
+    expect(sanitized).toEqual({
+      objectifs: ['perte_poids'],
+      objectif_detail: 'perdre 3kg',
+      experience_duree: 'debutant',
+      frequence_actuelle: 'une_deux',
+      blessures: [],
+      blessure_detail: 'dos parfois sensible',
+      seances_par_semaine: 3,
+      duree_seance_minutes: 45,
+      materiel: ['poids_du_corps'],
+      duree_semaines: 8,
+    });
+  });
+
+  it('drops any unexpected property added to the body', () => {
+    const sanitized = sanitizeOnboardingForPersistence({
+      ...baseInput,
+      adresse_postale: '12 rue X',
+      numero_telephone: '+33 6 00 00 00 00',
+    } as never);
+    expect(sanitized).not.toHaveProperty('adresse_postale');
+    expect(sanitized).not.toHaveProperty('numero_telephone');
+  });
+
+  it('works when optional fields are absent', () => {
+    const sanitized = sanitizeOnboardingForPersistence(baseInput);
+    expect(sanitized.objectif_detail).toBeUndefined();
+    expect(sanitized.blessure_detail).toBeUndefined();
+  });
+});

--- a/supabase/functions/generate-program/sanitize.ts
+++ b/supabase/functions/generate-program/sanitize.ts
@@ -1,0 +1,48 @@
+/**
+ * Privacy-minimization helpers for `programs.onboarding_data`.
+ *
+ * RGPD art. 5(1)(c) — data minimization: only persist what the feature
+ * actually needs downstream. `age` and `sexe` are sent to Anthropic at
+ * generation time (disclosed in the Privacy Policy) but never re-used by
+ * the app afterwards — storing them long-term in Supabase would create
+ * unnecessary exposure, especially combined with declared injuries which
+ * can shift the dataset toward RGPD art. 9 (health data).
+ *
+ * `onboarding_data` is preserved as a jsonb column for future replay /
+ * debugging of the generation; we project it to the subset that is safe
+ * to keep at rest.
+ */
+
+export interface PersistableOnboarding {
+  objectifs: string[];
+  objectif_detail?: string;
+  experience_duree: string;
+  frequence_actuelle: string;
+  blessures: string[];
+  blessure_detail?: string;
+  seances_par_semaine: number;
+  duree_seance_minutes: number;
+  materiel: string[];
+  duree_semaines: number;
+}
+
+/**
+ * Strips `age` and `sexe` (and any unknown key, defensive) from the raw
+ * request body before it is written to `programs.onboarding_data`.
+ */
+export function sanitizeOnboardingForPersistence(
+  body: PersistableOnboarding & { age?: number; sexe?: string; [key: string]: unknown },
+): PersistableOnboarding {
+  return {
+    objectifs: body.objectifs,
+    objectif_detail: body.objectif_detail,
+    experience_duree: body.experience_duree,
+    frequence_actuelle: body.frequence_actuelle,
+    blessures: body.blessures,
+    blessure_detail: body.blessure_detail,
+    seances_par_semaine: body.seances_par_semaine,
+    duree_seance_minutes: body.duree_seance_minutes,
+    materiel: body.materiel,
+    duree_semaines: body.duree_semaines,
+  };
+}

--- a/supabase/functions/generate-program/sanitize.ts
+++ b/supabase/functions/generate-program/sanitize.ts
@@ -13,6 +13,18 @@
  * to keep at rest.
  */
 
+/**
+ * Keep in sync with `PersistedProgramOnboarding` in
+ * `src/types/custom-program.ts` — same shape, duplicated because Deno edge
+ * functions cannot import from `src/`.
+ *
+ * `objectif_detail` and `blessure_detail` are free-text fields retained for
+ * future replay/debugging of the AI generation. `blessure_detail` in
+ * particular sits close to RGPD art. 9 (health data); its retention is
+ * justified by the need to reconstruct why the AI produced a given program
+ * and by the explicit user input. Revisit if the feature no longer requires
+ * the replay capability.
+ */
 export interface PersistableOnboarding {
   objectifs: string[];
   objectif_detail?: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.{ts,tsx}', 'scripts/**/*.test.ts'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'scripts/**/*.test.ts',
+      'supabase/functions/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Contexte

SEC-01 du rapport d'audit sécu/RGPD (`claudedocs/audit-2026-04-18/02-security-rgpd.md`).

L'edge function `generate-program` persistait l'intégralité du `RequestInput` dans `programs.onboarding_data`, y compris `age` et `sexe`. Ces deux champs ne sont jamais relus par l'app mais restent stockés — ce qui :
- Contredit l'esprit de la section "privacy by design" de la Politique de Confidentialité
- Combinés aux blessures déclarées, pousse la ligne vers RGPD art. 9 (données de santé inférables)
- N'apporte aucune valeur fonctionnelle (grep confirme zéro lecteur downstream)

## Fix

- Nouveau module `supabase/functions/generate-program/sanitize.ts` avec `sanitizeOnboardingForPersistence()` : whitelist projection qui drop explicitement `age`, `sexe` et défensivement toute clé inconnue.
- `generate-program/index.ts` : `onboarding_data: sanitizeOnboardingForPersistence(body)`.
- Nouveau type `PersistedProgramOnboarding = Omit<ProgramOnboardingInput, 'age' | 'sexe'>` utilisé dans `Program.onboarding_data` → type honnête aligné avec la réalité au repos.
- Commentaires RGPD cross-référencés entre les 3 fichiers (explique pourquoi le free-text `blessure_detail` / `objectif_detail` est retenu pour replay/debug).

## Tests

- 4 cas Vitest sur `sanitize.ts` :
  - strip `age` + `sexe`
  - préserve tous les champs utiles (optionnels inclus)
  - drop défensif des clés inconnues (guard vs futur élargissement frontend)
  - optionnels absents
- `vitest.config.ts` étendu pour inclure `supabase/functions/**/*.test.ts` (les tests edge function étaient silencieusement ignorés)
- `npm run build` ✅ · `npm test -- --run` ✅ 216/216

## Non impactées

Vérifié par l'audit que les autres edge functions (`generate-session`, `estimate-nutrition`, `stripe-*`) ne persistent pas de données démographiques — aucun autre fix nécessaire.

## Base de données

Aucune migration. La colonne `onboarding_data` (jsonb) reste inchangée ; les nouvelles lignes seront minimales, les anciennes conservent leur contenu (rétroactivement ces données pourraient être purgées dans un passe séparé si souhaité — hors scope ici).

## Test plan
- [ ] Build CI vert
- [ ] Tests CI verts
- [ ] Une génération de programme IA après merge → `onboarding_data` ne contient plus `age`/`sexe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)