### PR TITLE
perf(pwa): slim precache (316→95, 3.5MB→1.4MB) + hero image 7MB→96KB

### DIFF
--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -47,6 +47,8 @@ export function VisitorContent({
           <img
             src="/images/hero-landing-couple.webp"
             alt=""
+            fetchPriority="high"
+            decoding="async"
             className="w-full h-full object-cover object-[65%_center] md:object-center"
           />
           <div className="absolute inset-0 bg-gradient-to-r from-black/65 via-black/35 to-black/15 md:from-black/80 md:via-black/50 md:to-black/30" />

--- a/src/components/home/VisitorContent.tsx
+++ b/src/components/home/VisitorContent.tsx
@@ -47,6 +47,8 @@ export function VisitorContent({
           <img
             src="/images/hero-landing-couple.webp"
             alt=""
+            width={1920}
+            height={814}
             fetchPriority="high"
             decoding="async"
             className="w-full h-full object-cover object-[65%_center] md:object-center"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,10 @@ export default defineConfig(({ mode }) => ({
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['sessions/*.json'],
+      // No `includeAssets`: sessions/*.json are cached on-demand via the
+      // runtimeCaching CacheFirst rule below, and photo-wan.png is too large
+      // (~1.7 MB) to precache eagerly on first load. The service worker
+      // should ship a minimal install bundle and grab the rest lazily.
       manifest: {
         name: 'Wan2Fit',
         short_name: 'Wan2Fit',
@@ -28,7 +31,10 @@ export default defineConfig(({ mode }) => ({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,json,svg,png}'],
-        globIgnores: ['**/og-image.jpg'],
+        // og-image.jpg: social preview, never needed by the app itself.
+        // photo-wan.png: large portrait (~1.7 MB) rendered tiny; runtime-fetched.
+        // sessions/*.json: 200+ entries covered by the sessions-cache rule below.
+        globIgnores: ['**/og-image.jpg', '**/photo-wan.png', 'sessions/**/*.json'],
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [/^\/sessions\//, /^\/images\//, /^\/videos\//, /^\/icons\//, /^\/api\//, /^\/ads\.txt$/],
         runtimeCaching: [


### PR DESCRIPTION
## Contexte

P1 de l'audit `claudedocs/audit-2026-04-18/03-performance.md` — top ROI sur la perf PWA cold start mobile 3G.

## Changements

### Precache Service Worker
- Drop `includeAssets: ['sessions/*.json']` — ces 200+ JSON sont déjà captées par la règle `runtimeCaching CacheFirst` existante (`/sessions/.*\\.json$`, maxEntries=110, TTL 120j).
- Ajout à `globIgnores` : `'**/photo-wan.png'` (1,7 MB rendu en 16 px avatar → runtime) + `'sessions/**/*.json'`.

| Metric | Avant | Après | Δ |
|---|---|---|---|
| Precache entries | 316 | 95 | **−70 %** |
| Precache payload | 3535 KiB | 1441 KiB | **−59 %** |

### Hero image
- `public/images/hero-landing-couple.webp` était **7,4 MB** — un PNG mis-named `.webp`, 3172×1344. Re-encodé via `sharp` : WebP qualité 78, effort 6, 1920×814 → **96 KB (×75 plus petit)**.
- Ajout de `fetchPriority="high"` + `decoding="async"` sur le `<img>` pour prioriser le LCP sans bloquer le parser.
- Ajout de `width={1920}` / `height={814}` pour réserver l'espace (CLS zéro sur la hero).

## Tests
- `npm run build` ✅ precache `95 entries (1441.73 KiB)`
- `npm run lint` ✅
- `npm test` ✅ 315/315

## Follow-ups (toujours dans le rapport perf, PRs séparées)
- 8 `goal-*.webp` à ~7 MB chacun (ProgramCard backgrounds) → gros gain à venir.
- Stack fonts (Google Fonts + Fontshare) render-blocking.
- Sentry Replay eager parsing.

## Test plan
- [ ] CI verte
- [ ] Preview Vercel : hero visible, bien chargé, LCP faible (DevTools)
- [ ] Recette mobile : première visite visiteur plus rapide

🤖 Generated with [Claude Code](https://claude.com/claude-code)