### PR TITLE
test(edge-functions): cover critical validators + Stripe HMAC (closes P0-tests)

### DIFF
--- a/supabase/functions/estimate-nutrition/validate.test.ts
+++ b/supabase/functions/estimate-nutrition/validate.test.ts
@@ -58,6 +58,12 @@ describe('validateTextEstimate', () => {
     expect(validateTextEstimate({ ...baseValid, name: longName })).toEqual({ ok: false, error: 'name_too_long' });
   });
 
+  it('accepts calories at the zero boundary (water, coffee, etc.)', () => {
+    const result = validateTextEstimate({ ...baseValid, calories: 0 });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.calories).toBe(0);
+  });
+
   it('rejects calories that are not a finite positive number ≤ 5000', () => {
     expect(validateTextEstimate({ ...baseValid, calories: -1 }).ok).toBe(false);
     expect(validateTextEstimate({ ...baseValid, calories: 5001 }).ok).toBe(false);

--- a/supabase/functions/estimate-nutrition/validate.test.ts
+++ b/supabase/functions/estimate-nutrition/validate.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { validateOverflowInsight, validateTextEstimate } from './validate.ts';
+
+describe('validateTextEstimate', () => {
+  const baseValid = {
+    name: 'Salade de lentilles',
+    calories: 320,
+    protein_g: 18,
+    carbs_g: 45,
+    fat_g: 8,
+    confidence: 'medium' as const,
+  };
+
+  it('returns ok on a fully valid payload', () => {
+    const result = validateTextEstimate(baseValid);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe('Salade de lentilles');
+      expect(result.value.calories).toBe(320);
+      expect(result.value.confidence).toBe('medium');
+    }
+  });
+
+  it('rounds numeric fields to one decimal', () => {
+    const result = validateTextEstimate({ ...baseValid, calories: 123.456, protein_g: 7.89 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.calories).toBe(123.5);
+      expect(result.value.protein_g).toBe(7.9);
+    }
+  });
+
+  it('accepts null macros', () => {
+    const result = validateTextEstimate({ ...baseValid, protein_g: null, carbs_g: null, fat_g: null });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.protein_g).toBeNull();
+      expect(result.value.carbs_g).toBeNull();
+      expect(result.value.fat_g).toBeNull();
+    }
+  });
+
+  it('rejects non-objects', () => {
+    expect(validateTextEstimate(null)).toEqual({ ok: false, error: 'not_object' });
+    expect(validateTextEstimate('hello')).toEqual({ ok: false, error: 'not_object' });
+    expect(validateTextEstimate(42)).toEqual({ ok: false, error: 'not_object' });
+  });
+
+  it('rejects missing or empty name', () => {
+    expect(validateTextEstimate({ ...baseValid, name: '' })).toEqual({ ok: false, error: 'missing_name' });
+    expect(validateTextEstimate({ ...baseValid, name: '   ' })).toEqual({ ok: false, error: 'missing_name' });
+    const { name: _name, ...noName } = baseValid;
+    expect(validateTextEstimate(noName)).toEqual({ ok: false, error: 'missing_name' });
+  });
+
+  it('rejects name longer than 120 characters', () => {
+    const longName = 'a'.repeat(121);
+    expect(validateTextEstimate({ ...baseValid, name: longName })).toEqual({ ok: false, error: 'name_too_long' });
+  });
+
+  it('rejects calories that are not a finite positive number ≤ 5000', () => {
+    expect(validateTextEstimate({ ...baseValid, calories: -1 }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, calories: 5001 }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, calories: Number.NaN }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, calories: Number.POSITIVE_INFINITY }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, calories: '320' }).ok).toBe(false);
+  });
+
+  it('rejects macros out of [0, 500] (hallucination guard)', () => {
+    expect(validateTextEstimate({ ...baseValid, protein_g: 501 }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, protein_g: -1 }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, carbs_g: 9999 }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, fat_g: 501 }).ok).toBe(false);
+  });
+
+  it('rejects unknown confidence values', () => {
+    expect(validateTextEstimate({ ...baseValid, confidence: 'very-high' }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, confidence: '' }).ok).toBe(false);
+    expect(validateTextEstimate({ ...baseValid, confidence: undefined }).ok).toBe(false);
+  });
+
+  it('trims the name', () => {
+    const result = validateTextEstimate({ ...baseValid, name: '  Poulet rôti  ' });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.name).toBe('Poulet rôti');
+  });
+});
+
+describe('validateOverflowInsight', () => {
+  it('accepts a valid insight', () => {
+    const result = validateOverflowInsight({
+      summary: 'Tu es au-dessus de ta cible calorique, principalement à cause des glucides du midi.',
+      suggestions: ['Réduire les pâtes de 50g demain', 'Ajouter des légumes verts'],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(validateOverflowInsight(null)).toEqual({ ok: false, error: 'not_object' });
+    expect(validateOverflowInsight(12)).toEqual({ ok: false, error: 'not_object' });
+  });
+
+  it('rejects missing or empty summary', () => {
+    expect(validateOverflowInsight({ suggestions: [] })).toEqual({ ok: false, error: 'missing_summary' });
+    expect(validateOverflowInsight({ summary: '   ', suggestions: [] })).toEqual({
+      ok: false,
+      error: 'missing_summary',
+    });
+  });
+
+  it('rejects a summary longer than 2000 characters', () => {
+    const result = validateOverflowInsight({ summary: 'a'.repeat(2001), suggestions: [] });
+    expect(result).toEqual({ ok: false, error: 'summary_too_long' });
+  });
+
+  it('trims the summary', () => {
+    const result = validateOverflowInsight({ summary: '  OK  ', suggestions: [] });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.summary).toBe('OK');
+  });
+
+  it('caps suggestions at 3 and drops empty / over-long entries', () => {
+    const result = validateOverflowInsight({
+      summary: 'Résumé valide',
+      suggestions: ['', 'OK-1', '   ', 'OK-2', 'a'.repeat(301), 'OK-3', 'OK-4'],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.suggestions).toEqual(['OK-1', 'OK-2', 'OK-3']);
+    }
+  });
+
+  it('tolerates non-string entries in suggestions', () => {
+    const result = validateOverflowInsight({
+      summary: 'Résumé',
+      suggestions: ['ok', 42, null, 'also-ok'],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.suggestions).toEqual(['ok', 'also-ok']);
+  });
+
+  it('trims suggestion entries', () => {
+    const result = validateOverflowInsight({ summary: 'ok', suggestions: ['  spaced  '] });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.suggestions).toEqual(['spaced']);
+  });
+
+  it('handles missing suggestions array gracefully (returns empty)', () => {
+    const result = validateOverflowInsight({ summary: 'only summary' });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.suggestions).toEqual([]);
+  });
+});

--- a/supabase/functions/generate-program/validate.test.ts
+++ b/supabase/functions/generate-program/validate.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { validateProgram, validateSession } from './validate.ts';
+
+/** Minimal valid embedded session (shared by the program payload). */
+function embeddedSession(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Séance A',
+    description: 'Jambes et cardio',
+    estimatedDuration: 30,
+    focus: ['jambes'],
+    blocks: [
+      { type: 'warmup', name: 'Échauffement', exercises: [{ name: 'Mobilité', duration: 60, instructions: 'Relax' }] },
+      {
+        type: 'classic',
+        name: 'Force',
+        restBetweenExercises: 30,
+        exercises: [
+          {
+            name: 'Squats',
+            sets: 3,
+            reps: 10,
+            restBetweenSets: 60,
+            instructions: 'Descendre lentement',
+          },
+        ],
+      },
+      { type: 'cooldown', name: 'Récup', exercises: [{ name: 'Étirement', duration: 60, instructions: 'Respirer' }] },
+    ],
+    ...overrides,
+  };
+}
+
+function baseProgram(overrides: Record<string, unknown> = {}) {
+  return {
+    titre: 'Programme Test',
+    description: 'Description du programme de test',
+    niveau: 'intermediaire',
+    note_coach: "Note du coach pour l'utilisateur, en 3 phrases au moins.",
+    progression: { logique: 'Progression classique sur 4 semaines' },
+    sessions: {
+      A: embeddedSession({ title: 'Séance A' }),
+      B: embeddedSession({ title: 'Séance B', focus: ['haut du corps'] }),
+    },
+    calendrier: [{ semaines: [1, 2, 3, 4], sequence: ['A', 'B'] }],
+    consignes_semaine: { '1': 'Prendre ses marques', '2-4': 'Monter en intensité' },
+    ...overrides,
+  };
+}
+
+describe('validateProgram — happy path', () => {
+  it('accepts a well-formed 4-week program with 2 sessions', () => {
+    const result = validateProgram(baseProgram(), 4, 3);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateProgram — off-topic', () => {
+  it('reports off-topic distinctly', () => {
+    expect(validateProgram({ error: 'off_topic' }, 4, 3)).toEqual({ valid: false, error: 'off_topic' });
+  });
+});
+
+describe('validateProgram — top-level fields', () => {
+  it.each([
+    ['titre', 'titre is required'],
+    ['description', 'description is required'],
+  ])('requires %s', (field, error) => {
+    expect(validateProgram(baseProgram({ [field]: undefined }), 4, 3)).toEqual({ valid: false, error });
+  });
+
+  it('requires niveau to be one of debutant/intermediaire/avance', () => {
+    expect(validateProgram(baseProgram({ niveau: 'expert' }), 4, 3).valid).toBe(false);
+  });
+
+  it('requires a non-empty note_coach', () => {
+    expect(validateProgram(baseProgram({ note_coach: '' }), 4, 3)).toEqual({
+      valid: false,
+      error: 'note_coach is required',
+    });
+  });
+});
+
+describe('validateProgram — sessions count bounds', () => {
+  it('rejects fewer than 2 sessions', () => {
+    const single = { A: embeddedSession() };
+    const result = validateProgram(baseProgram({ sessions: single }), 4, 3);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('sessions must have 2-5 entries');
+  });
+
+  it('rejects more than 5 sessions', () => {
+    const six = Object.fromEntries(
+      ['A', 'B', 'C', 'D', 'E', 'F'].map((k) => [k, embeddedSession({ title: `S ${k}` })]),
+    );
+    const result = validateProgram(baseProgram({ sessions: six }), 4, 6);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('sessions must have 2-5 entries');
+  });
+
+  it('rejects more sessions than maxSessionsPerWeek allows', () => {
+    const four = Object.fromEntries(['A', 'B', 'C', 'D'].map((k) => [k, embeddedSession({ title: `S ${k}` })]));
+    const result = validateProgram(
+      baseProgram({ sessions: four, calendrier: [{ semaines: [1, 2, 3, 4], sequence: ['A', 'B', 'C', 'D'] }] }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('exceeds seances_par_semaine');
+  });
+});
+
+describe('validateProgram — calendrier coverage', () => {
+  it('rejects calendrier that misses a week', () => {
+    const result = validateProgram(baseProgram({ calendrier: [{ semaines: [1, 2, 3], sequence: ['A', 'B'] }] }), 4, 3);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('week 4 not covered');
+  });
+
+  it('rejects a session referenced in the sequence but absent from sessions', () => {
+    const result = validateProgram(
+      baseProgram({ calendrier: [{ semaines: [1, 2, 3, 4], sequence: ['A', 'B', 'GHOST'] }] }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('"GHOST" not found');
+  });
+
+  it('rejects empty semaines or sequence', () => {
+    const empty1 = validateProgram(
+      baseProgram({ calendrier: [{ semaines: [], sequence: ['A'] }, { semaines: [1, 2, 3, 4], sequence: ['A', 'B'] }] }),
+      4,
+      3,
+    );
+    expect(empty1.valid).toBe(false);
+    expect(empty1.error).toContain('semaines required');
+
+    const empty2 = validateProgram(
+      baseProgram({ calendrier: [{ semaines: [1], sequence: [] }, { semaines: [2, 3, 4], sequence: ['A', 'B'] }] }),
+      4,
+      3,
+    );
+    expect(empty2.valid).toBe(false);
+    expect(empty2.error).toContain('sequence required');
+  });
+
+  it('accepts multiple calendrier entries covering disjoint week ranges', () => {
+    const result = validateProgram(
+      baseProgram({
+        calendrier: [
+          { semaines: [1, 2], sequence: ['A', 'B'] },
+          { semaines: [3, 4], sequence: ['B', 'A'] },
+        ],
+      }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateProgram — consignes_semaine', () => {
+  it('requires at least one consigne entry', () => {
+    const result = validateProgram(baseProgram({ consignes_semaine: {} }), 4, 3);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('at least one entry');
+  });
+
+  it('rejects non-string consigne values', () => {
+    const result = validateProgram(baseProgram({ consignes_semaine: { '1': 123 } }), 4, 3);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('must be a string');
+  });
+});
+
+describe('validateProgram — sanitization', () => {
+  it('strips HTML + URLs from top-level strings and note_coach (up to 2000 chars)', () => {
+    const longNote = `Voir ${'https://evil.example '.repeat(60)} et <b>ok</b>`;
+    const program = baseProgram({
+      titre: 'Programme <script>evil</script>',
+      description: 'Plan d\'attaque https://bad.example',
+      note_coach: longNote,
+    });
+    const result = validateProgram(program, 4, 3);
+    expect(result.valid).toBe(true);
+    expect((program as Record<string, unknown>).titre).toBe('Programme evil');
+    expect((program as Record<string, unknown>).description).toBe("Plan d'attaque ");
+    const sanitizedNote = (program as Record<string, unknown>).note_coach as string;
+    expect(sanitizedNote).not.toContain('<');
+    expect(sanitizedNote).not.toContain('http');
+    expect(sanitizedNote.length).toBeLessThanOrEqual(2000);
+  });
+
+  it('sanitizes progression.logique and consignes_semaine values', () => {
+    const program = baseProgram({
+      progression: { logique: 'On augmente <b>lourd</b> via https://x.y' },
+      consignes_semaine: { '1': 'Attention <script>x</script>' },
+    });
+    const result = validateProgram(program, 4, 3);
+    expect(result.valid).toBe(true);
+    const progression = (program as Record<string, unknown>).progression as Record<string, unknown>;
+    expect(progression.logique).toBe('On augmente lourd via ');
+    const consignes = (program as Record<string, unknown>).consignes_semaine as Record<string, string>;
+    expect(consignes['1']).toBe('Attention x');
+  });
+});
+
+describe('validateSession (embedded)', () => {
+  // Same structural rules as generate-session/validate.ts, just without the
+  // requestedDuration cross-check (not relevant per-session in a program).
+  it('accepts a valid embedded session', () => {
+    expect(validateSession(embeddedSession()).valid).toBe(true);
+  });
+
+  it('rejects an embedded session with a missing title', () => {
+    expect(validateSession(embeddedSession({ title: undefined })).valid).toBe(false);
+  });
+});

--- a/supabase/functions/generate-program/validate.test.ts
+++ b/supabase/functions/generate-program/validate.test.ts
@@ -203,6 +203,21 @@ describe('validateProgram — sanitization', () => {
     const consignes = (program as Record<string, unknown>).consignes_semaine as Record<string, string>;
     expect(consignes['1']).toBe('Attention x');
   });
+
+  it('sanitizes the optional progression.cible_semaine_X fields', () => {
+    const program = baseProgram({
+      progression: {
+        logique: 'ok',
+        cible_semaine_3: 'Objectif <b>clair</b> https://x.y',
+        cible_semaine_8: 'Tenir <i>rythme</i>',
+      },
+    });
+    const result = validateProgram(program, 4, 3);
+    expect(result.valid).toBe(true);
+    const progression = (program as Record<string, unknown>).progression as Record<string, unknown>;
+    expect(progression.cible_semaine_3).toBe('Objectif clair ');
+    expect(progression.cible_semaine_8).toBe('Tenir rythme');
+  });
 });
 
 describe('validateSession (embedded)', () => {

--- a/supabase/functions/generate-session/validate.test.ts
+++ b/supabase/functions/generate-session/validate.test.ts
@@ -226,7 +226,7 @@ describe('validateSession — per-block requirements', () => {
     expect(validateSession(session).error).toContain('tabata: exercise instructions required');
   });
 
-  it('emom: minutes + exercise reps are required', () => {
+  it('emom: minutes is required', () => {
     const session = baseSession({
       blocks: [
         { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },

--- a/supabase/functions/generate-session/validate.test.ts
+++ b/supabase/functions/generate-session/validate.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { validateSession } from './validate.ts';
+
+/** Minimal session skeleton accepted by the validator. */
+function baseSession(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Séance cardio',
+    description: 'Une séance rapide pour transpirer',
+    estimatedDuration: 30,
+    focus: ['cardio'],
+    blocks: [
+      {
+        type: 'warmup',
+        name: 'Échauffement',
+        exercises: [
+          { name: 'Jumping jacks', duration: 60, instructions: 'Rester léger' },
+        ],
+      },
+      {
+        type: 'classic',
+        name: 'Force',
+        restBetweenExercises: 30,
+        exercises: [
+          {
+            name: 'Squats',
+            sets: 3,
+            reps: 12,
+            restBetweenSets: 60,
+            instructions: 'Descendre jusquà la parallèle',
+          },
+        ],
+      },
+      {
+        type: 'cooldown',
+        name: 'Récup',
+        exercises: [
+          { name: 'Étirements', duration: 120, instructions: 'Respirer lentement' },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validateSession — structural checks', () => {
+  it('accepts a well-formed session', () => {
+    expect(validateSession(baseSession()).valid).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(validateSession(null).valid).toBe(false);
+    expect(validateSession('string').valid).toBe(false);
+    expect(validateSession(42).valid).toBe(false);
+  });
+
+  it('reports off-topic responses distinctly', () => {
+    expect(validateSession({ error: 'off_topic' })).toEqual({ valid: false, error: 'off_topic' });
+  });
+
+  it.each([
+    ['title', 'title is required'],
+    ['description', 'description is required'],
+  ])('requires a string %s', (field, error) => {
+    const session = baseSession({ [field]: undefined });
+    expect(validateSession(session)).toEqual({ valid: false, error });
+  });
+
+  it('requires a numeric estimatedDuration', () => {
+    expect(validateSession(baseSession({ estimatedDuration: '30' })).valid).toBe(false);
+    expect(validateSession(baseSession({ estimatedDuration: Number.NaN })).valid).toBe(false);
+  });
+
+  it('rejects an estimatedDuration far from the requested one', () => {
+    const result = validateSession(baseSession({ estimatedDuration: 45 }), 30);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('too far from requested');
+  });
+
+  it('allows estimatedDuration ±10 minutes from requested', () => {
+    expect(validateSession(baseSession({ estimatedDuration: 40 }), 30).valid).toBe(true);
+    expect(validateSession(baseSession({ estimatedDuration: 20 }), 30).valid).toBe(true);
+  });
+
+  it('requires a non-empty focus array', () => {
+    expect(validateSession(baseSession({ focus: [] })).valid).toBe(false);
+    expect(validateSession(baseSession({ focus: 'cardio' })).valid).toBe(false);
+  });
+
+  it('requires at least 2 blocks', () => {
+    const [warmup] = baseSession().blocks as Array<Record<string, unknown>>;
+    expect(validateSession(baseSession({ blocks: [warmup] })).valid).toBe(false);
+  });
+
+  it('requires the first block to be warmup', () => {
+    const session = baseSession();
+    const firstBlock = (session.blocks as Array<Record<string, unknown>>)[0];
+    firstBlock.type = 'classic';
+    expect(validateSession(session).error).toContain('First block must be warmup');
+  });
+
+  it('requires the last block to be cooldown', () => {
+    const session = baseSession();
+    const blocks = session.blocks as Array<Record<string, unknown>>;
+    blocks[blocks.length - 1].type = 'classic';
+    // Also fix the payload so we get the cooldown error, not a block-validity one
+    blocks[blocks.length - 1].restBetweenExercises = 30;
+    expect(validateSession(session).error).toContain('Last block must be cooldown');
+  });
+
+  it('rejects unknown block types', () => {
+    const session = baseSession();
+    (session.blocks as Array<Record<string, unknown>>)[1].type = 'crossfit';
+    expect(validateSession(session).error).toContain('invalid type');
+  });
+});
+
+describe('validateSession — per-block requirements', () => {
+  it('warmup: exercise needs name + duration + instructions', () => {
+    const session = baseSession();
+    const warmup = (session.blocks as Array<Record<string, unknown>>)[0];
+    warmup.exercises = [{ name: 'Jumping', duration: 60 }];
+    expect(validateSession(session).error).toContain('instructions required');
+  });
+
+  it('classic: exercise needs sets + reps + restBetweenSets', () => {
+    const session = baseSession();
+    const classic = (session.blocks as Array<Record<string, unknown>>)[1];
+    (classic.exercises as Array<Record<string, unknown>>)[0].reps = undefined;
+    expect(validateSession(session).error).toContain('reps required');
+  });
+
+  it('classic: accepts reps === "max" as a sentinel', () => {
+    const session = baseSession();
+    const classic = (session.blocks as Array<Record<string, unknown>>)[1];
+    (classic.exercises as Array<Record<string, unknown>>)[0].reps = 'max';
+    expect(validateSession(session).valid).toBe(true);
+  });
+
+  it('circuit: exercise mode must be timed or reps', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'circuit',
+          name: 'C',
+          rounds: 3,
+          restBetweenExercises: 15,
+          restBetweenRounds: 45,
+          exercises: [{ name: 'Burpees', mode: 'both', instructions: 'Go' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('mode must be timed or reps');
+  });
+
+  it('superset: pair.exercises must not be empty', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'superset',
+          name: 'S',
+          sets: 3,
+          restBetweenSets: 60,
+          pairs: [{ exercises: [] }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('pair exercises required');
+  });
+
+  it('pyramid: pattern must be a non-empty array', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'pyramid',
+          name: 'P',
+          pattern: [],
+          restBetweenSets: 30,
+          exercises: [{ name: 'Ex', instructions: 'Do it' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('pattern required');
+  });
+});
+
+describe('validateSession — sanitization', () => {
+  it('strips HTML tags and URLs from title / description / exercise instructions', () => {
+    const session = baseSession({
+      title: 'Séance <script>alert(1)</script>',
+      description: 'Voir https://evil.example plus de détails',
+    });
+    (session.blocks as Array<Record<string, unknown>>)[0].name = 'Chauffe <b>rapide</b>';
+    const warmupEx = ((session.blocks as Array<Record<string, unknown>>)[0].exercises as Array<
+      Record<string, unknown>
+    >)[0];
+    warmupEx.name = 'Jumping <img src=x>';
+    warmupEx.instructions = 'Suis https://bad.link attentivement';
+
+    const result = validateSession(session);
+    expect(result.valid).toBe(true);
+    expect(session.title).toBe('Séance alert(1)');
+    expect(session.description).toBe('Voir  plus de détails');
+    expect((session.blocks as Array<Record<string, unknown>>)[0].name).toBe('Chauffe rapide');
+    expect(warmupEx.name).toBe('Jumping ');
+    expect(warmupEx.instructions).toBe('Suis  attentivement');
+  });
+
+  it('truncates strings beyond 500 characters', () => {
+    const long = 'x'.repeat(700);
+    const session = baseSession({ title: long });
+    expect(validateSession(session).valid).toBe(true);
+    expect((session.title as string).length).toBe(500);
+  });
+});

--- a/supabase/functions/generate-session/validate.test.ts
+++ b/supabase/functions/generate-session/validate.test.ts
@@ -81,6 +81,11 @@ describe('validateSession — structural checks', () => {
     expect(validateSession(baseSession({ estimatedDuration: 20 }), 30).valid).toBe(true);
   });
 
+  it('rejects estimatedDuration at exactly diff = 11 (off-by-one guard)', () => {
+    expect(validateSession(baseSession({ estimatedDuration: 41 }), 30).valid).toBe(false);
+    expect(validateSession(baseSession({ estimatedDuration: 19 }), 30).valid).toBe(false);
+  });
+
   it('requires a non-empty focus array', () => {
     expect(validateSession(baseSession({ focus: [] })).valid).toBe(false);
     expect(validateSession(baseSession({ focus: 'cardio' })).valid).toBe(false);
@@ -186,6 +191,72 @@ describe('validateSession — per-block requirements', () => {
       ],
     });
     expect(validateSession(session).error).toContain('pattern required');
+  });
+
+  it('hiit: rounds + work + rest are required', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'hiit',
+          name: 'H',
+          // missing `rounds`
+          work: 30,
+          rest: 15,
+          exercises: [{ name: 'Sprints', instructions: 'Fort' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('hiit: rounds required');
+  });
+
+  it('tabata: exercise instructions are required', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'tabata',
+          name: 'T',
+          exercises: [{ name: 'Burpees' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('tabata: exercise instructions required');
+  });
+
+  it('emom: minutes + exercise reps are required', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'emom',
+          name: 'E',
+          // missing `minutes`
+          exercises: [{ name: 'Kettlebell swings', reps: 10, instructions: 'Explosif' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('emom: minutes required');
+  });
+
+  it('amrap: duration + exercise reps are required', () => {
+    const session = baseSession({
+      blocks: [
+        { type: 'warmup', name: 'W', exercises: [{ name: 'X', duration: 30, instructions: 'Y' }] },
+        {
+          type: 'amrap',
+          name: 'A',
+          duration: 600,
+          // exercise missing `reps`
+          exercises: [{ name: 'Squats', instructions: 'Forme avant vitesse' }],
+        },
+        { type: 'cooldown', name: 'Cd', exercises: [{ name: 'Stretch', duration: 60, instructions: 'Breathe' }] },
+      ],
+    });
+    expect(validateSession(session).error).toContain('amrap: exercise reps required');
   });
 });
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,5 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { verifyStripeSignature } from "./verify-signature.ts";
 
 const ALLOWED_ORIGINS = [
   "https://wan2fit.fr",
@@ -26,67 +27,6 @@ function jsonResponse(data: unknown, status = 200, origin?: string) {
 
 function errorResponse(message: string, status = 400, origin?: string) {
   return jsonResponse({ error: message }, status, origin);
-}
-
-// Constant-time comparison to prevent timing attacks
-function timingSafeEqual(a: string, b: string): boolean {
-  const encoder = new TextEncoder();
-  const aBytes = encoder.encode(a);
-  const bBytes = encoder.encode(b);
-  const maxLen = Math.max(aBytes.length, bBytes.length);
-  let result = aBytes.length ^ bBytes.length; // non-zero if lengths differ
-  for (let i = 0; i < maxLen; i++) {
-    result |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0);
-  }
-  return result === 0;
-}
-
-// Verify Stripe webhook signature using crypto.subtle (Deno-compatible)
-async function verifyStripeSignature(
-  payload: string,
-  sigHeader: string,
-  secret: string,
-): Promise<boolean> {
-  const parts = sigHeader.split(",").reduce(
-    (acc, part) => {
-      const [key, value] = part.split("=");
-      if (key === "t") acc.timestamp = value;
-      if (key === "v1") acc.signatures.push(value);
-      return acc;
-    },
-    { timestamp: "", signatures: [] as string[] },
-  );
-
-  if (!parts.timestamp || parts.signatures.length === 0) return false;
-
-  // Check timestamp tolerance (5 minutes)
-  const tolerance = 300;
-  const now = Math.floor(Date.now() / 1000);
-  if (Math.abs(now - parseInt(parts.timestamp, 10)) > tolerance) return false;
-
-  const signedPayload = `${parts.timestamp}.${payload}`;
-  const encoder = new TextEncoder();
-
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    encoder.encode(signedPayload),
-  );
-
-  const expectedSig = Array.from(new Uint8Array(signature))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // Use constant-time comparison (CRITICAL fix #1)
-  return parts.signatures.some((sig) => timingSafeEqual(sig, expectedSig));
 }
 
 // Determine subscription tier from Stripe status

--- a/supabase/functions/stripe-webhook/verify-signature.test.ts
+++ b/supabase/functions/stripe-webhook/verify-signature.test.ts
@@ -35,7 +35,10 @@ describe('timingSafeEqual', () => {
     expect(timingSafeEqual('abc', 'abd')).toBe(false);
   });
 
-  it('returns false for different lengths (without short-circuiting)', () => {
+  it('returns false for different lengths', () => {
+    // The "constant-time" property is not observable from a JS unit test
+    // (no reliable timing primitive); here we only assert correctness.
+    // The non-short-circuit property is audited in the source.
     expect(timingSafeEqual('abc', 'abcd')).toBe(false);
     expect(timingSafeEqual('abc', '')).toBe(false);
   });
@@ -95,6 +98,11 @@ describe('verifyStripeSignature', () => {
     const payload = '{}';
     const sigHeader = 't=notanumber,v1=deadbeef';
     const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false for an empty sigHeader', async () => {
+    const ok = await verifyStripeSignature('{}', '', SECRET, { nowSeconds: FIXED_NOW });
     expect(ok).toBe(false);
   });
 

--- a/supabase/functions/stripe-webhook/verify-signature.test.ts
+++ b/supabase/functions/stripe-webhook/verify-signature.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TOLERANCE_SECONDS, timingSafeEqual, verifyStripeSignature } from './verify-signature.ts';
+
+const SECRET = 'whsec_test_secret';
+const FIXED_NOW = 1_700_000_000;
+
+/**
+ * Produce a valid `Stripe-Signature` header for a given payload + timestamp.
+ * Mirrors what Stripe sends in production:
+ *   `t=<unix>,v1=<hex-hmac-sha256>`
+ */
+async function signPayload(payload: string, timestamp: number, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sigBytes = await crypto.subtle.sign('HMAC', key, encoder.encode(`${timestamp}.${payload}`));
+  const hex = Array.from(new Uint8Array(sigBytes))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `t=${timestamp},v1=${hex}`;
+}
+
+describe('timingSafeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqual('abc', 'abc')).toBe(true);
+    expect(timingSafeEqual('', '')).toBe(true);
+  });
+
+  it('returns false for different content of the same length', () => {
+    expect(timingSafeEqual('abc', 'abd')).toBe(false);
+  });
+
+  it('returns false for different lengths (without short-circuiting)', () => {
+    expect(timingSafeEqual('abc', 'abcd')).toBe(false);
+    expect(timingSafeEqual('abc', '')).toBe(false);
+  });
+
+  it('handles unicode correctly (byte-level compare)', () => {
+    expect(timingSafeEqual('pomme', 'pomme')).toBe(true);
+    expect(timingSafeEqual('café', 'café')).toBe(true);
+    expect(timingSafeEqual('café', 'cafe')).toBe(false); // é is 2 bytes vs e is 1
+  });
+});
+
+describe('verifyStripeSignature', () => {
+  it('returns true for a freshly signed payload', async () => {
+    const payload = '{"id":"evt_1","type":"checkout.session.completed"}';
+    const sigHeader = await signPayload(payload, FIXED_NOW, SECRET);
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(true);
+  });
+
+  it('returns false when the payload is tampered with', async () => {
+    const original = '{"id":"evt_1","amount":100}';
+    const sigHeader = await signPayload(original, FIXED_NOW, SECRET);
+    const tampered = '{"id":"evt_1","amount":999}';
+    const ok = await verifyStripeSignature(tampered, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when the secret differs', async () => {
+    const payload = '{"ok":true}';
+    const sigHeader = await signPayload(payload, FIXED_NOW, SECRET);
+    const ok = await verifyStripeSignature(payload, sigHeader, 'whsec_other', { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when v1 is missing', async () => {
+    const payload = '{}';
+    const sigHeader = `t=${FIXED_NOW}`;
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when v1 is present but empty', async () => {
+    const payload = '{}';
+    const sigHeader = `t=${FIXED_NOW},v1=`;
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when t is missing', async () => {
+    const payload = '{}';
+    const sigHeader = 'v1=deadbeef';
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when t is not a finite number', async () => {
+    const payload = '{}';
+    const sigHeader = 't=notanumber,v1=deadbeef';
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects timestamps older than the tolerance window', async () => {
+    const payload = '{}';
+    const oldTs = FIXED_NOW - DEFAULT_TOLERANCE_SECONDS - 1;
+    const sigHeader = await signPayload(payload, oldTs, SECRET);
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('rejects timestamps further in the future than the tolerance', async () => {
+    const payload = '{}';
+    const futureTs = FIXED_NOW + DEFAULT_TOLERANCE_SECONDS + 1;
+    const sigHeader = await signPayload(payload, futureTs, SECRET);
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('accepts timestamps exactly at the tolerance boundary', async () => {
+    const payload = '{}';
+    const edgeTs = FIXED_NOW - DEFAULT_TOLERANCE_SECONDS;
+    const sigHeader = await signPayload(payload, edgeTs, SECRET);
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(true);
+  });
+
+  it('accepts when at least one of several v1 signatures matches', async () => {
+    const payload = '{"id":"evt"}';
+    const real = await signPayload(payload, FIXED_NOW, SECRET);
+    // Extract hex from the real signature, add a fake one before
+    const hex = real.split(',v1=')[1];
+    const sigHeader = `t=${FIXED_NOW},v1=deadbeef,v1=${hex}`;
+    const ok = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(true);
+  });
+
+  it('returns false when none of several v1 signatures match', async () => {
+    const sigHeader = `t=${FIXED_NOW},v1=deadbeef,v1=cafed00d`;
+    const ok = await verifyStripeSignature('{}', sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(ok).toBe(false);
+  });
+
+  it('honors a custom toleranceSeconds', async () => {
+    const payload = '{}';
+    const oldTs = FIXED_NOW - 60;
+    const sigHeader = await signPayload(payload, oldTs, SECRET);
+
+    // Default tolerance (300s) — accept
+    const acceptedDefault = await verifyStripeSignature(payload, sigHeader, SECRET, { nowSeconds: FIXED_NOW });
+    expect(acceptedDefault).toBe(true);
+
+    // Tight tolerance (30s) — reject
+    const rejectedTight = await verifyStripeSignature(payload, sigHeader, SECRET, {
+      nowSeconds: FIXED_NOW,
+      toleranceSeconds: 30,
+    });
+    expect(rejectedTight).toBe(false);
+  });
+});

--- a/supabase/functions/stripe-webhook/verify-signature.ts
+++ b/supabase/functions/stripe-webhook/verify-signature.ts
@@ -1,0 +1,87 @@
+/**
+ * Manual Stripe webhook signature verification using `crypto.subtle`.
+ *
+ * Re-implemented here (instead of pulling the Stripe SDK into the edge
+ * function) because:
+ * 1. The SDK verifier is Node-only and the edge runtime is Deno.
+ * 2. The verifier is ~30 lines — small enough to own, audit and unit-test
+ *    directly.
+ *
+ * The returned function is pure (modulo the Date.now() timestamp window) so
+ * unit tests run entirely offline.
+ *
+ * Reference: https://docs.stripe.com/webhooks#verify-manually
+ */
+
+/**
+ * Constant-time comparison of two hex signatures.
+ * Equal-length inputs: XOR each byte. Different-length: XOR the length
+ * mismatch too so the accumulator stays non-zero. Never early-exits.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  const maxLen = Math.max(aBytes.length, bBytes.length);
+  let result = aBytes.length ^ bBytes.length;
+  for (let i = 0; i < maxLen; i++) {
+    result |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0);
+  }
+  return result === 0;
+}
+
+export const DEFAULT_TOLERANCE_SECONDS = 300;
+
+/**
+ * Verifies the `Stripe-Signature` header against the raw request body using
+ * the shared webhook secret. Returns `true` only when the header parses, the
+ * timestamp is within `toleranceSeconds`, and at least one of the `v1=...`
+ * signatures matches the HMAC-SHA256 we compute locally.
+ *
+ * `nowSeconds` is injected so tests can freeze time deterministically.
+ */
+export async function verifyStripeSignature(
+  payload: string,
+  sigHeader: string,
+  secret: string,
+  options: { toleranceSeconds?: number; nowSeconds?: number } = {},
+): Promise<boolean> {
+  const toleranceSeconds = options.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+
+  const parts = sigHeader.split(',').reduce(
+    (acc, part) => {
+      const [key, value] = part.split('=');
+      if (key === 't') acc.timestamp = value;
+      if (key === 'v1' && value) acc.signatures.push(value);
+      return acc;
+    },
+    { timestamp: '', signatures: [] as string[] },
+  );
+
+  if (!parts.timestamp || parts.signatures.length === 0) return false;
+
+  const parsedTimestamp = Number.parseInt(parts.timestamp, 10);
+  if (!Number.isFinite(parsedTimestamp)) return false;
+
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  if (Math.abs(now - parsedTimestamp) > toleranceSeconds) return false;
+
+  const signedPayload = `${parts.timestamp}.${payload}`;
+  const encoder = new TextEncoder();
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(signedPayload));
+
+  const expectedSig = Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return parts.signatures.some((sig) => timingSafeEqual(sig, expectedSig));
+}


### PR DESCRIPTION
## Contexte

P0 du rapport audit `claudedocs/audit-2026-04-18/05-tests.md` — deux gaps dangereux pointés comme "les plus critiques" :
1. **Les validators des edge functions IA** sont la SEULE barrière entre sortie brute de Claude Haiku et données persistées. Régression silencieuse = séances injouables ou macros corrompues.
2. **`verifyStripeSignature`** est une implémentation HMAC-SHA256 manuelle. Un bug ici laisse passer des webhooks forgés — risque financier direct (promotion premium frauduleuse, suppression de subscription).

## Scope

4 fichiers de tests ajoutés (offline, aucun appel réseau) :

| Fichier | Tests | Couvre |
|---|---|---|
| `estimate-nutrition/validate.test.ts` | 20 | Happy path, null macros, bornes [0, 5000] kcal / [0, 500] g macros, NaN/Infinity, trim/length caps, confidence whitelist, suggestions cap+trim, tolerance non-string |
| `stripe-webhook/verify-signature.test.ts` | 18 | Payload tampering, mauvais secret, missing/empty `v1`, missing `t`, `t` non-numérique, boundaries tolérance past+future, multiple `v1` match, unicode byte-compare, `sigHeader=''` |
| `generate-session/validate.test.ts` | 26 | Off-topic, fields, estimatedDuration ±10 (boundary 11 incluse), placement warmup/cooldown, unknown types, per-block requirements pour les 10 types (classic, circuit, superset, pyramid, hiit, tabata, emom, amrap), sanitization HTML/URL + 500-char cap |
| `generate-program/validate.test.ts` | 20 | Off-topic, niveau whitelist, note_coach, sessions count 2-5 + exceeds-max, calendrier coverage + missing-session, consignes, sanitization top-level + progression.logique + `cible_semaine_X` + consignes |

**Total : 84 tests, suite passée de 216/216 à 300/300.**

## Extraction `verify-signature.ts`

`verifyStripeSignature` et `timingSafeEqual` étaient inline dans `stripe-webhook/index.ts`, ce qui les rendait non-testables (index.ts a des side-effects `Deno.serve()` et imports JSR Deno-only). Elles sont extraites dans `supabase/functions/stripe-webhook/verify-signature.ts`. Le module ajoute `{ nowSeconds, toleranceSeconds }` en injection pour rendre le timing déterministe en test.

Au passage : bug latent corrigé — l'ancien code passait `parseInt('notanumber', 10)` → `NaN` directement à `Math.abs(now - NaN) > 300`, ce qui retournait `false` dans la condition (donc la vérification temporelle était silencieusement bypassée sur timestamps non-numériques). Elle échouait quand même au final (HMAC mismatch), mais par accident. Le nouveau code rejette explicitement avec `Number.isFinite` — amélioration nette, couverte par test dédié.

**Aucun changement de comportement en production** : logique HMAC identique, même boucle, même path `crypto.subtle`.

## Tests

- `npm run lint` ✅ 0 erreurs
- `npm run build` ✅
- `npm test` ✅ 300/300
- Review senior REQUEST_CHANGES → 2 MEDIUM + 4 LOW adressés → APPROVE sur 2ème passe + mini ajustement de titre de test.

## Follow-ups

Les tests sont tous offline (Vitest, pas de Deno). Les tests edge-to-edge (véritable appel HTTP à une Supabase edge function déployée) restent hors scope — à prévoir dans une PR séparée avec un setup Supabase CLI + secrets de test.

## Test plan
- [ ] CI verte sur cette PR
- [ ] Aucune régression sur l'edge function stripe-webhook après merge (déployer le webhook avec la nouvelle structure d'import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)