### PR TITLE
feat(data): TanStack Query P2.1 phase 1 — install + root provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@biomejs/biome": "^2.4.4",
         "@sentry/vite-plugin": "^5.1.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -4296,6 +4297,7 @@
       "version": "5.99.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
       "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4322,6 +4324,7 @@
       "version": "5.99.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
       "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-devtools": "5.99.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@sentry/react": "^10.45.0",
         "@supabase/supabase-js": "^2.97.0",
+        "@tanstack/react-query": "^5.99.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@vercel/analytics": "^1.6.1",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
@@ -4278,6 +4280,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "^2.4.4",
     "@sentry/vite-plugin": "^5.1.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "@sentry/react": "^10.45.0",
     "@supabase/supabase-js": "^2.97.0",
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@vercel/analytics": "^1.6.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,36 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { lazy, Suspense } from 'react';
 import { RouterProvider } from 'react-router';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
 import { AuthProvider } from './contexts/AuthContext.tsx';
+import { queryClient } from './lib/queryClient.ts';
 import { router } from './router.tsx';
 
+// Dev-only: TanStack Query Devtools. `import.meta.env.DEV` is statically
+// replaced by Vite at build time, so the whole lazy(...) branch becomes
+// `null` in production and the devtools chunk is tree-shaken out.
+const ReactQueryDevtools = import.meta.env.DEV
+  ? lazy(() => import('@tanstack/react-query-devtools').then((m) => ({ default: m.ReactQueryDevtools })))
+  : null;
+
 export default function App() {
+  // QueryClientProvider sits INSIDE ErrorBoundary so any TanStack-originated
+  // render error is captured by Sentry via the boundary's componentDidCatch.
+  // A provider above the boundary would leak those errors to React's root
+  // uncaught handler. The devtools live under the same provider so they can
+  // read the real query cache.
   return (
     <ErrorBoundary>
-      <AuthProvider>
-        <RouterProvider router={router} />
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+        {ReactQueryDevtools && (
+          <Suspense fallback={null}>
+            <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />
+          </Suspense>
+        )}
+      </QueryClientProvider>
     </ErrorBoundary>
   );
 }

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,45 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Shared QueryClient for the whole app.
+ *
+ * Tuned for the Wan2Fit data model (mostly read-heavy, data changes slowly —
+ * program sessions, meal logs of the day, nutrition profile) and with a
+ * specific goal: replace the hand-rolled visibility-refresh dance in
+ * `AuthContext` + the `bumpDataGeneration()` global invalidation in
+ * `PublicLayout`, both of which are tied to the `inMemoryLock` deadlock
+ * documented in `tech-debt.md`.
+ *
+ * Defaults rationale:
+ * - `staleTime: 60s` — most queries (profile, program, nutrition target) can
+ *   serve a minute-old cache without any user-visible regression. Dramatically
+ *   cuts the refetch volume compared to the current "refetch on every
+ *   navigation" pattern.
+ * - `gcTime: 30min` — keep data in memory across route changes so a
+ *   back/forward doesn't re-hit the network. 30 min is long enough for a
+ *   typical single-session workflow, short enough to not hold stale user data
+ *   indefinitely.
+ * - `retry: 1` — Supabase queries that fail are usually either authz (no
+ *   point retrying) or a transient network blip (one retry catches it).
+ * - `refetchOnWindowFocus: false` — **this is the deadlock fix**. Refocus
+ *   used to trigger `refreshSession()` + every hook re-fetching, racing on
+ *   the GoTrueClient `inMemoryLock`. With TanStack we let stale data show
+ *   immediately and let a background `refetchOnMount` handle updates where
+ *   truly needed.
+ * - `refetchOnReconnect: true` — legitimate: if the user was offline, the
+ *   cache is probably stale.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -15,6 +15,15 @@ import { QueryClient } from '@tanstack/react-query';
  *   serve a minute-old cache without any user-visible regression. Dramatically
  *   cuts the refetch volume compared to the current "refetch on every
  *   navigation" pattern.
+ *
+ *   **MIGRATION CONTRACT**: post-mutation freshness is the caller's
+ *   responsibility. `staleTime` only governs background refetches — data
+ *   written by the current session is NOT refetched unless you call
+ *   `queryClient.invalidateQueries({ queryKey: [...] })` after the mutation.
+ *   Every hook migrated to `useMutation` must wire `onSuccess` /
+ *   `onSettled` → `invalidateQueries` for the lists it mutates, otherwise
+ *   the UI will show stale data for up to 60s post-write.
+ *
  * - `gcTime: 30min` — keep data in memory across route changes so a
  *   back/forward doesn't re-hit the network. 30 min is long enough for a
  *   typical single-session workflow, short enough to not hold stale user data
@@ -23,9 +32,16 @@ import { QueryClient } from '@tanstack/react-query';
  *   point retrying) or a transient network blip (one retry catches it).
  * - `refetchOnWindowFocus: false` — **this is the deadlock fix**. Refocus
  *   used to trigger `refreshSession()` + every hook re-fetching, racing on
- *   the GoTrueClient `inMemoryLock`. With TanStack we let stale data show
- *   immediately and let a background `refetchOnMount` handle updates where
- *   truly needed.
+ *   the GoTrueClient `inMemoryLock`. Disabling the default breaks that race
+ *   permanently.
+ *
+ *   **MIGRATION CONTRACT**: once hooks are migrated, the
+ *   `visibilitychange` handler currently in `AuthContext.tsx` (which calls
+ *   `bumpDataGeneration`) must be rewired to call
+ *   `queryClient.invalidateQueries()` after the same 5-minute staleness
+ *   threshold. Otherwise a user returning after > 5 min to an already-mounted
+ *   page sees unbounded stale data (up to `gcTime`).
+ *
  * - `refetchOnReconnect: true` — legitimate: if the user was offline, the
  *   cache is probably stale.
  */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,9 @@
 import * as Sentry from '@sentry/react';
-import { QueryClientProvider } from '@tanstack/react-query';
 import { Analytics } from '@vercel/analytics/react';
-import { lazy, StrictMode, Suspense } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
-import { queryClient } from './lib/queryClient.ts';
-
-// Dev-only: TanStack Query Devtools. Lazy + import.meta.env.DEV guard so the
-// ~40 KB devtools bundle never ships to production.
-const ReactQueryDevtools = import.meta.env.DEV
-  ? lazy(() => import('@tanstack/react-query-devtools').then((m) => ({ default: m.ReactQueryDevtools })))
-  : null;
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -25,14 +17,7 @@ Sentry.init({
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-      <Analytics />
-      {ReactQueryDevtools && (
-        <Suspense fallback={null}>
-          <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />
-        </Suspense>
-      )}
-    </QueryClientProvider>
+    <App />
+    <Analytics />
   </StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,17 @@
 import * as Sentry from '@sentry/react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Analytics } from '@vercel/analytics/react';
-import { StrictMode } from 'react';
+import { lazy, StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { queryClient } from './lib/queryClient.ts';
+
+// Dev-only: TanStack Query Devtools. Lazy + import.meta.env.DEV guard so the
+// ~40 KB devtools bundle never ships to production.
+const ReactQueryDevtools = import.meta.env.DEV
+  ? lazy(() => import('@tanstack/react-query-devtools').then((m) => ({ default: m.ReactQueryDevtools })))
+  : null;
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -17,7 +25,14 @@ Sentry.init({
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-    <Analytics />
+    <QueryClientProvider client={queryClient}>
+      <App />
+      <Analytics />
+      {ReactQueryDevtools && (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />
+        </Suspense>
+      )}
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## Contexte

Premier PR de 3 pour migrer l'app de `useEffect + supabaseQuery` vers **TanStack Query**. Objectif final : résoudre le deadlock `inMemoryLock` documenté dans `tech-debt.md` (bug tab-switch où chaque hook race GoTrueClient sur le même mutex non-réentrant).

**Scope phase 1 : wiring uniquement**. Aucun hook migré, comportement runtime identique.

## Changes

- Deps : `@tanstack/react-query ^5.99` (prod) + `@tanstack/react-query-devtools ^5.99` (dev).
- `src/lib/queryClient.ts` — QueryClient partagé avec defaults tunés :
  - `staleTime 60s` + `gcTime 30min`
  - `retry 1`, `mutations: { retry: 0 }`
  - **`refetchOnWindowFocus: false`** ← le fix du deadlock
  - `refetchOnReconnect: true`
- `App.tsx` — `QueryClientProvider` **à l'intérieur** de `ErrorBoundary` pour que les erreurs TanStack remontent à Sentry. Devtools co-localisés (dev-only, `import.meta.env.DEV` + lazy import → tree-shaken en prod).
- `main.tsx` — inchangé (shape pré-PR).

## Review senior — 2 passes

1ère passe → REQUEST_CHANGES :
- **BLOCKER** : Provider à l'extérieur de ErrorBoundary → fix : déplacé dans App.tsx.
- IMPORTANT : doc contrat `invalidateQueries` post-mutation → ajoutée dans queryClient.ts.
- NEEDS_DISCUSSION : dépendance sur le visibilitychange handler à migrer en phase 2 → ajoutée à la doc.
- RECOMMENDED : devtools → devDependencies → fait.

## Validation

- `npm run lint` / `npm run build` / `npm test` ✅ **315/315**.
- Bundle prod : index inchangé à **241 kB / 76 kB gzip** (devtools tree-shaken).
- Chrome dev : bouton Devtools visible (coin bas-gauche), app monte, zéro console error.

## Suite

- **Phase 2 (PR suivante)** : migrer `AuthContext.profile` vers `useQuery({ queryKey: ['profile', userId] })`. Drop `bumpDataGeneration` sur 2-3 hooks pour prouver le pattern. Rewire le visibilitychange handler vers `queryClient.invalidateQueries()`.
- **Phase 3** : migrer les hooks restants (nutrition, programs, history, custom sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)