### PR TITLE
refactor(edge-functions): centralize CORS in _shared/cors.ts

### DIFF
--- a/supabase/functions/_shared/cors.test.ts
+++ b/supabase/functions/_shared/cors.test.ts
@@ -69,13 +69,39 @@ describe('getCorsHeaders', () => {
     expect(allow).toContain('content-type');
   });
 
-  it('appends extra allowed headers (e.g. stripe-signature)', () => {
+  it('appends extra allowed headers (e.g. stripe-signature) with an exact header string', () => {
     const headers = getCorsHeaders(requestWithOrigin('https://wan2fit.fr'), {
       environment: 'production',
       extraAllowedHeaders: ['stripe-signature'],
     });
-    expect(headers['Access-Control-Allow-Headers']).toContain('stripe-signature');
-    expect(headers['Access-Control-Allow-Headers']).toContain('authorization');
+    expect(headers['Access-Control-Allow-Headers']).toBe(
+      'authorization, x-client-info, apikey, content-type, stripe-signature',
+    );
+  });
+
+  it('matches the stripe-webhook wrapper contract (synthetic Request construction)', () => {
+    // Mirrors the local wrapper in supabase/functions/stripe-webhook/index.ts:
+    // the wrapper constructs a synthetic Request from an optional origin and
+    // delegates here. Make sure both branches (origin defined / undefined)
+    // behave exactly as the wrapper expects.
+    const buildReq = (origin?: string) =>
+      new Request('https://edge.example/', {
+        headers: origin ? { origin } : undefined,
+      });
+
+    const whitelisted = getCorsHeaders(buildReq('http://localhost:5173'), {
+      environment: 'preview',
+      extraAllowedHeaders: ['stripe-signature'],
+    });
+    expect(whitelisted['Access-Control-Allow-Origin']).toBe('http://localhost:5173');
+    expect(whitelisted['Access-Control-Allow-Headers']).toContain('stripe-signature');
+
+    const noOrigin = getCorsHeaders(buildReq(), {
+      environment: 'production',
+      extraAllowedHeaders: ['stripe-signature'],
+    });
+    expect(noOrigin['Access-Control-Allow-Origin']).toBe(DEFAULT_ORIGIN);
+    expect(noOrigin['Access-Control-Allow-Headers']).toContain('stripe-signature');
   });
 });
 

--- a/supabase/functions/_shared/cors.test.ts
+++ b/supabase/functions/_shared/cors.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ORIGIN, getAllowedOrigins, getCorsHeaders, resolveAllowedOrigin } from './cors.ts';
+
+function requestWithOrigin(origin?: string): Request {
+  const headers = origin !== undefined ? { origin } : {};
+  return new Request('https://edge.example/', { headers });
+}
+
+describe('getAllowedOrigins', () => {
+  it('returns only production domains when ENVIRONMENT is "production"', () => {
+    const origins = getAllowedOrigins('production');
+    expect(origins).toEqual(['https://wan2fit.fr', 'https://www.wan2fit.fr']);
+  });
+
+  it('includes dev origins for any other environment', () => {
+    const origins = getAllowedOrigins('preview');
+    expect(origins).toContain('http://localhost:5173');
+    expect(origins).toContain('http://localhost:4173');
+  });
+
+  it('includes dev origins when environment is null/undefined', () => {
+    expect(getAllowedOrigins(null)).toContain('http://localhost:5173');
+    expect(getAllowedOrigins(undefined)).toContain('http://localhost:5173');
+  });
+});
+
+describe('getCorsHeaders', () => {
+  it('reflects a whitelisted prod origin verbatim', () => {
+    const req = requestWithOrigin('https://wan2fit.fr');
+    const headers = getCorsHeaders(req, { environment: 'production' });
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://wan2fit.fr');
+  });
+
+  it('reflects a whitelisted dev origin in non-prod', () => {
+    const req = requestWithOrigin('http://localhost:5173');
+    const headers = getCorsHeaders(req, { environment: 'preview' });
+    expect(headers['Access-Control-Allow-Origin']).toBe('http://localhost:5173');
+  });
+
+  it('falls back to the default origin for an unknown caller', () => {
+    const req = requestWithOrigin('https://attacker.example');
+    const headers = getCorsHeaders(req, { environment: 'production' });
+    expect(headers['Access-Control-Allow-Origin']).toBe(DEFAULT_ORIGIN);
+  });
+
+  it('falls back to the default origin when origin header is missing', () => {
+    const req = requestWithOrigin();
+    const headers = getCorsHeaders(req, { environment: 'production' });
+    expect(headers['Access-Control-Allow-Origin']).toBe(DEFAULT_ORIGIN);
+  });
+
+  it('does NOT reflect dev origins in production', () => {
+    const req = requestWithOrigin('http://localhost:5173');
+    const headers = getCorsHeaders(req, { environment: 'production' });
+    expect(headers['Access-Control-Allow-Origin']).toBe(DEFAULT_ORIGIN);
+  });
+
+  it('always advertises POST and OPTIONS', () => {
+    const headers = getCorsHeaders(requestWithOrigin(), { environment: 'preview' });
+    expect(headers['Access-Control-Allow-Methods']).toBe('POST, OPTIONS');
+  });
+
+  it('exposes the base allowed headers by default', () => {
+    const headers = getCorsHeaders(requestWithOrigin(), { environment: 'preview' });
+    const allow = headers['Access-Control-Allow-Headers'];
+    expect(allow).toContain('authorization');
+    expect(allow).toContain('x-client-info');
+    expect(allow).toContain('apikey');
+    expect(allow).toContain('content-type');
+  });
+
+  it('appends extra allowed headers (e.g. stripe-signature)', () => {
+    const headers = getCorsHeaders(requestWithOrigin('https://wan2fit.fr'), {
+      environment: 'production',
+      extraAllowedHeaders: ['stripe-signature'],
+    });
+    expect(headers['Access-Control-Allow-Headers']).toContain('stripe-signature');
+    expect(headers['Access-Control-Allow-Headers']).toContain('authorization');
+  });
+});
+
+describe('resolveAllowedOrigin', () => {
+  it('returns the verbatim origin when whitelisted', () => {
+    const req = requestWithOrigin('https://www.wan2fit.fr');
+    expect(resolveAllowedOrigin(req, 'production')).toBe('https://www.wan2fit.fr');
+  });
+
+  it('returns DEFAULT_ORIGIN when not whitelisted', () => {
+    const req = requestWithOrigin('https://unknown.example');
+    expect(resolveAllowedOrigin(req, 'production')).toBe(DEFAULT_ORIGIN);
+  });
+
+  it('returns DEFAULT_ORIGIN when origin header is missing', () => {
+    expect(resolveAllowedOrigin(requestWithOrigin(), 'production')).toBe(DEFAULT_ORIGIN);
+  });
+});

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared CORS helpers for all edge functions.
+ *
+ * Until 2026-04, the same six lines of origin whitelist + `getCorsHeaders`
+ * were duplicated across every edge function. Adding a preview domain or
+ * tightening an allowed origin meant six coordinated edits — an accident
+ * waiting to happen. This module is the single source of truth.
+ *
+ * Deno edge functions cannot import from `src/`, so this file intentionally
+ * lives under `supabase/functions/_shared/` which IS reachable from every
+ * edge function via a relative import: `import { ... } from "../_shared/cors.ts";`
+ */
+
+export const PROD_ORIGINS = [
+  'https://wan2fit.fr',
+  'https://www.wan2fit.fr',
+] as const;
+
+export const DEV_ORIGINS = ['http://localhost:5173', 'http://localhost:4173'] as const;
+
+export const DEFAULT_ORIGIN = 'https://wan2fit.fr';
+
+/**
+ * Returns the list of origins the edge functions should accept CORS requests
+ * from. In production, only the live domains are allowed; in any other
+ * environment the local dev servers are added.
+ *
+ * `environment` can be injected for deterministic tests; it defaults to the
+ * `ENVIRONMENT` Deno env variable. The check is loose on purpose: anything
+ * other than the exact string "production" falls back to the dev-friendly
+ * list.
+ */
+export function getAllowedOrigins(environment?: string | null): readonly string[] {
+  if (environment === 'production') return PROD_ORIGINS;
+  return [...PROD_ORIGINS, ...DEV_ORIGINS];
+}
+
+export interface CorsHeaderOptions {
+  /**
+   * Extra request headers to advertise in `Access-Control-Allow-Headers`
+   * beyond the default set. The Stripe webhook needs `stripe-signature`;
+   * other functions leave this unset.
+   */
+  extraAllowedHeaders?: readonly string[];
+  /**
+   * Override the environment check (tests, branches). When omitted we read
+   * `Deno.env.get("ENVIRONMENT")`.
+   */
+  environment?: string | null;
+}
+
+const BASE_ALLOWED_HEADERS = ['authorization', 'x-client-info', 'apikey', 'content-type'];
+const ALLOWED_METHODS = 'POST, OPTIONS';
+
+/**
+ * Builds the CORS response headers for an edge function. Accepts a `Request`
+ * so we can reflect the incoming `Origin` if it is on the whitelist (so
+ * browsers see their exact origin in `Access-Control-Allow-Origin`, which is
+ * required when the server also sets `Access-Control-Allow-Credentials`).
+ *
+ * Origins outside the whitelist fall back to the canonical production domain
+ * — this keeps the response valid without leaking arbitrary origins.
+ */
+export function getCorsHeaders(req: Request, options: CorsHeaderOptions = {}): Record<string, string> {
+  const environment = options.environment ?? safeReadEnv('ENVIRONMENT');
+  const allowed = getAllowedOrigins(environment);
+  const origin = req.headers.get('origin') ?? '';
+  const allowedOrigin = allowed.includes(origin) ? origin : DEFAULT_ORIGIN;
+
+  const headerList = options.extraAllowedHeaders
+    ? [...BASE_ALLOWED_HEADERS, ...options.extraAllowedHeaders]
+    : BASE_ALLOWED_HEADERS;
+
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Headers': headerList.join(', '),
+    'Access-Control-Allow-Methods': ALLOWED_METHODS,
+  };
+}
+
+/**
+ * Returns the resolved allowed origin for a request — used by Stripe flows
+ * that need to construct success/cancel URLs using the caller's origin.
+ */
+export function resolveAllowedOrigin(req: Request, environment?: string | null): string {
+  const env = environment ?? safeReadEnv('ENVIRONMENT');
+  const allowed = getAllowedOrigins(env);
+  const origin = req.headers.get('origin') ?? '';
+  return allowed.includes(origin) ? origin : DEFAULT_ORIGIN;
+}
+
+function safeReadEnv(key: string): string | null {
+  try {
+    // `Deno` is undefined in Vitest (Node). Tests pass `environment` explicitly.
+    // @ts-ignore - Deno global provided at runtime
+    return typeof Deno !== 'undefined' ? (Deno.env.get(key) ?? null) : null;
+  } catch {
+    return null;
+  }
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -56,7 +56,8 @@ const ALLOWED_METHODS = 'POST, OPTIONS';
  * Builds the CORS response headers for an edge function. Accepts a `Request`
  * so we can reflect the incoming `Origin` if it is on the whitelist (so
  * browsers see their exact origin in `Access-Control-Allow-Origin`, which is
- * required when the server also sets `Access-Control-Allow-Credentials`).
+ * required for authenticated requests carrying the `Authorization` header —
+ * wildcard `*` is not allowed by the spec in that case).
  *
  * Origins outside the whitelist fall back to the canonical production domain
  * — this keeps the response valid without leaking arbitrary origins.

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -13,10 +13,6 @@ function errorResponse(req: Request, message: string, status = 400) {
   return jsonResponse(req, { error: message }, status);
 }
 
-function getValidOrigin(req: Request): string {
-  return resolveAllowedOrigin(req);
-}
-
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: getCorsHeaders(req) });
@@ -139,7 +135,7 @@ Deno.serve(async (req: Request) => {
   }
 
   // Validate origin for redirect URLs
-  const origin = getValidOrigin(req);
+  const origin = resolveAllowedOrigin(req);
 
   // Create Checkout Session
   const params = new URLSearchParams({

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,24 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-
-const PROD_ORIGINS = [
-  "https://wan2fit.fr",
-  "https://www.wan2fit.fr",
-];
-const DEV_ORIGINS = ["http://localhost:5173", "http://localhost:4173"];
-const ALLOWED_ORIGINS = Deno.env.get("ENVIRONMENT") === "production" ? PROD_ORIGINS : [...PROD_ORIGINS, ...DEV_ORIGINS];
-
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get("origin") ?? "";
-  return {
-    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
-}
+import { getCorsHeaders, resolveAllowedOrigin } from "../_shared/cors.ts";
 
 function jsonResponse(req: Request, data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -32,8 +14,7 @@ function errorResponse(req: Request, message: string, status = 400) {
 }
 
 function getValidOrigin(req: Request): string {
-  const origin = req.headers.get("origin") ?? "";
-  return ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN;
+  return resolveAllowedOrigin(req);
 }
 
 Deno.serve(async (req: Request) => {

--- a/supabase/functions/create-portal-session/index.ts
+++ b/supabase/functions/create-portal-session/index.ts
@@ -13,10 +13,6 @@ function errorResponse(req: Request, message: string, status = 400) {
   return jsonResponse(req, { error: message }, status);
 }
 
-function getValidOrigin(req: Request): string {
-  return resolveAllowedOrigin(req);
-}
-
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: getCorsHeaders(req) });
@@ -68,7 +64,7 @@ Deno.serve(async (req: Request) => {
     return errorResponse(req, "Aucun compte de facturation trouvé", 400);
   }
 
-  const origin = getValidOrigin(req);
+  const origin = resolveAllowedOrigin(req);
 
   // Create Billing Portal session
   const portalRes = await fetch(

--- a/supabase/functions/create-portal-session/index.ts
+++ b/supabase/functions/create-portal-session/index.ts
@@ -1,24 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-
-const PROD_ORIGINS = [
-  "https://wan2fit.fr",
-  "https://www.wan2fit.fr",
-];
-const DEV_ORIGINS = ["http://localhost:5173", "http://localhost:4173"];
-const ALLOWED_ORIGINS = Deno.env.get("ENVIRONMENT") === "production" ? PROD_ORIGINS : [...PROD_ORIGINS, ...DEV_ORIGINS];
-
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get("origin") ?? "";
-  return {
-    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
-}
+import { getCorsHeaders, resolveAllowedOrigin } from "../_shared/cors.ts";
 
 function jsonResponse(req: Request, data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -32,8 +14,7 @@ function errorResponse(req: Request, message: string, status = 400) {
 }
 
 function getValidOrigin(req: Request): string {
-  const origin = req.headers.get("origin") ?? "";
-  return ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN;
+  return resolveAllowedOrigin(req);
 }
 
 Deno.serve(async (req: Request) => {

--- a/supabase/functions/estimate-nutrition/index.ts
+++ b/supabase/functions/estimate-nutrition/index.ts
@@ -1,5 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
 import {
   buildOverflowUserPrompt,
   buildTextUserPrompt,
@@ -8,21 +9,6 @@ import {
   TEXT_SYSTEM_PROMPT,
 } from "./prompts.ts";
 import { validateOverflowInsight, validateTextEstimate } from "./validate.ts";
-
-const PROD_ORIGINS = ["https://wan2fit.fr", "https://www.wan2fit.fr"];
-const DEV_ORIGINS = ["http://localhost:5173", "http://localhost:4173"];
-const ALLOWED_ORIGINS =
-  Deno.env.get("ENVIRONMENT") === "production" ? PROD_ORIGINS : [...PROD_ORIGINS, ...DEV_ORIGINS];
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get("origin") ?? "";
-  return {
-    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
-}
 
 const MODEL = "claude-haiku-4-5-20251001";
 const MAX_TOKENS_TEXT = 512;

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -1,27 +1,9 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
 import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
 import { sanitizeOnboardingForPersistence } from "./sanitize.ts";
 import { validateProgram } from "./validate.ts";
-
-const PROD_ORIGINS = [
-  "https://wan2fit.fr",
-  "https://www.wan2fit.fr",
-];
-const DEV_ORIGINS = ["http://localhost:5173", "http://localhost:4173"];
-const ALLOWED_ORIGINS = Deno.env.get("ENVIRONMENT") === "production" ? PROD_ORIGINS : [...PROD_ORIGINS, ...DEV_ORIGINS];
-
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get("origin") ?? "";
-  return {
-    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
-}
 
 const MAX_ACTIVE_PROGRAMS = 3;
 const MAX_DAILY_GENERATIONS = 3;

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -1,26 +1,8 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
 import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
 import { validateSession } from "./validate.ts";
-
-const PROD_ORIGINS = [
-  "https://wan2fit.fr",
-  "https://www.wan2fit.fr",
-];
-const DEV_ORIGINS = ["http://localhost:5173", "http://localhost:4173"];
-const ALLOWED_ORIGINS = Deno.env.get("ENVIRONMENT") === "production" ? PROD_ORIGINS : [...PROD_ORIGINS, ...DEV_ORIGINS];
-
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get("origin") ?? "";
-  return {
-    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
-}
 
 const MAX_DAILY_GENERATIONS = 10;
 const MODEL = "claude-haiku-4-5-20251001";

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -6,8 +6,14 @@ import { verifyStripeSignature } from "./verify-signature.ts";
 // Thin wrapper preserving the existing `(origin?: string)` signature while
 // delegating origin whitelisting to the shared module. `stripe-signature`
 // must be reflected in Allow-Headers for Stripe's preflight.
+//
+// Behavioural note: unlike the pre-refactor version, this now ALSO accepts
+// DEV_ORIGINS (http://localhost:5173 / 4173) in non-production environments.
+// Stripe production webhooks never send `Origin: localhost`, so the prod
+// behaviour is unchanged; the relaxation only benefits manual dev/preview
+// tooling and keeps stripe-webhook in line with the other 5 functions.
 function getCorsHeaders(origin?: string) {
-  const req = new Request("https://edge.local/", {
+  const req = new Request("https://edge.example/", {
     headers: origin ? { origin } : undefined,
   });
   return getSharedCorsHeaders(req, { extraAllowedHeaders: ["stripe-signature"] });

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,21 +1,16 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders as getSharedCorsHeaders } from "../_shared/cors.ts";
 import { verifyStripeSignature } from "./verify-signature.ts";
 
-const ALLOWED_ORIGINS = [
-  "https://wan2fit.fr",
-  "https://www.wan2fit.fr",
-];
-
-const DEFAULT_ORIGIN = "https://wan2fit.fr";
-
+// Thin wrapper preserving the existing `(origin?: string)` signature while
+// delegating origin whitelisting to the shared module. `stripe-signature`
+// must be reflected in Allow-Headers for Stripe's preflight.
 function getCorsHeaders(origin?: string) {
-  return {
-    "Access-Control-Allow-Origin": origin && ALLOWED_ORIGINS.includes(origin) ? origin : DEFAULT_ORIGIN,
-    "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type, stripe-signature",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-  };
+  const req = new Request("https://edge.local/", {
+    headers: origin ? { origin } : undefined,
+  });
+  return getSharedCorsHeaders(req, { extraAllowedHeaders: ["stripe-signature"] });
 }
 
 function jsonResponse(data: unknown, status = 200, origin?: string) {


### PR DESCRIPTION
## Contexte

P1 de l'audit `claudedocs/audit-2026-04-18/01-architecture.md` + `04-tech-debt.md` : ~15 lignes de whitelist d'origines + `getCorsHeaders` dupliquées dans les 6 edge functions. Une mise à jour de domaine = 6 edits coordonnés. `stripe-webhook` avait déjà drifté (signature différente, 2 prod origins seulement, pas de DEV_ORIGINS). 

## Fix

Nouveau module `supabase/functions/_shared/cors.ts` avec :
- `PROD_ORIGINS` / `DEV_ORIGINS` / `DEFAULT_ORIGIN` exportés
- `getAllowedOrigins(env)` — liste effective selon `ENVIRONMENT`
- `getCorsHeaders(req, { extraAllowedHeaders, environment })` — headers preflight, avec hook pour `stripe-signature`
- `resolveAllowedOrigin(req, env)` — pour les flows Stripe (success/cancel URLs)

### Refactor des 6 edge functions
- `create-checkout-session`, `create-portal-session` : bloc dupliqué → import shared, appel direct à `resolveAllowedOrigin` (plus de wrapper `getValidOrigin` inutile).
- `generate-session`, `generate-program`, `estimate-nutrition` : idem côté CORS.
- `stripe-webhook` : signature publique `(origin?: string)` préservée (10 call sites) via un wrapper local qui construit une `Request` synthétique et délègue au shared module avec `extraAllowedHeaders: ['stripe-signature']`. **Note comportementale** : accepte désormais `DEV_ORIGINS` en non-prod — Stripe prod ne send jamais `Origin: localhost`, donc aucun impact production ; bénéfice en dev/preview + cohérence avec les 5 autres fonctions.

## Tests

`_shared/cors.test.ts` — 15 cas Vitest :
- Prod vs non-prod origin list
- Reflection sur whitelist + fallback origin inconnue/absente
- Env override pour tests déterministes
- Base headers exposés + extra headers (assertion exacte sur la string)
- Stripe-webhook wrapper pattern (synthetic Request construction, 2 branches)
- `resolveAllowedOrigin` parity

**Suite : 315/315 verts** (était 300).

## Review senior

Première passe REQUEST_CHANGES → 2 WARNINGs bloquants + 2 NITs triviaux :
1. Commentaire JSDoc erroné sur `Allow-Credentials` → corrigé
2. Behavioral change stripe-webhook non documenté → commentaire ajouté dans le wrapper
3. Test `extraAllowedHeaders` avec `toContain` → assertion exacte
4. `getValidOrigin` one-liner wrapper → supprimé

Deuxième passe : tout est propre.

## Test plan
- [ ] CI verte sur cette PR
- [ ] Redéployer les 6 edge functions après merge (Supabase)
- [ ] Smoke test preflight CORS depuis `wan2fit.fr` en prod
- [ ] Smoke test webhook Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)