### PR TITLE
sec(csp): drop script-src 'unsafe-inline' + cover real first-party/third-party hosts

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,15 +92,8 @@
 
   </head>
   <body>
-    <script>
-      (function() {
-        var p = localStorage.getItem('wan2fit-theme') || 'light';
-        var t = p === 'system'
-          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : p;
-        if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
-      })();
-    </script>
+    <!-- Theme flash prevention: synchronous, external (kept out of inline script-src). -->
+    <script src="/theme-init.js"></script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,13 @@
 
   </head>
   <body>
-    <!-- Theme flash prevention: synchronous, external (kept out of inline script-src). -->
+    <!--
+      Theme flash prevention — synchronous, external (kept out of inline
+      script-src). IMPORTANT: never add `defer` or `async` here. The script
+      must block the parser so the <html data-theme> attribute is set
+      BEFORE the first paint, otherwise users on light theme see a dark
+      flash while React hydrates.
+    -->
     <script src="/theme-init.js"></script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,25 @@
+/**
+ * Theme flash prevention.
+ *
+ * Runs synchronously before the React bundle mounts so the <html data-theme>
+ * attribute is set at first paint — avoids the brief white/dark flash when
+ * the user has picked a non-system theme.
+ *
+ * This file is loaded via `<script src="/theme-init.js">` (external) rather
+ * than inline so the CSP `script-src` can stay free of `'unsafe-inline'`.
+ * Keep it framework-free, no import, no module syntax.
+ */
+(function () {
+  try {
+    var p = localStorage.getItem('wan2fit-theme') || 'light';
+    var t =
+      p === 'system'
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'
+        : p;
+    if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+  } catch (_) {
+    // localStorage can throw in privacy mode; fall through to the default dark theme.
+  }
+})();

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -8,6 +8,11 @@
  * This file is loaded via `<script src="/theme-init.js">` (external) rather
  * than inline so the CSP `script-src` can stay free of `'unsafe-inline'`.
  * Keep it framework-free, no import, no module syntax.
+ *
+ * IMPORTANT: the <script> tag referencing this file MUST NOT carry
+ * `defer` or `async` — it has to block the HTML parser so the theme
+ * attribute is set before first paint. Keep the script tag in index.html
+ * bare.
  */
 (function () {
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co https://images.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://world.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
         },
         {
           "key": "X-Frame-Options",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "rewrites": [
-    { "source": "/((?!assets|sessions|images|icons|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|manifest\\.webmanifest|sw\\.js).*)", "destination": "/index.html" }
+    { "source": "/((?!assets|sessions|images|icons|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|manifest\\.webmanifest|sw\\.js|theme-init\\.js).*)", "destination": "/index.html" }
   ],
   "headers": [
     {
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co https://images.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://world.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co https://*.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Contexte

P2 de l'audit sécu `claudedocs/audit-2026-04-18/02-security-rgpd.md` (SEC-02). La CSP actuelle carriait `script-src 'self' 'unsafe-inline'` — une ligne qui suffit à désactiver la majorité de la défense contre l'injection de scripts (n'importe quelle dépendance compromise peut injecter un `<script>` exécutable).

## Changements

### 1. Retrait de `'unsafe-inline'` de `script-src`
- Externalisation du seul script inline (theme flash prevention) dans `public/theme-init.js`.
- Remplacé dans `index.html` par `<script src="/theme-init.js">` avec **commentaire guard** interdisant `defer`/`async` (contrat parser-blocking).
- Script `try/catch` autour du `localStorage.getItem` pour le mode privé.
- Exclu du rewrite SPA Vercel (sinon `/theme-init.js` retournerait `index.html` avec Content-Type `text/html`, refus d'exécution).

### 2. Renforcement de `connect-src` / `img-src` / `script-src`
Les endpoints que l'app appelle réellement depuis le navigateur étaient soit silencieusement tolérés (CSP non-enforced avant ?) soit prêts à casser dès le durcissement. Alignés explicitement :
- `connect-src` : Open Food Facts (`*.openfoodfacts.org`), Sentry ingest (`*.ingest.sentry.io`, `*.ingest.us.sentry.io`, `*.ingest.de.sentry.io` ← DSN projet EU region), Vercel Analytics (`vitals.vercel-insights.com`, `va.vercel-scripts.com`).
- `img-src` : `*.openfoodfacts.org` pour que les images produits scannées rendent.
- `script-src` : ajout `va.vercel-scripts.com` (Vercel Analytics peut injecter un script externe en mode debug).

## Ce qui n'a PAS bougé
- `style-src 'unsafe-inline'` reste (Tailwind v4 injecte du CSS runtime ; retrait = refacto css-in-js, hors scope). Follow-up possible.
- `<script type=\"application/ld+json\">` reste inline : inerte par spec CSP, autorisé par tous les navigateurs modernes.
- `base-uri` toujours absent : pré-existant, hors scope (à tracker séparément).

## Review senior — 2 passes
1ère passe → **REQUEST_CHANGES** : 1 CRITICAL (Sentry DE region non couvert → events droppés) + 2 HIGH + 2 MEDIUM + 1 LOW. Les 5 premiers fixés dans le 2ème commit. Le LOW (preload hint) reste hors scope.
2ème passe → **APPROVE**.

## Validation
- `npm run build` ✅
- `npm test` ✅ 315/315
- Chrome dev : `theme-init.js` chargé (200), `<html data-theme=\"light\">` posé au premier paint, zéro erreur console.
- CSP réelle testable sur la preview Vercel — les headers `vercel.json` ne sont pas servis en dev Vite.

## Test plan
- [ ] CI verte
- [ ] Preview Vercel : ouvrir la Home visiteur, DevTools → vérifier aucune violation CSP dans la console.
- [ ] Vérifier que le scan de code-barres OFF rend bien les images produits.
- [ ] Vérifier que Sentry reçoit bien les erreurs (tester une erreur factice en dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)