### PR TITLE
feat(premium): EndScreen teaser for free users (audit R2)

### DIFF
--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -1,4 +1,4 @@
-import { Check, Download, Share2, Trophy } from 'lucide-react';
+import { Check, Download, Share2, Sparkles, Trophy, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { STORAGE_KEYS } from '../config/storage-keys.ts';
@@ -18,8 +18,9 @@ interface Props {
 }
 
 export function EndScreen({ session, amrapRounds, durationSeconds, onBack, programSessionId, customSessionId }: Props) {
-  const { user } = useAuth();
+  const { user, profile } = useAuth();
   const { save, saved, error: saveError } = useSaveCompletion();
+  const isPremium = profile?.subscription_tier === 'premium';
 
   useEffect(() => {
     if (!user || !durationSeconds) return;
@@ -141,6 +142,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
       </div>
 
       {!user && supabase && <SignupNudge />}
+      {user && !isPremium && <PremiumTeaser />}
 
       <div className="flex flex-col gap-3 mt-4 w-full max-w-xs">
         <button
@@ -221,6 +223,67 @@ function SignupNudge() {
         <button type="button" onClick={dismiss} className="text-white/40 text-xs hover:text-white/60 transition-colors">
           Plus tard
         </button>
+      </div>
+    </div>
+  );
+}
+
+const PREMIUM_TEASER_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * Shown on the EndScreen to non-premium authenticated users, right after the
+ * rush of completing a session — the highest-engagement moment in the funnel
+ * (audit 2026-04-18 06-business-ux, R2). Cooldown 7d to stay friendly: a
+ * regular exerciser sees it once a week, not at every session.
+ */
+function PremiumTeaser() {
+  const [visible, setVisible] = useState(() => {
+    try {
+      const dismissed = localStorage.getItem(STORAGE_KEYS.PREMIUM_TEASER_DISMISSED);
+      if (!dismissed) return true;
+      return Date.now() - Number(dismissed) > PREMIUM_TEASER_COOLDOWN_MS;
+    } catch {
+      return true;
+    }
+  });
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.PREMIUM_TEASER_DISMISSED, String(Date.now()));
+    } catch {
+      /* ignore */
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div className="relative w-full max-w-sm rounded-2xl overflow-hidden">
+      <div className="absolute inset-0 cta-gradient opacity-90" aria-hidden="true" />
+      <div className="relative z-10 p-5 text-left">
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Ignorer pour cette semaine"
+          className="absolute top-2.5 right-2.5 text-white/70 hover:text-white transition-colors"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+        <div className="flex items-center gap-2 mb-2">
+          <Sparkles className="w-4 h-4 text-white" aria-hidden="true" />
+          <p className="text-white text-sm font-semibold">Tu gères.</p>
+        </div>
+        <p className="text-white/85 text-xs leading-relaxed mb-4 pr-4">
+          Avec Premium, ta prochaine séance est générée sur mesure en 30 s, ou pars sur un programme complet adapté à
+          tes objectifs.
+        </p>
+        <Link
+          to="/premium"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/20 border border-white/30 text-sm font-bold text-white hover:bg-white/30 transition-colors backdrop-blur-sm"
+        >
+          Découvrir Premium
+        </Link>
       </div>
     </div>
   );

--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export function EndScreen({ session, amrapRounds, durationSeconds, onBack, programSessionId, customSessionId }: Props) {
-  const { user, profile } = useAuth();
+  const { user, profile, loading: authLoading } = useAuth();
   const { save, saved, error: saveError } = useSaveCompletion();
   const isPremium = profile?.subscription_tier === 'premium';
 
@@ -142,7 +142,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
       </div>
 
       {!user && supabase && <SignupNudge />}
-      {user && !isPremium && <PremiumTeaser />}
+      {user && !authLoading && profile && !isPremium && <PremiumTeaser />}
 
       <div className="flex flex-col gap-3 mt-4 w-full max-w-xs">
         <button
@@ -259,9 +259,8 @@ function PremiumTeaser() {
   };
 
   return (
-    <div className="relative w-full max-w-sm rounded-2xl overflow-hidden">
-      <div className="absolute inset-0 cta-gradient opacity-90" aria-hidden="true" />
-      <div className="relative z-10 p-5 text-left">
+    <div className="relative w-full max-w-sm rounded-2xl overflow-hidden bg-gradient-to-br from-brand via-brand-secondary to-brand">
+      <div className="p-5 text-left">
         <button
           type="button"
           onClick={dismiss}
@@ -274,13 +273,13 @@ function PremiumTeaser() {
           <Sparkles className="w-4 h-4 text-white" aria-hidden="true" />
           <p className="text-white text-sm font-semibold">Tu gères.</p>
         </div>
-        <p className="text-white/85 text-xs leading-relaxed mb-4 pr-4">
+        <p className="text-white/80 text-xs leading-relaxed mb-4 pr-4">
           Avec Premium, ta prochaine séance est générée sur mesure en 30 s, ou pars sur un programme complet adapté à
           tes objectifs.
         </p>
         <Link
           to="/premium"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/20 border border-white/30 text-sm font-bold text-white hover:bg-white/30 transition-colors backdrop-blur-sm"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/20 border border-white/30 text-sm font-bold text-white hover:bg-white/30 transition-colors"
         >
           Découvrir Premium
         </Link>

--- a/src/config/storage-keys.ts
+++ b/src/config/storage-keys.ts
@@ -4,4 +4,5 @@ export const STORAGE_KEYS = {
   AUDIO_ENABLED: 'wan2fit-audio-enabled',
   NUDGE_DISMISSED: 'wan2fit-nudge-dismissed',
   CREATE_PROGRAM_DRAFT: 'wan2fit-create-program-draft',
+  PREMIUM_TEASER_DISMISSED: 'wan2fit-premium-teaser-dismissed',
 } as const;


### PR DESCRIPTION
## Contexte

Audit `claudedocs/audit-2026-04-18/06-business-ux.md` — **R2 : activer la conversion à chaud**. Le moment post-séance est le point d'engagement max du funnel ; aucune surface de conversion ne l'exploitait (le paywall vit sur la home froide).

## Changement

Nouveau composant `PremiumTeaser` dans `EndScreen.tsx`, affiché **uniquement** pour un user authentifié non-premium une fois le profile résolu :

- Gradient brand (bg-gradient-to-br), dark-mode natif car EndScreen est hardcoded dark.
- Sparkles + hook "Tu gères." + value prop "séance sur mesure en 30 s OU programme complet adapté".
- CTA → `/premium`.
- Close button avec cooldown **7 jours** (`localStorage.PREMIUM_TEASER_DISMISSED`) pour ne pas polluer un user qui s'entraîne quotidiennement.

Condition de rendu : `{user && !authLoading && profile && !isPremium && <PremiumTeaser />}` — évite le flash sur les users premium arrivant via deep link avant résolution du profile.

## Test plan (recette effectuée)
- ✅ Tier 'free' → UI paywalls affichés (validé via flip tier temporaire : banner "Débloquer avec Premium" visible sur `/programmes`). Même condition `subscription_tier === 'premium'` que le teaser.
- ✅ Tier 'premium' → pas de teaser (pas de changement visuel pour les payants).
- ✅ `npm run lint` / `npm run build` / `npm test` → **315/315**.
- ⏭️ Affichage visuel du teaser après complétion d'une séance → à voir sur preview Vercel (impossible à déclencher sans compléter 30 min de sport).

## Review senior — 2 passes
- 1ère → REQUEST_CHANGES : 1 bloquant (flash pour premium si profile pas encore chargé) + 2 faibles (`cta-gradient` sur background div + `text-white/85` hors scale).
- Tous adressés → 2ème passe **APPROVE**.

## Follow-ups (audit R2 restants, PRs séparées)
- "Reviens demain" push-notification opt-in : nécessite setup SW push + permission flow.
- `InsightCard` nutrition free-tier avec exemple représentatif.
- Tracking analytics sur le CTR du teaser (pas de solution analytics actuelle dans l'app → tech-debt à créer si besoin de mesurer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)