### PR TITLE
feat(i18n): install react-i18next + locale toggle (infra only, no strings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
         "@tanstack/react-query": "^5.99.0",
         "@tanstack/react-query-devtools": "^5.99.0",
         "@vercel/analytics": "^1.6.1",
+        "i18next": "^26.0.7",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^17.0.4",
         "react-router": "^7.13.0"
       },
       "devDependencies": {
@@ -1535,10 +1538,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6010,6 +6012,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -6022,6 +6033,43 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.7.tgz",
+      "integrity": "sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iceberg-js": {
@@ -7531,6 +7579,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+      "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -8573,7 +8648,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8715,6 +8790,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {
@@ -8899,6 +8983,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/walk-up-path": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@vercel/analytics": "^1.6.1",
+    "i18next": "^26.0.7",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^17.0.4",
     "react-router": "^7.13.0"
   },
   "devDependencies": {

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { AuthButton } from './auth/AuthButton.tsx';
+import { LocaleToggle } from './LocaleToggle.tsx';
 
 const NAV_ITEMS = [
   { to: '/', label: 'Accueil', match: (p: string) => p === '/' },
@@ -54,7 +55,8 @@ export function BrandHeader() {
         </nav>
 
         {/* Controls */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
+          <LocaleToggle />
           <AuthButton />
         </div>
       </div>

--- a/src/components/LocaleToggle.tsx
+++ b/src/components/LocaleToggle.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+
+import { useLocale } from '../hooks/useLocale.ts';
+import type { SupportedLocale } from '../i18n';
+
+const PILLS: ReadonlyArray<{ code: SupportedLocale; label: string; longLabelKey: string }> = [
+  { code: 'fr', label: 'FR', longLabelKey: 'language_switcher.option_fr' },
+  { code: 'en', label: 'EN', longLabelKey: 'language_switcher.option_en' },
+];
+
+export function LocaleToggle() {
+  const { t } = useTranslation();
+  const { locale, setLocale } = useLocale();
+
+  return (
+    <fieldset className="inline-flex rounded-lg border border-divider bg-card-bg p-0.5 m-0">
+      <legend className="sr-only">{t('language_switcher.aria_label')}</legend>
+      {PILLS.map(({ code, label, longLabelKey }) => {
+        const active = locale === code;
+        return (
+          <button
+            key={code}
+            type="button"
+            onClick={() => setLocale(code)}
+            aria-pressed={active}
+            aria-label={t(longLabelKey)}
+            className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-colors cursor-pointer ${
+              active ? 'bg-brand/10 text-brand' : 'text-muted hover:text-heading'
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -1,24 +1,16 @@
-import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SUPPORTED_LOCALES, type SupportedLocale } from '../i18n';
-
-function isSupportedLocale(value: string): value is SupportedLocale {
-  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
-}
+import { isSupportedLocale, type SupportedLocale } from '../i18n';
 
 export function useLocale() {
   const { i18n } = useTranslation();
   const rawLocale = i18n.resolvedLanguage ?? i18n.language;
   const locale: SupportedLocale = isSupportedLocale(rawLocale) ? rawLocale : 'fr';
 
-  const setLocale = useCallback(
-    (next: SupportedLocale) => {
-      if (next === locale) return;
-      void i18n.changeLanguage(next);
-    },
-    [i18n, locale],
-  );
+  const setLocale = (next: SupportedLocale) => {
+    if (next === locale) return;
+    void i18n.changeLanguage(next);
+  };
 
-  return { locale, setLocale, supportedLocales: SUPPORTED_LOCALES } as const;
+  return { locale, setLocale } as const;
 }

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SUPPORTED_LOCALES, type SupportedLocale } from '../i18n';
+
+function isSupportedLocale(value: string): value is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+export function useLocale() {
+  const { i18n } = useTranslation();
+  const rawLocale = i18n.resolvedLanguage ?? i18n.language;
+  const locale: SupportedLocale = isSupportedLocale(rawLocale) ? rawLocale : 'fr';
+
+  const setLocale = useCallback(
+    (next: SupportedLocale) => {
+      if (next === locale) return;
+      void i18n.changeLanguage(next);
+    },
+    [i18n, locale],
+  );
+
+  return { locale, setLocale, supportedLocales: SUPPORTED_LOCALES } as const;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,45 @@
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
+
+import commonEn from './locales/en/common.json';
+import commonFr from './locales/fr/common.json';
+
+export const SUPPORTED_LOCALES = ['fr', 'en'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export const LOCALE_STORAGE_KEY = 'wan2fit-locale';
+const DEFAULT_LOCALE: SupportedLocale = 'fr';
+
+const resources = {
+  fr: { common: commonFr },
+  en: { common: commonEn },
+} as const;
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: DEFAULT_LOCALE,
+    supportedLngs: SUPPORTED_LOCALES,
+    ns: ['common'],
+    defaultNS: 'common',
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: LOCALE_STORAGE_KEY,
+      caches: ['localStorage'],
+    },
+    returnNull: false,
+  });
+
+const syncHtmlLang = (lng: string) => {
+  const normalized = (SUPPORTED_LOCALES as readonly string[]).includes(lng) ? lng : DEFAULT_LOCALE;
+  document.documentElement.lang = normalized;
+};
+
+syncHtmlLang(i18n.language);
+i18n.on('languageChanged', syncHtmlLang);
+
+export default i18n;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,8 +8,12 @@ import commonFr from './locales/fr/common.json';
 export const SUPPORTED_LOCALES = ['fr', 'en'] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
-export const LOCALE_STORAGE_KEY = 'wan2fit-locale';
+const LOCALE_STORAGE_KEY = 'wan2fit-locale';
 const DEFAULT_LOCALE: SupportedLocale = 'fr';
+
+export function isSupportedLocale(value: string): value is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
 
 const resources = {
   fr: { common: commonFr },
@@ -35,8 +39,7 @@ i18n
   });
 
 const syncHtmlLang = (lng: string) => {
-  const normalized = (SUPPORTED_LOCALES as readonly string[]).includes(lng) ? lng : DEFAULT_LOCALE;
-  document.documentElement.lang = normalized;
+  document.documentElement.lang = isSupportedLocale(lng) ? lng : DEFAULT_LOCALE;
 };
 
 syncHtmlLang(i18n.language);

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,0 +1,7 @@
+{
+  "language_switcher": {
+    "aria_label": "Switch language",
+    "option_fr": "French",
+    "option_en": "English"
+  }
+}

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,0 +1,7 @@
+{
+  "language_switcher": {
+    "aria_label": "Changer de langue",
+    "option_fr": "Français",
+    "option_en": "Anglais"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
+import './i18n';
 import App from './App.tsx';
 
 Sentry.init({


### PR DESCRIPTION
## Summary
PR 1/4 du chantier i18n. Pose l'infra sans extraire aucune string UI — l'app reste 100% en français visible.

- Install `react-i18next` + `i18next` + `i18next-browser-languagedetector`
- Setup `src/i18n/` avec namespace `common` (FR/EN) — seulement les clés du toggle lui-même pour l'instant
- Hook `useLocale` + composant `<LocaleToggle />` (pills FR/EN) dans `BrandHeader` à gauche de `AuthButton`
- Persistance `localStorage['wan2fit-locale']` (préfixe projet)
- Sync `<html lang>` au changement, fallback `fr`, détection `navigator.language` au premier chargement

## Tradeoffs
Bundle main chunk +18 kB gzip (78 → 97) — amorti dès la PR 2 quand les strings UI seront extraites. Accepté.

## Plan du chantier
- **PR 1 (celle-ci)** — infra + toggle
- **PR 2** — extraction strings UI → `fr.json` / `en.json`
- **PR 3** — contenu éditorial (formats, programs, exercices) + edge functions IA (param locale, colonne Supabase)
- **PR 4** — QA finale, check isomorphisme clés FR/EN, puis merge `develop → main`

Pendant ce chantier, `develop` ne part pas en prod.

## Test plan
- [x] `npm run lint` (biome) — OK
- [x] `npm run build` — OK
- [x] `npm test` — 315/315 OK
- [x] Validation Chrome : toggle visible à gauche de l'avatar, bascule FR↔EN met à jour `aria-pressed`, `<html lang>`, `localStorage`, persistance au reload
- [x] Review quality-engineer → WARNING adressés (commit 58e8358)

🤖 Generated with [Claude Code](https://claude.com/claude-code)