### PR TITLE
feat(data): TanStack Query P2.1 phase 3 — full migration + retire legacy counter

### DIFF
--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
-import { useAuth } from '../contexts/AuthContext.tsx';
 import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
 import { Footer } from './Footer.tsx';
@@ -9,19 +8,13 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
   const { pathname } = useLocation();
-  const { user, bumpDataGeneration } = useAuth();
 
-  // Navigation bumps the legacy `dataGeneration` counter so hooks still on
-  // the pre-TanStack pattern refetch on every route change (old contract).
-  // Queries already migrated to TanStack Query are NOT invalidated here on
-  // purpose: they rely on `staleTime` + mutation-side invalidation
-  // (useSaveCompletion, etc.) to stay fresh. Mirroring this effect into
-  // `queryClient.invalidateQueries()` would refetch every cache entry on
-  // every navigation and negate the cache benefit we just introduced.
+  // Scroll top on route change. Data freshness is no longer tied to
+  // navigation — every hook is on TanStack Query and relies on its
+  // `staleTime` + mutation-side invalidation contract.
   useEffect(() => {
     window.scrollTo(0, 0);
-    if (user) bumpDataGeneration();
-  }, [pathname, user, bumpDataGeneration]);
+  }, [pathname]);
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,8 +10,6 @@ interface AuthContextValue {
   profile: Profile | null;
   loading: boolean;
   sessionExpired: boolean;
-  dataGeneration: number;
-  bumpDataGeneration: () => void;
   refreshProfile: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string, displayName: string) => Promise<{ error: string | null }>;
@@ -57,11 +55,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [sessionLoading, setSessionLoading] = useState(!!supabase);
   const [sessionExpired, setSessionExpired] = useState(false);
-  // Legacy counter still read by hooks not yet migrated to TanStack Query.
-  // New hooks rely on `queryClient.invalidateQueries()` instead. Both are
-  // bumped together from the visibility handler and the legacy
-  // `bumpDataGeneration` helper until migration completes.
-  const [dataGeneration, setDataGeneration] = useState(0);
   const mounted = useRef(true);
   const lastVisibleAt = useRef(Date.now());
 
@@ -79,9 +72,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const profile = profileQuery.data ?? null;
 
   // Refresh session + invalidate all queries when returning from background
-  // after inactivity. Replaces the old pattern that only bumped
-  // `dataGeneration`; we now do both so hooks migrated to TanStack are also
-  // refreshed (invalidateQueries({})) alongside legacy hooks (dataGeneration).
+  // after inactivity. Every data hook now reads through TanStack Query; this
+  // single `invalidateQueries()` call covers them all without the legacy
+  // `dataGeneration` counter.
   useEffect(() => {
     function handleVisibilityChange() {
       if (document.visibilityState === 'visible') {
@@ -91,7 +84,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             .refreshSession()
             .then(() => {
               if (mounted.current) {
-                setDataGeneration((g) => g + 1);
                 queryClient.invalidateQueries();
               }
             })
@@ -205,8 +197,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     queryClient.clear();
   }, [queryClient]);
 
-  const bumpDataGeneration = useCallback(() => setDataGeneration((g) => g + 1), []);
-
   // `loading` stays true until both the initial session is resolved AND —
   // when a user was present — the profile query has finished its first
   // attempt. Keeps the previous invariant: consumers see no flash of
@@ -219,8 +209,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       profile,
       loading,
       sessionExpired,
-      dataGeneration,
-      bumpDataGeneration,
       refreshProfile,
       signIn,
       signUp,
@@ -228,20 +216,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       updatePassword,
       signOut,
     }),
-    [
-      user,
-      profile,
-      loading,
-      sessionExpired,
-      dataGeneration,
-      bumpDataGeneration,
-      refreshProfile,
-      signIn,
-      signUp,
-      resetPassword,
-      updatePassword,
-      signOut,
-    ],
+    [user, profile, loading, sessionExpired, refreshProfile, signIn, signUp, resetPassword, updatePassword, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/useCustomSessions.ts
+++ b/src/hooks/useCustomSessions.ts
@@ -1,25 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useAuth } from '../contexts/AuthContext.tsx';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { CustomSessionRecord } from '../types/custom-session.ts';
 
 export function useCustomSessions(userId: string | undefined) {
-  const { dataGeneration } = useAuth();
-  const [sessions, setSessions] = useState<CustomSessionRecord[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const refresh = useCallback(async () => {
-    if (!supabase || !userId) {
-      setSessions([]);
-      setError(null);
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-    try {
+  const query = useQuery<{ sessions: CustomSessionRecord[]; error: string | null }>({
+    queryKey: ['customSessions', userId ?? null],
+    queryFn: async () => {
       const {
         data,
         error: fetchError,
@@ -28,7 +18,7 @@ export function useCustomSessions(userId: string | undefined) {
         supabase!
           .from('custom_sessions')
           .select('*')
-          .eq('user_id', userId)
+          .eq('user_id', userId!)
           .eq('status', 'confirmed')
           .order('created_at', { ascending: false })
           .limit(20),
@@ -36,70 +26,45 @@ export function useCustomSessions(userId: string | undefined) {
 
       if (sessionExpired) {
         notifySessionExpired();
-        setError('Session expirée. Rafraîchis la page.');
-      } else if (fetchError) {
-        setError('Impossible de charger l\u2019historique.');
-      } else {
-        setSessions(data as CustomSessionRecord[]);
-        setError(null);
+        return { sessions: [], error: 'Session expirée. Rafraîchis la page.' };
       }
-    } catch (err) {
-      console.error('Custom sessions fetch error:', err);
-      setError('Impossible de charger l\u2019historique.');
-    } finally {
-      setLoading(false);
-    }
-  }, [userId, dataGeneration]);
+      if (fetchError) {
+        return { sessions: [], error: 'Impossible de charger l\u2019historique.' };
+      }
+      return { sessions: (data as CustomSessionRecord[]) ?? [], error: null };
+    },
+    enabled: !!userId && !!supabase,
+  });
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['customSessions', userId] });
+  }, [queryClient, userId]);
 
-  return { sessions, loading, error, refresh };
+  return {
+    sessions: query.data?.sessions ?? [],
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+    refresh,
+  };
 }
 
 export function useCustomSession(id: string | undefined, userId: string | undefined) {
-  const { dataGeneration } = useAuth();
-  const [session, setSession] = useState<CustomSessionRecord | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!id || !userId || !supabase) {
-      setSession(null);
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    async function load() {
-      try {
-        const { data, sessionExpired } = await supabaseQuery(() =>
-          supabase!.from('custom_sessions').select('*').eq('id', id).eq('user_id', userId).single(),
-        );
-
-        if (sessionExpired) {
-          notifySessionExpired();
-        }
-        if (!cancelled && data) {
-          setSession(data as CustomSessionRecord);
-        }
-      } catch (err) {
-        console.error('Custom session fetch error:', err);
-      } finally {
-        if (!cancelled) setLoading(false);
+  const query = useQuery<CustomSessionRecord | null>({
+    queryKey: ['customSession', id ?? null, userId ?? null],
+    queryFn: async () => {
+      const { data, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('custom_sessions').select('*').eq('id', id!).eq('user_id', userId!).single(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return null;
       }
-    }
+      return (data as CustomSessionRecord | null) ?? null;
+    },
+    enabled: !!id && !!userId && !!supabase,
+  });
 
-    load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [id, userId, dataGeneration]);
-
-  return { session, loading };
+  return { session: query.data ?? null, loading: query.isPending };
 }
 
 export async function confirmCustomSession(id: string): Promise<boolean> {

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo, useRef } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -49,62 +50,39 @@ export interface UseDailyNutritionResult {
 }
 
 export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNutritionResult {
-  const { user, dataGeneration } = useAuth();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const userId = user?.id;
-  const [logs, setLogs] = useState<MealLog[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [localGeneration, setLocalGeneration] = useState(0);
   const inflightRef = useRef(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration + localGeneration force re-fetch
-  useEffect(() => {
-    if (!userId || !supabase) {
-      setLogs([]);
-      setLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    (async () => {
-      try {
-        const {
-          data,
-          error: err,
-          sessionExpired,
-        } = await supabaseQuery(() =>
-          supabase!
-            .from('meal_logs')
-            .select('*')
-            .eq('user_id', userId)
-            .eq('logged_date', dateKey)
-            .order('created_at', { ascending: true }),
-        );
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        if (err) {
-          setError(err.message ?? 'Erreur de chargement des repas');
-          setLoading(false);
-          return;
-        }
-        setLogs((data ?? []) as MealLog[]);
-        setLoading(false);
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Erreur inconnue');
-          setLoading(false);
-        }
+  const query = useQuery<{ logs: MealLog[]; error: string | null }>({
+    queryKey: ['dailyNutrition', userId ?? null, dateKey],
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('meal_logs')
+          .select('*')
+          .eq('user_id', userId!)
+          .eq('logged_date', dateKey)
+          .order('created_at', { ascending: true }),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return { logs: [], error: null };
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, dateKey, dataGeneration, localGeneration]);
+      if (err) {
+        return { logs: [], error: err.message ?? 'Erreur de chargement des repas' };
+      }
+      return { logs: (data ?? []) as MealLog[], error: null };
+    },
+    enabled: !!userId && !!supabase,
+  });
+
+  const logs = query.data?.logs ?? [];
 
   const addMeal = useCallback(
     async (input: Omit<MealLogInsert, 'logged_date'> & { logged_date?: string }) => {
@@ -123,17 +101,22 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
           return null;
         }
         if (err) {
-          setError(err.message ?? "Erreur lors de l'ajout du repas");
           return null;
         }
         const inserted = data as MealLog;
-        setLogs((prev) => [...prev, inserted]);
+        // Optimistic update: push to the current cache, then invalidate so
+        // any other day-dependent view (overflow insight) also refreshes.
+        queryClient.setQueryData<{ logs: MealLog[]; error: string | null }>(
+          ['dailyNutrition', userId, payload.logged_date],
+          (prev) => ({ logs: [...(prev?.logs ?? []), inserted], error: null }),
+        );
+        queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
         return inserted;
       } finally {
         inflightRef.current = false;
       }
     },
-    [userId, dateKey],
+    [userId, dateKey, queryClient],
   );
 
   const deleteMeal = useCallback(
@@ -147,18 +130,21 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         return false;
       }
       if (err) {
-        setError(err.message ?? 'Erreur lors de la suppression');
         return false;
       }
-      setLogs((prev) => prev.filter((l) => l.id !== id));
+      queryClient.setQueryData<{ logs: MealLog[]; error: string | null }>(
+        ['dailyNutrition', userId, dateKey],
+        (prev) => ({ logs: (prev?.logs ?? []).filter((l) => l.id !== id), error: null }),
+      );
+      queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
       return true;
     },
-    [userId],
+    [userId, dateKey, queryClient],
   );
 
   const refresh = useCallback(() => {
-    setLocalGeneration((g) => g + 1);
-  }, []);
+    queryClient.invalidateQueries({ queryKey: ['dailyNutrition', userId, dateKey] });
+  }, [queryClient, userId, dateKey]);
 
   const summary = useMemo<DailyNutritionSummary>(() => {
     const totals = sumTotals(logs);
@@ -173,5 +159,13 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
     };
   }, [logs, dateKey]);
 
-  return { summary, logs, loading, error, addMeal, deleteMeal, refresh };
+  return {
+    summary,
+    logs,
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+    addMeal,
+    deleteMeal,
+    refresh,
+  };
 }

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -1,53 +1,66 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import type { GenerateProgramResponse, ProgramOnboardingInput } from '../types/custom-program.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useGenerateProgram() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const inflightRef = useRef(false);
 
-  const generate = useCallback(async (input: ProgramOnboardingInput): Promise<GenerateProgramResponse | null> => {
-    if (inflightRef.current) return null;
-    if (!supabase) {
-      setError('Service indisponible');
-      return null;
-    }
-
-    inflightRef.current = true;
-    setLoading(true);
-    setError(null);
-
-    try {
-      const { data, error: fnError } = await supabase.functions.invoke('generate-program', {
-        body: input,
-      });
-
-      if (fnError) {
-        const message = await extractEdgeFunctionError(
-          fnError as unknown as Record<string, unknown>,
-          'Une erreur est survenue. Réessaye.',
-        );
-        setError(message);
+  const generate = useCallback(
+    async (input: ProgramOnboardingInput): Promise<GenerateProgramResponse | null> => {
+      if (inflightRef.current) return null;
+      if (!supabase) {
+        setError('Service indisponible');
         return null;
       }
 
-      if (data?.error) {
-        setError(data.error);
-        return null;
-      }
+      inflightRef.current = true;
+      setLoading(true);
+      setError(null);
 
-      return data as GenerateProgramResponse;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Erreur inattendue');
-      return null;
-    } finally {
-      setLoading(false);
-      inflightRef.current = false;
-    }
-  }, []);
+      try {
+        const { data, error: fnError } = await supabase.functions.invoke('generate-program', {
+          body: input,
+        });
+
+        if (fnError) {
+          const message = await extractEdgeFunctionError(
+            fnError as unknown as Record<string, unknown>,
+            'Une erreur est survenue. Réessaye.',
+          );
+          setError(message);
+          return null;
+        }
+
+        if (data?.error) {
+          setError(data.error);
+          return null;
+        }
+
+        // The new program must appear in the user programs list and may become
+        // the active program on first session completion. Invalidate both so
+        // the redirect target page shows the fresh data.
+        queryClient.invalidateQueries({ queryKey: ['userPrograms', user?.id] });
+        queryClient.invalidateQueries({ queryKey: ['activeProgram', user?.id] });
+
+        return data as GenerateProgramResponse;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Erreur inattendue');
+        return null;
+      } finally {
+        setLoading(false);
+        inflightRef.current = false;
+      }
+    },
+    [queryClient, user?.id],
+  );
 
   return { generate, loading, error };
 }

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -8,6 +8,7 @@ import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 export function useGenerateProgram() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const userId = user?.id;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,10 +46,11 @@ export function useGenerateProgram() {
         }
 
         // The new program must appear in the user programs list and may become
-        // the active program on first session completion. Invalidate both so
-        // the redirect target page shows the fresh data.
-        queryClient.invalidateQueries({ queryKey: ['userPrograms', user?.id] });
-        queryClient.invalidateQueries({ queryKey: ['activeProgram', user?.id] });
+        // the active program on first session completion. Use `userId ?? null`
+        // so the keys match the ones the read hooks registered (TanStack keys
+        // are compared with strict ===, so undefined ≠ null).
+        queryClient.invalidateQueries({ queryKey: ['userPrograms', userId ?? null] });
+        queryClient.invalidateQueries({ queryKey: ['activeProgram', userId ?? null] });
 
         return data as GenerateProgramResponse;
       } catch (e) {
@@ -59,7 +61,7 @@ export function useGenerateProgram() {
         inflightRef.current = false;
       }
     },
-    [queryClient, user?.id],
+    [queryClient, userId],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -8,6 +8,7 @@ import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 export function useGenerateSession() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const userId = user?.id;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,9 +46,11 @@ export function useGenerateSession() {
         }
 
         // The new session row enters `custom_sessions` via the edge function;
-        // invalidate the user's list so the "Mes séances précédentes" section
-        // shows it immediately on the next render.
-        queryClient.invalidateQueries({ queryKey: ['customSessions', user?.id] });
+        // invalidate the user's list so "Mes séances précédentes" shows it
+        // immediately on the next render. Use `userId ?? null` so the key
+        // matches the one the read hook registered for logged-out visitors
+        // (TanStack compares keys with strict ===, so undefined ≠ null).
+        queryClient.invalidateQueries({ queryKey: ['customSessions', userId ?? null] });
 
         return data as GenerateSessionResponse;
       } catch (e) {
@@ -58,7 +61,7 @@ export function useGenerateSession() {
         inflightRef.current = false;
       }
     },
-    [queryClient, user?.id],
+    [queryClient, userId],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -1,53 +1,65 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import type { CustomSessionInput, GenerateSessionResponse } from '../types/custom-session.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useGenerateSession() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const inflightRef = useRef(false);
 
-  const generate = useCallback(async (input: CustomSessionInput): Promise<GenerateSessionResponse | null> => {
-    if (inflightRef.current) return null;
-    if (!supabase) {
-      setError('Service indisponible');
-      return null;
-    }
-
-    inflightRef.current = true;
-    setLoading(true);
-    setError(null);
-
-    try {
-      const { data, error: fnError } = await supabase.functions.invoke('generate-session', {
-        body: input,
-      });
-
-      if (fnError) {
-        const message = await extractEdgeFunctionError(
-          fnError as unknown as Record<string, unknown>,
-          'Une erreur est survenue. Réessayez.',
-        );
-        setError(message);
+  const generate = useCallback(
+    async (input: CustomSessionInput): Promise<GenerateSessionResponse | null> => {
+      if (inflightRef.current) return null;
+      if (!supabase) {
+        setError('Service indisponible');
         return null;
       }
 
-      if (data?.error) {
-        setError(data.error);
-        return null;
-      }
+      inflightRef.current = true;
+      setLoading(true);
+      setError(null);
 
-      return data as GenerateSessionResponse;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Erreur inattendue');
-      return null;
-    } finally {
-      setLoading(false);
-      inflightRef.current = false;
-    }
-  }, []);
+      try {
+        const { data, error: fnError } = await supabase.functions.invoke('generate-session', {
+          body: input,
+        });
+
+        if (fnError) {
+          const message = await extractEdgeFunctionError(
+            fnError as unknown as Record<string, unknown>,
+            'Une erreur est survenue. Réessayez.',
+          );
+          setError(message);
+          return null;
+        }
+
+        if (data?.error) {
+          setError(data.error);
+          return null;
+        }
+
+        // The new session row enters `custom_sessions` via the edge function;
+        // invalidate the user's list so the "Mes séances précédentes" section
+        // shows it immediately on the next render.
+        queryClient.invalidateQueries({ queryKey: ['customSessions', user?.id] });
+
+        return data as GenerateSessionResponse;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Erreur inattendue');
+        return null;
+      } finally {
+        setLoading(false);
+        inflightRef.current = false;
+      }
+    },
+    [queryClient, user?.id],
+  );
 
   return { generate, loading, error };
 }

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useAuth } from '../contexts/AuthContext.tsx';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { SessionCompletion } from '../types/completion.ts';
@@ -130,70 +130,45 @@ interface SessionData {
 }
 
 export function useHistory(userId: string | undefined): HistoryStats {
-  const { dataGeneration } = useAuth();
-  const [completions, setCompletions] = useState<CompletionWithTitle[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration forces re-fetch on auth state change
-  useEffect(() => {
-    if (!userId || !supabase) {
-      setCompletions([]);
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        const { data, sessionExpired } = await supabaseQuery(() =>
-          supabase!
-            .from('session_completions')
-            .select('*, program_sessions(session_data), custom_sessions(session_data)')
-            .eq('user_id', userId!)
-            .order('completed_at', { ascending: false })
-            .limit(200),
-        );
-
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-
-        const rows = (data ?? []) as unknown as (SessionCompletion & {
-          program_sessions: { session_data?: SessionData } | null;
-          custom_sessions: { session_data?: SessionData } | null;
-        })[];
-
-        const enriched: CompletionWithTitle[] = rows.map((row) => {
-          const meta = row.metadata as Record<string, unknown>;
-          const sd = row.program_sessions?.session_data ?? row.custom_sessions?.session_data;
-          return {
-            ...row,
-            session_title: (meta?.session_title as string | undefined) ?? sd?.title ?? null,
-            session_description: (meta?.session_description as string | undefined) ?? sd?.description ?? null,
-            session_focus: (meta?.session_focus as string[] | undefined) ?? sd?.focus ?? [],
-            block_types: (meta?.block_types as string[] | undefined) ?? [
-              ...new Set((sd?.blocks ?? []).map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown')),
-            ],
-          };
-        });
-
-        setCompletions(enriched);
-        setLoading(false);
-      } catch (err) {
-        console.error('History fetch error:', err);
-        if (!cancelled) setLoading(false);
+  const query = useQuery<CompletionWithTitle[]>({
+    queryKey: ['history', userId ?? null],
+    queryFn: async () => {
+      const { data, sessionExpired } = await supabaseQuery(() =>
+        supabase!
+          .from('session_completions')
+          .select('*, program_sessions(session_data), custom_sessions(session_data)')
+          .eq('user_id', userId!)
+          .order('completed_at', { ascending: false })
+          .limit(200),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return [];
       }
-    })();
+      const rows = (data ?? []) as unknown as (SessionCompletion & {
+        program_sessions: { session_data?: SessionData } | null;
+        custom_sessions: { session_data?: SessionData } | null;
+      })[];
 
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, dataGeneration]);
+      return rows.map((row) => {
+        const meta = row.metadata as Record<string, unknown>;
+        const sd = row.program_sessions?.session_data ?? row.custom_sessions?.session_data;
+        return {
+          ...row,
+          session_title: (meta?.session_title as string | undefined) ?? sd?.title ?? null,
+          session_description: (meta?.session_description as string | undefined) ?? sd?.description ?? null,
+          session_focus: (meta?.session_focus as string[] | undefined) ?? sd?.focus ?? [],
+          block_types: (meta?.block_types as string[] | undefined) ?? [
+            ...new Set((sd?.blocks ?? []).map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown')),
+          ],
+        };
+      });
+    },
+    enabled: !!userId && !!supabase,
+  });
+
+  const completions = query.data ?? [];
+  const loading = query.isPending;
 
   const derived = useMemo(() => {
     const totalSessions = completions.length;

--- a/src/hooks/useNutritionProfile.ts
+++ b/src/hooks/useNutritionProfile.ts
@@ -66,8 +66,6 @@ export function useNutritionProfile(): UseNutritionProfileResult {
       // Update the cache optimistically so subsequent reads see the new value
       // immediately, then let the next background refetch reconcile.
       queryClient.setQueryData(['nutritionProfile', userId], { profile: next, error: null });
-      // Invalidate the daily nutrition view (it reads the target calories).
-      queryClient.invalidateQueries({ queryKey: ['dailyNutrition', userId] });
       return next;
     },
     [userId, queryClient],

--- a/src/hooks/useNutritionProfile.ts
+++ b/src/hooks/useNutritionProfile.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -14,59 +15,31 @@ export interface UseNutritionProfileResult {
 }
 
 export function useNutritionProfile(): UseNutritionProfileResult {
-  const { user, dataGeneration } = useAuth();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const userId = user?.id;
-  const [profile, setProfile] = useState<NutritionProfile | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [localGeneration, setLocalGeneration] = useState(0);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration + localGeneration force re-fetch
-  useEffect(() => {
-    if (!userId || !supabase) {
-      setProfile(null);
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-
-    (async () => {
-      try {
-        const {
-          data,
-          error: err,
-          sessionExpired,
-        } = await supabaseQuery(() =>
-          supabase!.from('nutrition_profiles').select('*').eq('user_id', userId).maybeSingle(),
-        );
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        if (err) {
-          setError(err.message ?? 'Erreur de chargement du profil');
-          setLoading(false);
-          return;
-        }
-        setProfile((data as NutritionProfile | null) ?? null);
-        setLoading(false);
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Erreur inconnue');
-          setLoading(false);
-        }
+  const query = useQuery<{ profile: NutritionProfile | null; error: string | null }>({
+    queryKey: ['nutritionProfile', userId ?? null],
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!.from('nutrition_profiles').select('*').eq('user_id', userId!).maybeSingle(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return { profile: null, error: null };
       }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, dataGeneration, localGeneration]);
+      if (err) {
+        return { profile: null, error: err.message ?? 'Erreur de chargement du profil' };
+      }
+      return { profile: (data as NutritionProfile | null) ?? null, error: null };
+    },
+    enabled: !!userId && !!supabase,
+  });
 
   const upsert = useCallback(
     async (patch: NutritionProfileUpsert) => {
@@ -87,14 +60,17 @@ export function useNutritionProfile(): UseNutritionProfileResult {
         return null;
       }
       if (err) {
-        setError(err.message ?? 'Erreur de sauvegarde');
         return null;
       }
-      const next = data as NutritionProfile | null;
-      setProfile(next);
+      const next = (data as NutritionProfile | null) ?? null;
+      // Update the cache optimistically so subsequent reads see the new value
+      // immediately, then let the next background refetch reconcile.
+      queryClient.setQueryData(['nutritionProfile', userId], { profile: next, error: null });
+      // Invalidate the daily nutrition view (it reads the target calories).
+      queryClient.invalidateQueries({ queryKey: ['dailyNutrition', userId] });
       return next;
     },
-    [userId],
+    [userId, queryClient],
   );
 
   const clearTarget = useCallback(async () => {
@@ -109,8 +85,15 @@ export function useNutritionProfile(): UseNutritionProfileResult {
   }, [upsert]);
 
   const refresh = useCallback(() => {
-    setLocalGeneration((g) => g + 1);
-  }, []);
+    queryClient.invalidateQueries({ queryKey: ['nutritionProfile', userId] });
+  }, [queryClient, userId]);
 
-  return { profile, loading, error, upsert, clearTarget, refresh };
+  return {
+    profile: query.data?.profile ?? null,
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+    upsert,
+    clearTarget,
+    refresh,
+  };
 }

--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -101,159 +100,94 @@ export function usePrograms() {
 }
 
 export function useProgram(slug: string | undefined, userId: string | undefined) {
-  const { dataGeneration } = useAuth();
-  const [program, setProgram] = useState<ProgramWithSessions | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!slug || !supabase) {
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        // Fetch program (RLS handles access control)
-        const { data: pgm, sessionExpired } = await supabaseQuery(() =>
-          supabase!.from('programs').select('*').eq('slug', slug!).single(),
-        );
-
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        if (!pgm) {
-          setLoading(false);
-          return;
-        }
-
-        // Fetch program sessions
-        const { data: sessions, sessionExpired: sessExp } = await supabaseQuery(() =>
-          supabase!
-            .from('program_sessions')
-            .select('*')
-            .eq('program_id', (pgm as Program).id)
-            .order('session_order'),
-        );
-
-        if (cancelled) return;
-        if (sessExp) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-
-        // Fetch user's completions for this program's sessions
-        const sessionIds = (sessions ?? []).map((s: ProgramSession) => s.id);
-        let completedIds = new Set<string>();
-
-        if (sessionIds.length > 0 && userId) {
-          const { data: completions, sessionExpired: compExp } = await supabaseQuery(() =>
-            supabase!
-              .from('session_completions')
-              .select('program_session_id')
-              .eq('user_id', userId)
-              .in('program_session_id', sessionIds),
-          );
-
-          if (compExp) {
-            notifySessionExpired();
-            setLoading(false);
-            return;
-          }
-
-          completedIds = new Set(
-            (completions as Pick<SessionCompletion, 'program_session_id'>[] | null)
-              ?.map((c) => c.program_session_id)
-              .filter((id): id is string => id !== null) ?? [],
-          );
-        }
-
-        if (cancelled) return;
-
-        setProgram({
-          ...(pgm as Program),
-          sessions: (sessions as ProgramSession[]) ?? [],
-          completedSessionIds: completedIds,
-        });
-        setLoading(false);
-      } catch (err) {
-        console.error('Program fetch error:', err);
-        if (!cancelled) setLoading(false);
+  const query = useQuery<ProgramWithSessions | null>({
+    queryKey: ['program', slug ?? null, userId ?? null],
+    queryFn: async () => {
+      // Fetch program (RLS handles access control)
+      const { data: pgm, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('programs').select('*').eq('slug', slug!).single(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return null;
       }
-    })();
+      if (!pgm) return null;
 
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, userId, dataGeneration]);
+      const { data: sessions, sessionExpired: sessExp } = await supabaseQuery(() =>
+        supabase!
+          .from('program_sessions')
+          .select('*')
+          .eq('program_id', (pgm as Program).id)
+          .order('session_order'),
+      );
+      if (sessExp) {
+        notifySessionExpired();
+        return null;
+      }
 
-  return { program, loading };
+      const sessionIds = ((sessions as ProgramSession[]) ?? []).map((s) => s.id);
+      let completedIds = new Set<string>();
+
+      if (sessionIds.length > 0 && userId) {
+        const { data: completions, sessionExpired: compExp } = await supabaseQuery(() =>
+          supabase!
+            .from('session_completions')
+            .select('program_session_id')
+            .eq('user_id', userId)
+            .in('program_session_id', sessionIds),
+        );
+        if (compExp) {
+          notifySessionExpired();
+          return null;
+        }
+        completedIds = new Set(
+          (completions as Pick<SessionCompletion, 'program_session_id'>[] | null)
+            ?.map((c) => c.program_session_id)
+            .filter((id): id is string => id !== null) ?? [],
+        );
+      }
+
+      return {
+        ...(pgm as Program),
+        sessions: (sessions as ProgramSession[]) ?? [],
+        completedSessionIds: completedIds,
+      };
+    },
+    enabled: !!slug && !!supabase,
+  });
+
+  return { program: query.data ?? null, loading: query.isPending };
 }
 
 export function useProgramSession(slug: string | undefined, order: number | undefined) {
-  const { dataGeneration } = useAuth();
-  const [session, setSession] = useState<ProgramSession | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!slug || order == null || !supabase) {
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        const { data: pgm, sessionExpired } = await supabaseQuery(() =>
-          supabase!.from('programs').select('id').eq('slug', slug!).single(),
-        );
-
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        if (!pgm) {
-          setLoading(false);
-          return;
-        }
-
-        const { data: ps, sessionExpired: sessExp } = await supabaseQuery(() =>
-          supabase!
-            .from('program_sessions')
-            .select('*')
-            .eq('program_id', (pgm as { id: string }).id)
-            .eq('session_order', order!)
-            .single(),
-        );
-
-        if (cancelled) return;
-        if (sessExp) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        setSession((ps as ProgramSession) ?? null);
-        setLoading(false);
-      } catch (err) {
-        console.error('Program session fetch error:', err);
-        if (!cancelled) setLoading(false);
+  const query = useQuery<ProgramSession | null>({
+    queryKey: ['programSession', slug ?? null, order ?? null],
+    queryFn: async () => {
+      const { data: pgm, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('programs').select('id').eq('slug', slug!).single(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return null;
       }
-    })();
+      if (!pgm) return null;
 
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, order, dataGeneration]);
+      const { data: ps, sessionExpired: sessExp } = await supabaseQuery(() =>
+        supabase!
+          .from('program_sessions')
+          .select('*')
+          .eq('program_id', (pgm as { id: string }).id)
+          .eq('session_order', order!)
+          .single(),
+      );
+      if (sessExp) {
+        notifySessionExpired();
+        return null;
+      }
+      return (ps as ProgramSession | null) ?? null;
+    },
+    enabled: !!slug && order != null && !!supabase,
+  });
 
-  return { session, loading };
+  return { session: query.data ?? null, loading: query.isPending };
 }

--- a/src/hooks/useSaveCompletion.ts
+++ b/src/hooks/useSaveCompletion.ts
@@ -53,12 +53,16 @@ export function useSaveCompletion() {
         } else {
           setSaved(true);
           // Every query whose cache is affected by a new completion row must
-          // be invalidated here — TanStack has no way to infer which lists
-          // a mutation touches. Keep this list in sync with the migrated
-          // read hooks:
+          // be invalidated here — TanStack has no way to infer which lists a
+          // mutation touches. Keep this list in sync with the migrated read
+          // hooks:
           //  - useActiveProgram: progress + nextSession
           //  - useHistory: prepends the new row
-          //  - useProgram(slug): completedSessionIds for the matching program
+          //  - useProgram(slug): completedSessionIds for the matching program.
+          //    We invalidate the whole `['program']` prefix rather than a
+          //    specific slug because the save call does not know which slug
+          //    the ProgramPlayer was playing (no slug on the payload). The
+          //    cost is small (rarely more than 1-2 cached programs at a time).
           queryClient.invalidateQueries({ queryKey: ['activeProgram', user.id] });
           queryClient.invalidateQueries({ queryKey: ['history', user.id] });
           queryClient.invalidateQueries({ queryKey: ['program'] });

--- a/src/hooks/useSaveCompletion.ts
+++ b/src/hooks/useSaveCompletion.ts
@@ -52,13 +52,16 @@ export function useSaveCompletion() {
           setError(true);
         } else {
           setSaved(true);
-          // TanStack invariant: a completion mutates the set of rows
-          // behind `useActiveProgram` (progress, nextSession). The legacy
-          // hooks still react via the global `dataGeneration` bumped by
-          // PublicLayout's navigation effect, but TanStack queries must be
-          // invalidated explicitly — otherwise the completed session stays
-          // hidden until the next visibility-change after 5 min.
+          // Every query whose cache is affected by a new completion row must
+          // be invalidated here — TanStack has no way to infer which lists
+          // a mutation touches. Keep this list in sync with the migrated
+          // read hooks:
+          //  - useActiveProgram: progress + nextSession
+          //  - useHistory: prepends the new row
+          //  - useProgram(slug): completedSessionIds for the matching program
           queryClient.invalidateQueries({ queryKey: ['activeProgram', user.id] });
+          queryClient.invalidateQueries({ queryKey: ['history', user.id] });
+          queryClient.invalidateQueries({ queryKey: ['program'] });
         }
       } catch {
         setError(true);

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -6,52 +7,33 @@ import type { Subscription } from '../types/subscription.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useSubscription() {
-  const { profile, user, dataGeneration } = useAuth();
-  const [subscription, setSubscription] = useState<Subscription | null>(null);
-  const [loading, setLoading] = useState(false);
+  const { profile, user } = useAuth();
+  const userId = user?.id;
 
   const tier = profile?.subscription_tier ?? 'free';
   const isPremium = tier === 'premium';
 
-  // Fetch subscription details (period, cancel status, etc.)
-  useEffect(() => {
-    if (!supabase || !user || !isPremium) {
-      setSubscription(null);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        const { data, sessionExpired } = await supabaseQuery(() =>
-          supabase!
-            .from('subscriptions')
-            .select('*')
-            .eq('user_id', user.id)
-            .in('status', ['active', 'past_due', 'trialing'])
-            .order('created_at', { ascending: false })
-            .limit(1)
-            .maybeSingle(),
-        );
-
-        if (sessionExpired) {
-          notifySessionExpired();
-          return;
-        }
-        if (!cancelled) setSubscription(data as Subscription | null);
-      } catch (err) {
-        console.error('Subscription fetch error:', err);
-      } finally {
-        if (!cancelled) setLoading(false);
+  const query = useQuery<Subscription | null>({
+    queryKey: ['subscription', userId ?? null],
+    queryFn: async () => {
+      const { data, sessionExpired } = await supabaseQuery(() =>
+        supabase!
+          .from('subscriptions')
+          .select('*')
+          .eq('user_id', userId!)
+          .in('status', ['active', 'past_due', 'trialing'])
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return null;
       }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [user, isPremium, dataGeneration]);
+      return (data as Subscription | null) ?? null;
+    },
+    enabled: !!userId && !!supabase && isPremium,
+  });
 
   const checkout = useCallback(
     async (priceId: string): Promise<string | null> => {
@@ -95,5 +77,12 @@ export function useSubscription() {
     return data?.error || "Erreur lors de l'ouverture du portail";
   }, [user]);
 
-  return { tier, isPremium, subscription, loading, checkout, manageSubscription };
+  return {
+    tier,
+    isPremium,
+    subscription: query.data ?? null,
+    loading: query.isPending && isPremium,
+    checkout,
+    manageSubscription,
+  };
 }

--- a/src/hooks/useTodayInsight.ts
+++ b/src/hooks/useTodayInsight.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -19,65 +20,56 @@ export interface UseTodayInsightResult {
  * and lets the consumer update it after a generation.
  */
 export function useTodayInsight(dateKey: string = todayYYYYMMDD()): UseTodayInsightResult {
-  const { user, dataGeneration } = useAuth();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const userId = user?.id;
-  const [insight, setInsight] = useState<NutritionInsight | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [localGeneration, setLocalGeneration] = useState(0);
+  const queryKey = ['todayInsight', userId ?? null, dateKey];
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataGeneration + localGeneration force re-fetch
-  useEffect(() => {
-    if (!userId || !supabase) {
-      setInsight(null);
-      setLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    (async () => {
-      try {
-        const {
-          data,
-          error: err,
-          sessionExpired,
-        } = await supabaseQuery(() =>
-          supabase!
-            .from('nutrition_insights')
-            .select('*')
-            .eq('user_id', userId)
-            .eq('logged_date', dateKey)
-            .maybeSingle(),
-        );
-        if (cancelled) return;
-        if (sessionExpired) {
-          notifySessionExpired();
-          setLoading(false);
-          return;
-        }
-        if (err) {
-          setError(err.message ?? "Erreur de chargement de l'analyse");
-          setLoading(false);
-          return;
-        }
-        setInsight((data as NutritionInsight | null) ?? null);
-        setLoading(false);
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Erreur inconnue');
-          setLoading(false);
-        }
+  const query = useQuery<{ insight: NutritionInsight | null; error: string | null }>({
+    queryKey,
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('nutrition_insights')
+          .select('*')
+          .eq('user_id', userId!)
+          .eq('logged_date', dateKey)
+          .maybeSingle(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return { insight: null, error: null };
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, dateKey, dataGeneration, localGeneration]);
+      if (err) {
+        return { insight: null, error: err.message ?? "Erreur de chargement de l'analyse" };
+      }
+      return { insight: (data as NutritionInsight | null) ?? null, error: null };
+    },
+    enabled: !!userId && !!supabase,
+  });
+
+  const setInsight = useCallback(
+    (next: NutritionInsight | null) => {
+      // Direct cache write keeps generateInsight-style consumers trivially
+      // imperative (call setInsight(result) after the AI call resolves).
+      queryClient.setQueryData(queryKey, { insight: next, error: null });
+    },
+    [queryClient, queryKey],
+  );
 
   const refresh = useCallback(() => {
-    setLocalGeneration((g) => g + 1);
-  }, []);
+    queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
 
-  return { insight, loading, error, setInsight, refresh };
+  return {
+    insight: query.data?.insight ?? null,
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+    setInsight,
+    refresh,
+  };
 }

--- a/src/hooks/useTodayInsight.ts
+++ b/src/hooks/useTodayInsight.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
@@ -23,7 +23,10 @@ export function useTodayInsight(dateKey: string = todayYYYYMMDD()): UseTodayInsi
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const userId = user?.id;
-  const queryKey = ['todayInsight', userId ?? null, dateKey];
+  // Memoised so `useCallback` deps below stay referentially stable — otherwise
+  // consumers passing `setInsight` / `refresh` as props see a new function
+  // every render, cascading into needless re-renders.
+  const queryKey = useMemo(() => ['todayInsight', userId ?? null, dateKey] as const, [userId, dateKey]);
 
   const query = useQuery<{ insight: NutritionInsight | null; error: string | null }>({
     queryKey,

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -1,70 +1,62 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program } from '../types/completion.ts';
 
 export function useUserPrograms() {
-  const { user, dataGeneration } = useAuth();
-  const [programs, setPrograms] = useState<Program[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const userId = user?.id;
 
-  const fetchPrograms = useCallback(async () => {
-    if (!user || !supabase) {
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-    try {
+  const query = useQuery<Program[]>({
+    queryKey: ['userPrograms', userId ?? null],
+    queryFn: async () => {
       const { data, sessionExpired } = await supabaseQuery(() =>
         supabase!
           .from('programs')
           .select('*')
-          .eq('user_id', user.id)
+          .eq('user_id', userId!)
           .eq('is_fixed', false)
           .order('created_at', { ascending: false }),
       );
-
       if (sessionExpired) {
         notifySessionExpired();
-        return;
+        return [];
       }
-      setPrograms((data as Program[]) ?? []);
-    } catch (err) {
-      console.error('User programs fetch error:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [user]);
-
-  useEffect(() => {
-    fetchPrograms();
-  }, [fetchPrograms, dataGeneration]);
+      return (data as Program[]) ?? [];
+    },
+    enabled: !!userId && !!supabase,
+  });
 
   const deleteProgram = useCallback(
     async (id: string) => {
-      if (!supabase) return false;
-
+      if (!supabase || !userId) return false;
       try {
-        const { error } = await supabase
-          .from('programs')
-          .delete()
-          .eq('id', id)
-          .eq('user_id', user?.id ?? '');
+        const { error } = await supabase.from('programs').delete().eq('id', id).eq('user_id', userId);
         if (error) {
           console.error('Delete program error:', error);
           return false;
         }
-        setPrograms((prev) => prev.filter((p) => p.id !== id));
+        // Optimistic local update + invalidate so the active-program query
+        // (which may have pointed at this program) is also refreshed.
+        queryClient.setQueryData<Program[] | undefined>(['userPrograms', userId], (prev) =>
+          prev?.filter((p) => p.id !== id),
+        );
+        queryClient.invalidateQueries({ queryKey: ['activeProgram', userId] });
         return true;
       } catch (err) {
         console.error('Delete program error:', err);
         return false;
       }
     },
-    [user],
+    [userId, queryClient],
   );
 
-  return { programs, loading, deleteProgram, refresh: fetchPrograms };
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['userPrograms', userId] });
+  }, [queryClient, userId]);
+
+  return { programs: query.data ?? [], loading: query.isPending, deleteProgram, refresh };
 }

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -4,25 +4,18 @@ import { QueryClient } from '@tanstack/react-query';
  * Shared QueryClient for the whole app.
  *
  * Tuned for the Wan2Fit data model (mostly read-heavy, data changes slowly —
- * program sessions, meal logs of the day, nutrition profile) and with a
- * specific goal: replace the hand-rolled visibility-refresh dance in
- * `AuthContext` + the `bumpDataGeneration()` global invalidation in
- * `PublicLayout`, both of which are tied to the `inMemoryLock` deadlock
- * documented in `tech-debt.md`.
- *
- * Defaults rationale:
+ * program sessions, meal logs of the day, nutrition profile). Defaults
+ * rationale:
  * - `staleTime: 60s` — most queries (profile, program, nutrition target) can
  *   serve a minute-old cache without any user-visible regression. Dramatically
- *   cuts the refetch volume compared to the current "refetch on every
+ *   cuts the refetch volume compared to the pre-migration "refetch on every
  *   navigation" pattern.
  *
- *   **MIGRATION CONTRACT**: post-mutation freshness is the caller's
+ *   **MUTATION CONTRACT**: post-mutation freshness is the caller's
  *   responsibility. `staleTime` only governs background refetches — data
  *   written by the current session is NOT refetched unless you call
  *   `queryClient.invalidateQueries({ queryKey: [...] })` after the mutation.
- *   Every hook migrated to `useMutation` must wire `onSuccess` /
- *   `onSettled` → `invalidateQueries` for the lists it mutates, otherwise
- *   the UI will show stale data for up to 60s post-write.
+ *   Every mutation helper must invalidate the query keys it affects.
  *
  * - `gcTime: 30min` — keep data in memory across route changes so a
  *   back/forward doesn't re-hit the network. 30 min is long enough for a
@@ -30,18 +23,12 @@ import { QueryClient } from '@tanstack/react-query';
  *   indefinitely.
  * - `retry: 1` — Supabase queries that fail are usually either authz (no
  *   point retrying) or a transient network blip (one retry catches it).
- * - `refetchOnWindowFocus: false` — **this is the deadlock fix**. Refocus
- *   used to trigger `refreshSession()` + every hook re-fetching, racing on
- *   the GoTrueClient `inMemoryLock`. Disabling the default breaks that race
- *   permanently.
- *
- *   **MIGRATION CONTRACT**: once hooks are migrated, the
- *   `visibilitychange` handler currently in `AuthContext.tsx` (which calls
- *   `bumpDataGeneration`) must be rewired to call
- *   `queryClient.invalidateQueries()` after the same 5-minute staleness
- *   threshold. Otherwise a user returning after > 5 min to an already-mounted
- *   page sees unbounded stale data (up to `gcTime`).
- *
+ * - `refetchOnWindowFocus: false` — fixes the `inMemoryLock` deadlock that
+ *   used to bite at every tab switch: the prior `AuthContext` visibility
+ *   handler called `refreshSession()` while hooks refetched in parallel,
+ *   racing on GoTrueClient's non-reentrant mutex. Now the visibility handler
+ *   runs a single `invalidateQueries()` call after the 5-minute staleness
+ *   threshold (see `AuthContext`). No per-hook race.
  * - `refetchOnReconnect: true` — legitimate: if the user was offline, the
  *   cache is probably stale.
  */


### PR DESCRIPTION
## Contexte

Troisième et dernière PR de la migration TanStack Query. Phase 1 (PR #110) a wiré le provider. Phase 2 (PR #111) a migré `profile` + 2 hooks programme. Phase 3 **termine le travail** et supprime l'infrastructure legacy `dataGeneration` / `bumpDataGeneration`.

Résout définitivement le deadlock `inMemoryLock` documenté dans `tech-debt.md` : plus aucune race entre hooks data et `refreshSession()` sur le mutex non-réentrant GoTrueClient. Le tab-switch bug devient impossible par construction.

## Hooks migrés (10 queries)

- `useProgram(slug, userId)` → `['program', slug, userId]`
- `useProgramSession(slug, order)` → `['programSession', slug, order]`
- `useUserPrograms()` → `['userPrograms', userId]`
- `useHistory(userId)` → `['history', userId]`
- `useSubscription()` → `['subscription', userId]` (enabled uniquement quand premium)
- `useCustomSessions(userId)` → `['customSessions', userId]`
- `useCustomSession(id, userId)` → `['customSession', id, userId]`
- `useNutritionProfile()` → `['nutritionProfile', userId]`
- `useDailyNutrition(dateKey)` → `['dailyNutrition', userId, dateKey]`
- `useTodayInsight(dateKey)` → `['todayInsight', userId, dateKey]`

## Mutations invalidantes

- `useSaveCompletion.save` → `['activeProgram', userId]`, `['history', userId]`, `['program']` (prefix — toutes les pages programme en cache).
- `useUserPrograms.deleteProgram` → optimistic update + `['activeProgram', userId]`.
- `useGenerateProgram.generate` → `['userPrograms', userId]` + `['activeProgram', userId]`.
- `useGenerateSession.generate` → `['customSessions', userId]`.
- `useDailyNutrition.addMeal` / `deleteMeal` → optimistic setQueryData + `['todayInsight', userId]`.
- `useNutritionProfile.upsert` → optimistic setQueryData.

## Legacy retiré

- `AuthContext` : `dataGeneration` state + `bumpDataGeneration` callback + leurs fields dans le context. Visibility handler → un seul `queryClient.invalidateQueries()` après 5 min en background.
- `PublicLayout` : effet de navigation réduit à `window.scrollTo(0, 0)`.
- `queryClient.ts` JSDoc : section "migration contract" → "mutation contract" (langage de coexistence legacy retiré).

## Validation
- `npm run lint` / `npm run build` / `npm test` ✅ **315/315**
- Chrome : /programmes et /nutrition chargent cleanly, zero console error, meal logs + target ring + active program hero servis depuis le nouveau cache.
- `grep -rn dataGeneration src/` → empty.

## Review senior — 2 passes
1ère → REQUEST_CHANGES : 2 WARN (queryKey instable useTodayInsight, asymétrie `undefined`/`null` sur les generate-*) + 2 NIT (invalidation orpheline + commentaire imprécis). Tous adressés.

## Suite
- tech-debt.md : l'entrée `inMemoryLock` est obsolète. À nettoyer dans une PR follow-up après 1 semaine de prod sans report du bug.

## Test plan
- [ ] CI verte
- [ ] Preview Vercel : tab switch > 5 min → données se refetchent cleanly, pas de spinner infini.
- [ ] Compléter une séance → activeProgram + history se mettent à jour sans refresh.
- [ ] Générer un programme IA → apparaît dans "Mes programmes" immédiatement.
- [ ] Générer une séance custom → apparaît dans "Mes séances précédentes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)