### PR TITLE
feat(i18n): content data + edge functions locale (PR 3/4)

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -6,17 +6,6 @@ import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import type { ExerciseCategory, ExerciseData } from '../types/exercise.ts';
 import { CATEGORY_ORDER, DIFFICULTY_COLORS } from '../types/exercise.ts';
 
-const FORMAT_SHORT_DESCS: Record<string, string> = {
-  pyramid: 'Séries croissantes puis décroissantes',
-  classic: 'Travail ciblé en séries classiques',
-  superset: 'Deux exercices enchaînés sans pause',
-  emom: 'Chaque minute, un effort à compléter',
-  circuit: "Rotation d'ateliers variés en boucle",
-  amrap: 'Maximum de tours dans le temps imparti',
-  hiit: 'Efforts explosifs, récupération courte',
-  tabata: '20s à fond, 10s de repos, sans répit',
-};
-
 function groupByCategory(exercises: ExerciseData[]): [ExerciseCategory, ExerciseData[]][] {
   const groups = new Map<ExerciseCategory, ExerciseData[]>();
   for (const ex of exercises) {
@@ -29,6 +18,8 @@ function groupByCategory(exercises: ExerciseData[]): [ExerciseCategory, Exercise
 
 export function Discover() {
   const { t } = useTranslation('explore');
+  const { t: td } = useTranslation('formats_data');
+  const { t: te } = useTranslation('exercises_data');
   useDocumentHead({
     title: t('discover.page_title'),
     description: t('discover.page_description'),
@@ -59,12 +50,10 @@ export function Discover() {
               className="glass-card rounded-xl p-4 flex flex-col gap-3 hover:border-divider-strong transition-colors"
             >
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-heading">{f.name}</h3>
+                <h3 className="text-sm font-bold text-heading">{td(`${f.slug}.name`)}</h3>
                 <span className="text-xs text-muted shrink-0">{f.duration} min</span>
               </div>
-              <p className="text-xs text-muted leading-relaxed flex-1">
-                {FORMAT_SHORT_DESCS[f.type] ?? f.shortDescription}
-              </p>
+              <p className="text-xs text-muted leading-relaxed flex-1">{td(`${f.slug}.shortDescription`)}</p>
               <div className="flex items-center gap-1">
                 {[1, 2, 3, 4, 5].map((i) => (
                   <div key={i} className={`intensity-dot ${i <= f.intensity ? 'active' : 'inactive'}`} />
@@ -87,25 +76,28 @@ export function Discover() {
           <div key={category} className="space-y-3">
             <h3 className="text-sm font-bold uppercase tracking-wider text-subtle">{t(`category.${category}`)}</h3>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-              {exercises.slice(0, 6).map((ex) => (
-                <Link
-                  key={ex.slug}
-                  to={`/exercices/${ex.slug}`}
-                  className="glass-card rounded-xl overflow-hidden group"
-                >
-                  <div className="relative h-24">
-                    <img src={ex.image} alt={ex.name} className="w-full h-full object-cover" loading="lazy" />
-                  </div>
-                  <div className="px-3 py-2 flex items-center justify-between">
-                    <span className="text-xs font-semibold text-heading truncate">{ex.name}</span>
-                    <span
-                      className={`text-xs font-bold px-1.5 py-0.5 rounded-full border shrink-0 ${DIFFICULTY_COLORS[ex.difficulty - 1]}`}
-                    >
-                      {t(`difficulty_level.${ex.difficulty}`)}
-                    </span>
-                  </div>
-                </Link>
-              ))}
+              {exercises.slice(0, 6).map((ex) => {
+                const exName = te(`${ex.slug}.name`);
+                return (
+                  <Link
+                    key={ex.slug}
+                    to={`/exercices/${ex.slug}`}
+                    className="glass-card rounded-xl overflow-hidden group"
+                  >
+                    <div className="relative h-24">
+                      <img src={ex.image} alt={exName} className="w-full h-full object-cover" loading="lazy" />
+                    </div>
+                    <div className="px-3 py-2 flex items-center justify-between">
+                      <span className="text-xs font-semibold text-heading truncate">{exName}</span>
+                      <span
+                        className={`text-xs font-bold px-1.5 py-0.5 rounded-full border shrink-0 ${DIFFICULTY_COLORS[ex.difficulty - 1]}`}
+                      >
+                        {t(`difficulty_level.${ex.difficulty}`)}
+                      </span>
+                    </div>
+                  </Link>
+                );
+              })}
             </div>
             {exercises.length > 6 && (
               <Link to="/exercices" className="text-xs text-link hover:text-link-hover transition-colors">

--- a/src/components/ExercisePage.tsx
+++ b/src/components/ExercisePage.tsx
@@ -10,15 +10,17 @@ import { ContentSection } from './ContentSection.tsx';
 
 export function ExercisePage() {
   const { t } = useTranslation('explore');
+  const { t: td } = useTranslation('exercises_data');
   const { slug } = useParams<{ slug: string }>();
   const { hash } = useLocation();
   const exercise = slug ? getExerciseBySlug(slug) : undefined;
 
+  const name = exercise ? td(`${exercise.slug}.name`) : '';
+  const shortDescription = exercise ? td(`${exercise.slug}.shortDescription`) : '';
+
   useDocumentHead({
-    title: exercise ? `${exercise.name} — Exercice` : 'Exercice',
-    description: exercise
-      ? `${exercise.name} : ${exercise.shortDescription} Exécution, variantes, conseils et erreurs courantes.`
-      : undefined,
+    title: exercise ? t('exercise_page.doc_title', { name }) : t('exercise_page.doc_title_fallback'),
+    description: exercise ? t('exercise_page.doc_description', { name, short: shortDescription }) : undefined,
   });
 
   // Scroll to variant anchor on mount
@@ -34,12 +36,20 @@ export function ExercisePage() {
     return <Navigate to="/exercices" replace />;
   }
 
+  const muscles = td(`${exercise.slug}.muscles`, { returnObjects: true }) as string[];
+  const execution = td(`${exercise.slug}.execution`);
+  const breathing = td(`${exercise.slug}.breathing`);
+  const benefits = td(`${exercise.slug}.benefits`, { returnObjects: true }) as string[];
+  const variants = td(`${exercise.slug}.variants`, { returnObjects: true }) as { name: string; description: string }[];
+  const tips = td(`${exercise.slug}.tips`, { returnObjects: true }) as string[];
+  const commonMistakes = td(`${exercise.slug}.commonMistakes`, { returnObjects: true }) as string[];
+
   return (
     <>
       {/* Hero */}
       <div className="relative">
         <div className="h-48 sm:h-56 overflow-hidden">
-          <img src={exercise.image} alt={exercise.name} className="w-full h-full object-cover" loading="eager" />
+          <img src={exercise.image} alt={name} className="w-full h-full object-cover" loading="eager" />
           <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/50 to-surface/20" />
         </div>
 
@@ -54,9 +64,7 @@ export function ExercisePage() {
         <div className="absolute bottom-4 left-5 right-5">
           <div className="flex items-end justify-between gap-3">
             <div>
-              <h1 className="font-display text-3xl font-black text-white drop-shadow-sm leading-tight">
-                {exercise.name}
-              </h1>
+              <h1 className="font-display text-3xl font-black text-white drop-shadow-sm leading-tight">{name}</h1>
               <p className="text-sm text-white/60 mt-1">{t(`category.${exercise.category}`)}</p>
             </div>
             <div className="flex items-center gap-2 shrink-0">
@@ -68,7 +76,7 @@ export function ExercisePage() {
 
       <div className="max-w-2xl mx-auto px-6 py-8 space-y-8">
         {/* Intro */}
-        <p className="text-base text-body leading-relaxed">{exercise.shortDescription}</p>
+        <p className="text-base text-body leading-relaxed">{shortDescription}</p>
 
         {/* Vidéo */}
         {exercise.video && (
@@ -78,14 +86,14 @@ export function ExercisePage() {
             muted
             playsInline
             preload="metadata"
-            aria-label={t('exercise_page.demo_aria', { name: exercise.name })}
+            aria-label={t('exercise_page.demo_aria', { name })}
             className="w-full rounded-xl"
           />
         )}
 
         {/* Muscles ciblés */}
         <div className="flex flex-wrap gap-2">
-          {exercise.muscles.map((m) => (
+          {muscles.map((m) => (
             <span
               key={m}
               className="px-3 py-1.5 rounded-full text-xs font-semibold bg-brand/10 text-link border border-brand/20"
@@ -100,7 +108,7 @@ export function ExercisePage() {
           title={t('exercise_page.section_execution')}
           icon={<Dumbbell className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
-          <p className="text-sm text-subtle leading-relaxed">{exercise.execution}</p>
+          <p className="text-sm text-subtle leading-relaxed">{execution}</p>
         </ContentSection>
 
         {/* Respiration */}
@@ -108,7 +116,7 @@ export function ExercisePage() {
           title={t('exercise_page.section_breathing')}
           icon={<Wind className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
-          <p className="text-sm text-subtle leading-relaxed">{exercise.breathing}</p>
+          <p className="text-sm text-subtle leading-relaxed">{breathing}</p>
         </ContentSection>
 
         {/* Bénéfices */}
@@ -117,7 +125,7 @@ export function ExercisePage() {
           icon={<CheckCircle className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {exercise.benefits.map((b, i) => (
+            {benefits.map((b, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-link shrink-0 mt-0.5">•</span>
                 <span>{b}</span>
@@ -132,27 +140,30 @@ export function ExercisePage() {
           icon={<GitBranch className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
           <div className="space-y-4">
-            {exercise.variants.map((v, i) => (
-              <div
-                key={i}
-                id={slugify(v.name)}
-                className="scroll-mt-24 target:ring-2 target:ring-brand/30 target:rounded-lg target:p-2 target:-m-2"
-              >
-                <h3 className="text-sm font-bold text-strong mb-1">{v.name}</h3>
-                <p className="text-sm text-subtle leading-relaxed">{v.description}</p>
-                {v.video && (
-                  <video
-                    src={`${v.video}#t=0.1`}
-                    controls
-                    muted
-                    playsInline
-                    preload="metadata"
-                    aria-label={t('exercise_page.demo_aria', { name: v.name })}
-                    className="w-full rounded-lg mt-2"
-                  />
-                )}
-              </div>
-            ))}
+            {variants.map((v, i) => {
+              const video = exercise.variantVideos?.[i];
+              return (
+                <div
+                  key={i}
+                  id={slugify(v.name)}
+                  className="scroll-mt-24 target:ring-2 target:ring-brand/30 target:rounded-lg target:p-2 target:-m-2"
+                >
+                  <h3 className="text-sm font-bold text-strong mb-1">{v.name}</h3>
+                  <p className="text-sm text-subtle leading-relaxed">{v.description}</p>
+                  {video && (
+                    <video
+                      src={`${video}#t=0.1`}
+                      controls
+                      muted
+                      playsInline
+                      preload="metadata"
+                      aria-label={t('exercise_page.demo_aria', { name: v.name })}
+                      className="w-full rounded-lg mt-2"
+                    />
+                  )}
+                </div>
+              );
+            })}
           </div>
         </ContentSection>
 
@@ -162,7 +173,7 @@ export function ExercisePage() {
           icon={<Lightbulb className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {exercise.tips.map((tip, i) => (
+            {tips.map((tip, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-emerald-400 shrink-0 mt-0.5">{i + 1}.</span>
                 <span>{tip}</span>
@@ -177,7 +188,7 @@ export function ExercisePage() {
           icon={<AlertTriangle className="w-4 h-4 text-amber-400" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {exercise.commonMistakes.map((m, i) => (
+            {commonMistakes.map((m, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-amber-400 shrink-0 mt-0.5">•</span>
                 <span>{m}</span>

--- a/src/components/Exercises.tsx
+++ b/src/components/Exercises.tsx
@@ -17,6 +17,7 @@ function groupByCategory(exercises: ExerciseData[]): [ExerciseCategory, Exercise
 
 export function Exercises() {
   const { t } = useTranslation('explore');
+  const { t: td } = useTranslation('exercises_data');
   useDocumentHead({
     title: t('exercises.page_title'),
     description: t('exercises.page_description'),
@@ -57,50 +58,59 @@ export function Exercises() {
           <section key={category}>
             <h2 className="text-xs font-bold uppercase tracking-wider text-muted mb-4">{t(`category.${category}`)}</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {exercises.map((ex) => (
-                <Link
-                  key={ex.slug}
-                  to={`/exercices/${ex.slug}`}
-                  className="format-card rounded-2xl overflow-hidden flex flex-col transition-transform hover:scale-[1.01]"
-                >
-                  {/* Image */}
-                  <div className="relative h-28 overflow-hidden">
-                    <img src={ex.image} alt={ex.name} className="w-full h-full object-cover" loading="lazy" />
-                    <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/40 to-transparent" />
-                    <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between">
-                      <h3 className="font-bold text-white text-base drop-shadow-sm">{ex.name}</h3>
-                      <span
-                        className={`text-xs font-bold px-2 py-0.5 rounded-full border shrink-0 ${DIFFICULTY_COLORS[ex.difficulty - 1]}`}
-                      >
-                        {t(`difficulty_level.${ex.difficulty}`)}
+              {exercises.map((ex) => {
+                const name = td(`${ex.slug}.name`);
+                const muscles = td(`${ex.slug}.muscles`, { returnObjects: true }) as string[];
+                const shortDescription = td(`${ex.slug}.shortDescription`);
+                const variants = td(`${ex.slug}.variants`, { returnObjects: true }) as {
+                  name: string;
+                  description: string;
+                }[];
+                return (
+                  <Link
+                    key={ex.slug}
+                    to={`/exercices/${ex.slug}`}
+                    className="format-card rounded-2xl overflow-hidden flex flex-col transition-transform hover:scale-[1.01]"
+                  >
+                    {/* Image */}
+                    <div className="relative h-28 overflow-hidden">
+                      <img src={ex.image} alt={name} className="w-full h-full object-cover" loading="lazy" />
+                      <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/40 to-transparent" />
+                      <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between">
+                        <h3 className="font-bold text-white text-base drop-shadow-sm">{name}</h3>
+                        <span
+                          className={`text-xs font-bold px-2 py-0.5 rounded-full border shrink-0 ${DIFFICULTY_COLORS[ex.difficulty - 1]}`}
+                        >
+                          {t(`difficulty_level.${ex.difficulty}`)}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Content */}
+                    <div className="p-4 flex-1 flex flex-col gap-3">
+                      <div className="flex flex-wrap gap-1.5">
+                        {muscles.slice(0, 3).map((m) => (
+                          <span
+                            key={m}
+                            className="px-2 py-0.5 rounded-full text-xs font-semibold bg-brand/10 text-link border border-brand/20"
+                          >
+                            {m}
+                          </span>
+                        ))}
+                        {muscles.length > 3 && (
+                          <span className="px-2 py-0.5 rounded-full text-xs font-semibold text-muted">
+                            +{muscles.length - 3}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[13px] text-subtle leading-relaxed flex-1 line-clamp-2">{shortDescription}</p>
+                      <span className="text-xs text-link font-medium">
+                        {t('exercises.variant', { n: variants.length, count: variants.length })}
                       </span>
                     </div>
-                  </div>
-
-                  {/* Content */}
-                  <div className="p-4 flex-1 flex flex-col gap-3">
-                    <div className="flex flex-wrap gap-1.5">
-                      {ex.muscles.slice(0, 3).map((m) => (
-                        <span
-                          key={m}
-                          className="px-2 py-0.5 rounded-full text-xs font-semibold bg-brand/10 text-link border border-brand/20"
-                        >
-                          {m}
-                        </span>
-                      ))}
-                      {ex.muscles.length > 3 && (
-                        <span className="px-2 py-0.5 rounded-full text-xs font-semibold text-muted">
-                          +{ex.muscles.length - 3}
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-[13px] text-subtle leading-relaxed flex-1 line-clamp-2">{ex.shortDescription}</p>
-                    <span className="text-xs text-link font-medium">
-                      {t('exercises.variant', { n: ex.variants.length, count: ex.variants.length })}
-                    </span>
-                  </div>
-                </Link>
-              ))}
+                  </Link>
+                );
+              })}
             </div>
           </section>
         ))}

--- a/src/components/FormatPage.tsx
+++ b/src/components/FormatPage.tsx
@@ -7,19 +7,29 @@ import { ContentSection } from './ContentSection.tsx';
 
 export function FormatPage() {
   const { t } = useTranslation('explore');
+  const { t: td } = useTranslation('formats_data');
   const { slug } = useParams<{ slug: string }>();
   const format = slug ? getFormatBySlug(slug) : undefined;
 
   useDocumentHead({
-    title: format ? `${format.name} — Format d'entraînement` : 'Format',
+    title: format
+      ? t('format_page_meta.doc_title', { name: td(`${format.slug}.name`) })
+      : t('format_page_meta.doc_title_fallback'),
     description: format
-      ? `${format.name} : ${format.shortDescription} Découvrez le principe, le protocole, les bénéfices et les conseils pour ce format d'entraînement sans matériel.`
+      ? t('format_page_meta.doc_description', {
+          name: td(`${format.slug}.name`),
+          short: td(`${format.slug}.shortDescription`),
+        })
       : undefined,
   });
 
   if (!format) {
     return <Navigate to="/formats" replace />;
   }
+
+  const benefits = td(`${format.slug}.benefits`, { returnObjects: true }) as string[];
+  const tips = td(`${format.slug}.tips`, { returnObjects: true }) as string[];
+  const commonMistakes = td(`${format.slug}.commonMistakes`, { returnObjects: true }) as string[];
 
   return (
     <>
@@ -28,7 +38,7 @@ export function FormatPage() {
         <div className="h-48 sm:h-56 overflow-hidden">
           <img
             src={format.image}
-            alt={t('format_page.img_alt', { name: format.name })}
+            alt={t('format_page.img_alt', { name: td(`${format.slug}.name`) })}
             className="w-full h-full object-cover object-[50%_30%]"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/50 to-surface/20" />
@@ -46,9 +56,9 @@ export function FormatPage() {
           <div className="flex items-end justify-between gap-3">
             <div>
               <h1 className="font-display text-3xl font-black text-white drop-shadow-sm leading-tight">
-                {format.name}
+                {td(`${format.slug}.name`)}
               </h1>
-              <p className="text-sm text-white/60 mt-1">{format.subtitle}</p>
+              <p className="text-sm text-white/60 mt-1">{td(`${format.slug}.subtitle`)}</p>
             </div>
             <div className="flex items-center gap-3 shrink-0">
               <span className="text-xs font-bold text-white bg-white/15 backdrop-blur-sm px-2.5 py-1 rounded-full">
@@ -70,14 +80,14 @@ export function FormatPage() {
 
       <div className="max-w-2xl mx-auto px-6 py-8 space-y-8">
         {/* Intro */}
-        <p className="text-base text-body leading-relaxed">{format.shortDescription}</p>
+        <p className="text-base text-body leading-relaxed">{td(`${format.slug}.shortDescription`)}</p>
 
         {/* Principe */}
         <ContentSection
           title={t('format_page.section_principle')}
           icon={<Lightbulb className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
-          <p className="text-sm text-subtle leading-relaxed">{format.principle}</p>
+          <p className="text-sm text-subtle leading-relaxed">{td(`${format.slug}.principle`)}</p>
         </ContentSection>
 
         {/* Protocole */}
@@ -85,7 +95,7 @@ export function FormatPage() {
           title={t('format_page.section_protocol')}
           icon={<Clock className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
-          <p className="text-sm text-subtle leading-relaxed">{format.protocol}</p>
+          <p className="text-sm text-subtle leading-relaxed">{td(`${format.slug}.protocol`)}</p>
         </ContentSection>
 
         {/* Bénéfices */}
@@ -94,7 +104,7 @@ export function FormatPage() {
           icon={<CheckCircle className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {format.benefits.map((b, i) => (
+            {benefits.map((b, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-link shrink-0 mt-0.5">•</span>
                 <span>{b}</span>
@@ -108,7 +118,7 @@ export function FormatPage() {
           title={t('format_page.section_audience')}
           icon={<Users className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
-          <p className="text-sm text-subtle leading-relaxed">{format.targetAudience}</p>
+          <p className="text-sm text-subtle leading-relaxed">{td(`${format.slug}.targetAudience`)}</p>
         </ContentSection>
 
         {/* Conseils */}
@@ -117,7 +127,7 @@ export function FormatPage() {
           icon={<Lightbulb className="w-4 h-4 text-brand" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {format.tips.map((tip, i) => (
+            {tips.map((tip, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-emerald-400 shrink-0 mt-0.5">{i + 1}.</span>
                 <span>{tip}</span>
@@ -132,7 +142,7 @@ export function FormatPage() {
           icon={<AlertTriangle className="w-4 h-4 text-amber-400" aria-hidden="true" />}
         >
           <ul className="space-y-2">
-            {format.commonMistakes.map((m, i) => (
+            {commonMistakes.map((m, i) => (
               <li key={i} className="flex gap-3 text-sm text-subtle leading-relaxed">
                 <span className="text-amber-400 shrink-0 mt-0.5">•</span>
                 <span>{m}</span>

--- a/src/components/Formats.tsx
+++ b/src/components/Formats.tsx
@@ -4,46 +4,9 @@ import { Link } from 'react-router';
 import { FORMATS_DATA } from '../data/formats.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 
-const FORMAT_DESCRIPTIONS: Record<string, { description: string; benefit: string }> = {
-  pyramid: {
-    description:
-      "Les répétitions augmentent à chaque palier (2, 4, 6, 8…) puis redescendent. L'intensité monte puis diminue naturellement.",
-    benefit: "Auto-régulé : l'échauffement est intégré dans la montée.",
-  },
-  classic: {
-    description:
-      'Des exercices ciblés en séries avec des temps de repos. Haut du corps (push & pull) ou bas du corps & core.',
-    benefit: 'Tonification ciblée. Progression claire et mesurable.',
-  },
-  superset: {
-    description:
-      'Deux exercices complémentaires enchaînés sans repos (ex : pompes puis tirage). Repos entre les paires.',
-    benefit: 'Travail équilibré et efficace en moins de temps.',
-  },
-  emom: {
-    description: 'À chaque début de minute, réaliser un nombre défini de répétitions. Le temps restant = repos.',
-    benefit: "Développe l'endurance et apprend à gérer son effort.",
-  },
-  circuit: {
-    description: "Enchaînement d'exercices variés avec très peu de repos. On répète le circuit plusieurs fois.",
-    benefit: 'Combine renforcement et cardio pour un travail complet.',
-  },
-  amrap: {
-    description: 'Enchaîner un circuit le plus de fois possible dans un temps imparti. Tu gères ton rythme.',
-    benefit: 'Liberté de rythme. Idéal pour mesurer sa progression.',
-  },
-  hiit: {
-    description: "Alternance d'effort intense (30s) et de repos (30s). Chaque exercice est réalisé à fond.",
-    benefit: 'Maximum de résultats en minimum de temps.',
-  },
-  tabata: {
-    description: "8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Court mais intense.",
-    benefit: 'Le format le plus court et le plus intense.',
-  },
-};
-
 export function Formats() {
   const { t } = useTranslation('explore');
+  const { t: td } = useTranslation('formats_data');
   useDocumentHead({
     title: t('formats.page_title'),
     description: t('formats.page_description'),
@@ -72,55 +35,52 @@ export function Formats() {
         />
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {FORMATS_DATA.map((format) => {
-            const extra = FORMAT_DESCRIPTIONS[format.type];
-            return (
-              <Link
-                key={format.type}
-                to={`/formats/${format.slug}`}
-                className="format-card rounded-2xl overflow-hidden flex flex-col transition-transform hover:scale-[1.01]"
-              >
-                {/* Image — text stays white (over image) */}
-                <div className="relative h-28 overflow-hidden">
-                  <img
-                    src={format.image}
-                    alt={t('formats.img_alt', { name: format.name })}
-                    className="w-full h-full object-cover object-[50%_30%]"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/40 to-transparent" />
-                  <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between">
-                    <div>
-                      <h2 className="font-bold text-white text-base drop-shadow-sm">{format.name}</h2>
-                      <p className="text-xs text-white/60">{format.subtitle}</p>
-                    </div>
-                    <span className="text-xs font-bold text-white bg-white/15 backdrop-blur-sm px-2.5 py-1 rounded-full shrink-0">
-                      {format.duration} min
-                    </span>
+          {FORMATS_DATA.map((format) => (
+            <Link
+              key={format.type}
+              to={`/formats/${format.slug}`}
+              className="format-card rounded-2xl overflow-hidden flex flex-col transition-transform hover:scale-[1.01]"
+            >
+              {/* Image — text stays white (over image) */}
+              <div className="relative h-28 overflow-hidden">
+                <img
+                  src={format.image}
+                  alt={t('formats.img_alt', { name: td(`${format.slug}.name`) })}
+                  className="w-full h-full object-cover object-[50%_30%]"
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/40 to-transparent" />
+                <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between">
+                  <div>
+                    <h2 className="font-bold text-white text-base drop-shadow-sm">{td(`${format.slug}.name`)}</h2>
+                    <p className="text-xs text-white/60">{td(`${format.slug}.subtitle`)}</p>
                   </div>
+                  <span className="text-xs font-bold text-white bg-white/15 backdrop-blur-sm px-2.5 py-1 rounded-full shrink-0">
+                    {format.duration} min
+                  </span>
+                </div>
+              </div>
+
+              {/* Content (below image) */}
+              <div className="p-4 flex-1 flex flex-col gap-3">
+                {/* Intensity dots */}
+                <div
+                  className="flex items-center gap-1.5"
+                  role="img"
+                  aria-label={t('formats.intensity_aria', { n: format.intensity })}
+                >
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <div key={i} className={`intensity-dot ${i <= format.intensity ? 'active' : 'inactive'}`} />
+                  ))}
                 </div>
 
-                {/* Content (below image) */}
-                <div className="p-4 flex-1 flex flex-col gap-3">
-                  {/* Intensity dots */}
-                  <div
-                    className="flex items-center gap-1.5"
-                    role="img"
-                    aria-label={t('formats.intensity_aria', { n: format.intensity })}
-                  >
-                    {[1, 2, 3, 4, 5].map((i) => (
-                      <div key={i} className={`intensity-dot ${i <= format.intensity ? 'active' : 'inactive'}`} />
-                    ))}
-                  </div>
+                <p className="text-[13px] text-subtle leading-relaxed flex-1">
+                  {td(`${format.slug}.card_description`)}
+                </p>
 
-                  <p className="text-[13px] text-subtle leading-relaxed flex-1">
-                    {extra?.description ?? format.shortDescription}
-                  </p>
-
-                  <p className="text-xs text-link font-medium leading-relaxed">{extra?.benefit}</p>
-                </div>
-              </Link>
-            );
-          })}
+                <p className="text-xs text-link font-medium leading-relaxed">{td(`${format.slug}.card_benefit`)}</p>
+              </div>
+            </Link>
+          ))}
         </div>
 
         <p className="text-xs text-faint text-center leading-relaxed">{t('formats.footer_note')}</p>

--- a/src/components/ProgramContentPage.tsx
+++ b/src/components/ProgramContentPage.tsx
@@ -51,7 +51,11 @@ export function ProgramContentPage() {
       {/* Hero */}
       <div className="relative">
         <div className="h-56 sm:h-72 md:h-80 overflow-hidden">
-          <img src={image} alt={`Programme ${headline}`} className="w-full h-full object-cover object-[50%_30%]" />
+          <img
+            src={image}
+            alt={t('content.img_alt', { headline })}
+            className="w-full h-full object-cover object-[50%_30%]"
+          />
           <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/60 to-surface/20" />
         </div>
 

--- a/src/components/ProgramContentPage.tsx
+++ b/src/components/ProgramContentPage.tsx
@@ -2,40 +2,56 @@ import { ArrowRight, Calendar, ChevronLeft, Clock, Repeat, Target } from 'lucide
 import { useTranslation } from 'react-i18next';
 import { Link, Navigate, useParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
-import { PROGRAM_CONTENT } from '../data/programContent.ts';
+import { PROGRAM_CONTENT_META } from '../data/programContent.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { getProgramImage } from '../utils/programImage.ts';
 
 export function ProgramContentPage() {
   const { t } = useTranslation('programs');
+  const { t: tData } = useTranslation('programs_data');
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
-  const content = slug ? PROGRAM_CONTENT[slug] : undefined;
+  const meta = slug ? PROGRAM_CONTENT_META[slug] : undefined;
+
+  const headline = slug ? tData(`${slug}.headline`) : undefined;
+  const intro = slug ? tData(`${slug}.intro`) : undefined;
 
   useDocumentHead({
-    title: content ? `${content.headline} ${t('page.title_suffix')}` : t('page.title_suffix'),
-    description: content?.intro,
+    title: headline ? `${headline} ${t('page.title_suffix')}` : t('page.title_suffix'),
+    description: intro,
   });
 
   if (!slug) return <Navigate to="/programmes" replace />;
 
   // Custom/AI programs have no editorial content — go straight to suivi
-  if (!content) return <Navigate to={`/programme/${slug}/suivi`} replace />;
+  if (!meta) return <Navigate to={`/programme/${slug}/suivi`} replace />;
 
   const image = getProgramImage(slug);
   const ctaTo = user ? `/programme/${slug}/suivi` : '/signup';
   const ctaLabel = user ? t('content.cta_start') : t('content.cta_signup');
+
+  const audience = tData(`${slug}.audience`);
+  const duration = tData(`${slug}.duration`);
+  const frequency = tData(`${slug}.frequency`);
+  const sessionLength = tData(`${slug}.sessionLength`);
+  const approach = tData(`${slug}.approach`);
+  const tip = tData(`${slug}.tip`);
+  const benefits = tData(`${slug}.benefits`, { returnObjects: true }) as string[];
+  const weeksData = tData(`${slug}.weeks`, { returnObjects: true }) as { title: string; description: string }[];
+
+  // Merge translated text with structural metadata (week number + formats)
+  const weeks = weeksData.map((w, i) => ({
+    ...w,
+    week: meta.weeks[i]?.week ?? i + 1,
+    formats: meta.weeks[i]?.formats ?? [],
+  }));
 
   return (
     <div className="min-h-screen">
       {/* Hero */}
       <div className="relative">
         <div className="h-56 sm:h-72 md:h-80 overflow-hidden">
-          <img
-            src={image}
-            alt={`Programme ${content.headline}`}
-            className="w-full h-full object-cover object-[50%_30%]"
-          />
+          <img src={image} alt={`Programme ${headline}`} className="w-full h-full object-cover object-[50%_30%]" />
           <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/60 to-surface/20" />
         </div>
 
@@ -49,24 +65,22 @@ export function ProgramContentPage() {
 
         <div className="absolute bottom-0 left-0 right-0 px-6 pb-6 md:px-10">
           <div className="max-w-3xl mx-auto">
-            <h1 className="font-display text-3xl md:text-4xl font-black text-white drop-shadow-md">
-              {content.headline}
-            </h1>
+            <h1 className="font-display text-3xl md:text-4xl font-black text-white drop-shadow-md">{headline}</h1>
           </div>
         </div>
       </div>
 
       <div className="max-w-3xl mx-auto px-6 md:px-10 py-8 space-y-10">
         {/* Intro */}
-        <p className="text-lg text-body leading-relaxed">{content.intro}</p>
+        <p className="text-lg text-body leading-relaxed">{intro}</p>
 
         {/* Key stats */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {[
-            { icon: Calendar, label: t('content.stat_duration'), value: content.duration },
-            { icon: Repeat, label: t('content.stat_frequency'), value: content.frequency },
-            { icon: Clock, label: t('content.stat_session_length'), value: content.sessionLength },
-            { icon: Target, label: t('content.stat_audience'), value: content.audience.split(',')[0].trim() },
+            { icon: Calendar, label: t('content.stat_duration'), value: duration },
+            { icon: Repeat, label: t('content.stat_frequency'), value: frequency },
+            { icon: Clock, label: t('content.stat_session_length'), value: sessionLength },
+            { icon: Target, label: t('content.stat_audience'), value: audience.split(',')[0].trim() },
           ].map((stat) => (
             <div key={stat.label} className="rounded-xl border border-card-border bg-surface-card p-4 space-y-2">
               <stat.icon className="w-5 h-5 text-brand" aria-hidden="true" />
@@ -95,20 +109,20 @@ export function ProgramContentPage() {
         {/* Approach */}
         <section className="space-y-3">
           <h2 className="font-display text-xl font-bold text-heading">{t('content.approach')}</h2>
-          <p className="text-body leading-relaxed">{content.approach}</p>
+          <p className="text-body leading-relaxed">{approach}</p>
         </section>
 
         {/* Public cible */}
         <section className="space-y-3">
           <h2 className="font-display text-xl font-bold text-heading">{t('content.for_who')}</h2>
-          <p className="text-body leading-relaxed">{content.audience}</p>
+          <p className="text-body leading-relaxed">{audience}</p>
         </section>
 
         {/* Week by week */}
         <section className="space-y-4">
           <h2 className="font-display text-xl font-bold text-heading">{t('content.week_by_week')}</h2>
           <div className="space-y-3">
-            {content.weeks.map((week) => (
+            {weeks.map((week) => (
               <div key={week.week} className="rounded-xl border border-card-border bg-surface-card p-5 space-y-2">
                 <div className="flex items-center gap-3">
                   <span className="flex items-center justify-center w-8 h-8 rounded-full bg-brand/10 text-brand text-sm font-bold shrink-0">
@@ -133,7 +147,7 @@ export function ProgramContentPage() {
         <section className="space-y-3">
           <h2 className="font-display text-xl font-bold text-heading">{t('content.benefits')}</h2>
           <ul className="space-y-2">
-            {content.benefits.map((b) => (
+            {benefits.map((b) => (
               <li key={b} className="flex items-start gap-3">
                 <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0 mt-2" />
                 <span className="text-body leading-relaxed">{b}</span>
@@ -145,7 +159,7 @@ export function ProgramContentPage() {
         {/* Tip */}
         <section className="rounded-xl border border-accent/20 bg-accent/5 p-5 space-y-2">
           <h3 className="font-bold text-heading">{t('content.tip')}</h3>
-          <p className="text-sm text-body leading-relaxed">{content.tip}</p>
+          <p className="text-sm text-body leading-relaxed">{tip}</p>
         </section>
 
         {/* Cross-links */}

--- a/src/data/exercises.ts
+++ b/src/data/exercises.ts
@@ -4,1277 +4,190 @@ export const EXERCISES_DATA: ExerciseData[] = [
   // ─── Haut du corps ──────────────────────────────────────────────
   {
     slug: 'pompes-classiques',
-    name: 'Pompes classiques',
-    aliases: ['Pompes', 'Push-ups', 'Scapular push-ups', 'Pompes pike'],
     category: 'upper',
-    muscles: ['Pectoraux', 'Triceps', 'Deltoïdes antérieurs', 'Core (stabilisation)'],
     difficulty: 2,
     image: '/images/upper.webp',
     video: '/videos/pompes-classiques.mp4',
-    shortDescription:
-      "L'exercice fondamental du haut du corps au poids du corps. Les pompes développent la poussée horizontale en sollicitant pectoraux, triceps et épaules dans un mouvement complet et fonctionnel.",
-    execution:
-      "Position de départ : mains au sol légèrement plus larges que les épaules, bras tendus, corps aligné de la tête aux talons. Les pieds sont serrés ou légèrement écartés. Descendez en fléchissant les coudes jusqu'à ce que la poitrine frôle le sol (coudes à environ 45° du corps, pas écartés à 90°). Poussez pour revenir à la position initiale en verrouillant les bras. Le corps reste gainé tout au long du mouvement : pas de creux dans le dos, pas de fesses en l'air.",
-    breathing:
-      "Inspirez pendant la descente, expirez pendant la poussée. Ne bloquez jamais votre respiration, même quand l'effort devient intense.",
-    benefits: [
-      "Renforce l'ensemble de la chaîne de poussée (pectoraux, triceps, épaules)",
-      'Travaille le gainage du tronc en position de planche dynamique',
-      'Ne nécessite aucun matériel et se pratique partout',
-      'Transfert direct vers les mouvements du quotidien (se relever, pousser une porte)',
-      'Des dizaines de variantes permettent de progresser indéfiniment',
-    ],
-    variants: [
-      {
-        name: 'Pompes inclinées',
-        description:
-          "Mains sur un support surélevé (chaise, marche). Réduit la charge et facilite le mouvement — idéal pour débuter ou en fin de série quand la fatigue s'installe.",
-      },
-      {
-        name: 'Pompes diamant',
-        description:
-          'Mains rapprochées sous la poitrine, pouces et index formant un losange. Augmente le travail des triceps et de la partie interne des pectoraux.',
-      },
-      {
-        name: 'Pompes déclinées',
-        description:
-          'Pieds surélevés sur un support. Augmente la charge sur les épaules et la partie haute des pectoraux. Réservé aux pratiquants qui maîtrisent les pompes classiques.',
-        video: '/videos/pompes-declinees.mp4',
-      },
-      {
-        name: 'Pompes explosives',
-        description:
-          'Poussée suffisamment puissante pour que les mains décollent du sol. Développe la puissance et la vitesse de contraction musculaire.',
-      },
-      {
-        name: 'Pompes archer',
-        description:
-          "Un bras tendu sur le côté, l'autre bras effectue l'essentiel de la poussée. Développe la force unilatérale et prépare progressivement aux pompes à un bras.",
-      },
-      {
-        name: 'Pompes commando',
-        description:
-          "Départ en planche sur les avant-bras, montée en planche bras tendus un bras après l'autre, puis redescente. Travaille la force de transition et la stabilité du tronc sous effort asymétrique.",
-      },
-      {
-        name: 'Pompes Hindu',
-        description:
-          "Départ en position du chien tête en bas, le corps plonge vers l'avant en rasant le sol puis remonte en cobra. Mouvement dynamique qui combine souplesse, force et mobilité de la colonne.",
-        video: '/videos/pompes-hindu.mp4',
-      },
-      {
-        name: 'Pompes larges',
-        description:
-          "Mains placées nettement plus larges que les épaules. Augmente le recrutement des pectoraux et réduit l'implication des triceps — idéal pour cibler la poitrine au poids du corps.",
-        video: '/videos/pompes-larges.mp4',
-      },
-      {
-        name: 'Pike push-ups',
-        description:
-          'Hanches hautes en V inversé, poussée verticale vers le sol. Cible les épaules de manière similaire à un développé militaire — excellente progression vers le handstand push-up.',
-      },
-      {
-        name: 'Pompes scapulaires',
-        description:
-          'En position de planche bras tendus, seules les omoplates bougent (protraction et rétraction) sans fléchir les coudes. Renforce le dentelé antérieur et améliore la stabilité scapulaire.',
-        video: '/videos/scapular-push-ups.mp4',
-      },
-    ],
-    tips: [
-      'Gardez les coudes à 45° du corps (ni collés, ni écartés à 90°) pour protéger les épaules',
-      'Serrez les abdos et les fessiers comme si vous teniez une planche — le corps ne doit pas "casser"',
-      "Descendez jusqu'en bas : les demi-pompes ne comptent pas et limitent la progression",
-      "Si vous n'arrivez pas à faire une pompe complète, commencez par les pompes inclinées plutôt que sur les genoux",
-    ],
-    commonMistakes: [
-      "Le bassin qui s'affaisse (dos creux) — signe d'un gainage insuffisant. Contractez les abdos.",
-      'Les fesses qui montent en pic — raccourcit le mouvement et supprime le travail des pectoraux',
-      "Les coudes qui s'écartent à 90° — crée un stress excessif sur l'articulation de l'épaule",
-      "L'amplitude incomplète — ne pas descendre assez bas limite les gains de force et de mobilité",
-      'La tête qui tombe vers le sol — gardez le regard vers le sol, à 30 cm devant vos mains, nuque neutre',
-    ],
+    variantVideos: {
+      2: '/videos/pompes-declinees.mp4',
+      6: '/videos/pompes-hindu.mp4',
+      7: '/videos/pompes-larges.mp4',
+      9: '/videos/scapular-push-ups.mp4',
+    },
   },
   {
     slug: 'dips-sur-chaise',
-    name: 'Dips sur chaise',
-    aliases: ['Dips', 'Triceps dips'],
     category: 'upper',
-    muscles: ['Triceps', 'Deltoïdes antérieurs', 'Pectoraux (partie basse)'],
     difficulty: 2,
     image: '/images/upper.webp',
     video: '/videos/dips-sur-chaise.mp4',
-    shortDescription:
-      "Un exercice de poussée verticale qui cible les triceps en utilisant une chaise ou un support stable. Les dips sur chaise sont l'un des meilleurs mouvements au poids du corps pour sculpter l'arrière des bras et renforcer la poussée.",
-    execution:
-      "Asseyez-vous au bord d'une chaise ou d'un banc stable, mains agrippées au rebord de chaque côté des hanches, doigts vers l'avant. Avancez les pieds pour décoller les fesses du support, bras tendus. Descendez en fléchissant les coudes vers l'arrière (pas vers l'extérieur) jusqu'à ce que vos bras forment un angle d'environ 90°. Poussez dans vos paumes pour remonter en verrouillant les bras en haut. Gardez le dos proche du support tout au long du mouvement — ne vous éloignez pas de la chaise. Les épaules restent basses et en arrière, loin des oreilles.",
-    breathing:
-      'Inspirez pendant la descente en contrôlant le mouvement. Expirez en poussant pour remonter. Ne bloquez pas votre respiration en position basse.',
-    benefits: [
-      'Isole efficacement les triceps avec un mouvement naturel de poussée',
-      'Renforce les deltoïdes antérieurs et la partie basse des pectoraux',
-      "Ne nécessite qu'une chaise, un banc ou une marche — praticable partout",
-      'Développe la force de poussée verticale utile au quotidien',
-      'Intensité facilement modulable en ajustant la position des pieds',
-    ],
-    variants: [],
-    tips: [
-      'Utilisez un support parfaitement stable — une chaise qui glisse peut provoquer une chute',
-      "Gardez les coudes serrés et dirigés vers l'arrière, jamais vers l'extérieur",
-      'Pour faciliter le mouvement, rapprochez les pieds du support en fléchissant les genoux',
-      'Pour augmenter la difficulté, tendez les jambes ou surélevez les pieds sur un second support',
-    ],
-    commonMistakes: [
-      "Les coudes qui s'écartent vers l'extérieur — gardez-les serrés et dirigés vers l'arrière pour protéger les épaules",
-      "Descendre trop bas (au-delà de 90°) — crée un stress excessif sur l'articulation de l'épaule",
-      "Les épaules qui montent vers les oreilles — tirez les omoplates vers le bas et l'arrière",
-      "Le dos qui s'éloigne de la chaise — restez proche du support pour maintenir le travail sur les triceps",
-      'Pousser avec les jambes au lieu des bras — les pieds sont un appui, pas le moteur du mouvement',
-    ],
   },
   {
     slug: 'rowing-inverse',
-    name: 'Rowing inverse (table)',
-    aliases: ['Rowing inverse', 'Inverted row'],
     category: 'upper',
-    muscles: ['Dorsaux', 'Rhomboïdes', 'Trapèzes', 'Biceps', 'Deltoïdes postérieurs'],
     difficulty: 2,
     image: '/images/upper.webp',
-    shortDescription:
-      "Le pendant inversé des pompes pour le haut du dos. Le rowing inverse sous une table ou une barre basse permet de travailler la traction horizontale au poids du corps en ciblant les dorsaux, les rhomboïdes et les biceps. Un exercice fondamental pour l'équilibre postural.",
-    execution:
-      "Allongez-vous sous une table solide (ou une barre basse) et saisissez le bord de la table avec les mains à largeur d'épaules, paumes vers vous ou en prise neutre. Le corps est aligné de la tête aux talons, bras tendus, talons au sol. En gardant le corps parfaitement gainé, tirez votre poitrine vers la table en serrant les omoplates l'une vers l'autre. Les coudes passent le long du corps (pas écartés). Montez jusqu'à ce que la poitrine touche ou s'approche de la table, marquez un temps d'arrêt en haut en contractant le haut du dos, puis redescendez lentement jusqu'à l'extension complète des bras.",
-    breathing:
-      "Expirez en tirant la poitrine vers la table, inspirez en redescendant de manière contrôlée. Gardez les abdominaux engagés pour maintenir l'alignement du corps pendant toute la série.",
-    benefits: [
-      "Renforce l'ensemble de la chaîne de traction : dorsaux, rhomboïdes, trapèzes et biceps",
-      'Corrige les déséquilibres posturaux en ciblant les muscles du haut du dos souvent négligés',
-      'Prépare aux tractions classiques en développant la force de traction horizontale',
-      'Améliore la rétraction scapulaire, essentielle pour la santé des épaules',
-      "Ne nécessite qu'une table solide ou une barre basse — réalisable à la maison",
-    ],
-    variants: [
-      {
-        name: 'Face pulls au sol',
-        description:
-          "Allongé sur le ventre, bras tendus devant vous, tirez les coudes vers l'arrière en serrant les omoplates. Isole le travail des rhomboïdes et des deltoïdes postérieurs sans aucun matériel. Excellent pour la posture et l'activation du haut du dos.",
-        video: '/videos/face-pulls-au-sol.mp4',
-      },
-    ],
-    tips: [
-      'Choisissez une table bien stable et solide — testez-la avant de vous suspendre dessous',
-      'Serrez les omoplates en haut du mouvement et maintenez la contraction une seconde avant de redescendre',
-      "Plus vos pieds sont avancés (corps horizontal), plus l'exercice est difficile — ajustez en reculant les pieds pour réduire la charge",
-      'Gardez le corps rigide comme une planche : les fessiers et les abdos restent contractés tout au long du mouvement',
-    ],
-    commonMistakes: [
-      "Le bassin qui s'affaisse — le corps doit rester aligné comme en planche. Contractez les fessiers et les abdominaux.",
-      'Les épaules qui montent vers les oreilles en tirant — abaissez les épaules et focalisez-vous sur le rapprochement des omoplates',
-      "L'amplitude incomplète — descendez bras tendus et montez poitrine contre la table. Les demi-répétitions ne comptent pas.",
-      "Les coudes qui s'écartent à 90° du corps — gardez-les à 45° maximum pour protéger les épaules et cibler les bons muscles",
-      "Utiliser l'élan en balançant les hanches — le mouvement doit être lent et contrôlé, seuls les bras et le dos travaillent",
-    ],
+    variantVideos: {
+      0: '/videos/face-pulls-au-sol.mp4',
+    },
   },
 
   // ─── Bas du corps ───────────────────────────────────────────────
   {
     slug: 'squats',
-    name: 'Squats',
-    aliases: ['Squat', 'Flexion de jambes', 'Jump squats', 'Speed squats'],
     category: 'lower',
-    muscles: ['Quadriceps', 'Fessiers', 'Ischio-jambiers', 'Core (stabilisation)'],
     difficulty: 1,
     image: '/images/explosive.webp',
-    shortDescription:
-      "Le mouvement roi du bas du corps. Le squat est un patron moteur fondamental qui sollicite l'ensemble de la chaîne inférieure : cuisses, fessiers et tronc. C'est le mouvement que vous faites chaque fois que vous vous asseyez et vous relevez.",
-    execution:
-      "Debout, pieds écartés à largeur d'épaules ou légèrement plus, pointes de pieds tournées vers l'extérieur (15-30°). Initiez le mouvement en poussant les hanches vers l'arrière comme pour vous asseoir sur une chaise. Descendez en gardant le poids sur les talons et le milieu du pied, genoux alignés avec les pointes de pieds. Descendez au moins jusqu'à ce que les cuisses soient parallèles au sol (ou plus bas si votre mobilité le permet). Poussez dans le sol pour remonter en contractant les fessiers en haut du mouvement.",
-    breathing:
-      'Inspirez profondément pendant la descente (le ventre se gonfle), expirez puissamment pendant la remontée. Sur les séries lourdes ou intenses, prenez une inspiration avant de descendre et expirez en passant le point le plus difficile de la remontée.',
-    benefits: [
-      "Renforce l'ensemble du bas du corps : quadriceps, fessiers, ischio-jambiers",
-      'Améliore la mobilité des hanches, genoux et chevilles',
-      "Mouvement fonctionnel essentiel : s'asseoir, se relever, porter des charges",
-      'Sollicite fortement le gainage du tronc pour maintenir le dos droit',
-      'Stimule une réponse hormonale importante grâce à la masse musculaire engagée',
-    ],
-    variants: [
-      {
-        name: 'Squats sumo',
-        description:
-          "Pieds très écartés, pointes vers l'extérieur. Cible davantage les adducteurs (intérieur des cuisses) et les fessiers. Plus facile en termes de mobilité de cheville.",
-      },
-      {
-        name: 'Squats pulse',
-        description:
-          'Rester dans la partie basse du squat et effectuer de petits mouvements de rebond. Augmente le temps sous tension et brûle les quadriceps.',
-      },
-      {
-        name: 'Squats sautés',
-        description:
-          'Ajouter un saut explosif à la remontée. Développe la puissance et le cardio. Réservé aux pratiquants sans problèmes articulaires aux genoux.',
-      },
-      {
-        name: 'Pistol squat assisté',
-        description:
-          "Squat sur une jambe en se tenant à un support. Travaille l'équilibre, la force unilatérale et la mobilité. Objectif avancé à construire progressivement.",
-      },
-      {
-        name: 'Squats 1.5',
-        description:
-          'Descente complète, remontée à mi-chemin, redescente, puis remontée complète — ça compte pour une seule répétition. Augmente considérablement le temps sous tension dans la partie basse du mouvement.',
-        video: '/videos/squats-1-5.mp4',
-      },
-      {
-        name: 'Pop squats',
-        description:
-          'Sautez pour écarter les pieds en squat large, puis sautez pour les ramener serrés. Combine travail cardio et renforcement des jambes dans un mouvement dynamique et rythmé.',
-      },
-      {
-        name: 'Goblet squat (sans poids)',
-        description:
-          'Mains jointes devant la poitrine, coudes poussés entre les genoux en bas du mouvement. Aide à maintenir le buste droit et à gagner en profondeur de squat — excellent outil de correction technique.',
-      },
-      {
-        name: 'Sissy squat',
-        description:
-          "Penchez le buste en arrière, poussez les genoux vers l'avant, talons décollés. Isole intensément les quadriceps. Mouvement avancé qui demande un bon équilibre et des genoux en bonne santé.",
-      },
-      {
-        name: 'Wall sit',
-        description:
-          "Dos plaqué contre un mur, cuisses parallèles au sol, maintien en isométrie. Défi d'endurance pure pour les quadriceps — simple en apparence, redoutable après 30 secondes.",
-      },
-    ],
-    tips: [
-      "Poussez les genoux vers l'extérieur pendant la descente — ils ne doivent jamais rentrer vers l'intérieur",
-      'Gardez le poids sur les talons : vous devez pouvoir remuer les orteils à tout moment',
-      'Le dos reste droit et la poitrine ouverte. Imaginez que vous portez un logo sur le torse et que tout le monde doit le voir',
-      'Descendez au moins cuisses parallèles — les quarts de squat ne développent ni la force ni la mobilité',
-    ],
-    commonMistakes: [
-      "Les genoux qui rentrent vers l'intérieur (valgus) — activez consciemment les fessiers pour pousser les genoux dehors",
-      "Les talons qui décollent du sol — signe d'un manque de mobilité de cheville. Travaillez la mobilité ou placez un petit support sous les talons",
-      "Le buste qui tombe trop vers l'avant — renforcez le haut du dos et le gainage. Essayez les squats goblet pour corriger",
-      "L'amplitude insuffisante — descendre à moitié prive le mouvement de ses principaux bénéfices",
-      'La vitesse excessive — contrôlez la descente (2-3 secondes) avant de remonter de manière dynamique',
-    ],
+    variantVideos: {
+      4: '/videos/squats-1-5.mp4',
+    },
   },
   {
     slug: 'fentes',
-    name: 'Fentes avant',
-    aliases: ['Fentes', 'Lunges', 'Fentes alternees', 'Jump lunges', 'Jumping lunges'],
     category: 'lower',
-    muscles: ['Quadriceps', 'Fessiers', 'Ischio-jambiers', 'Mollets', 'Core (stabilisation)'],
     difficulty: 2,
     image: '/images/lower.webp',
-    shortDescription:
-      "Le mouvement unilatéral incontournable pour des jambes puissantes et équilibrées. Les fentes sollicitent quadriceps, fessiers et ischio-jambiers tout en travaillant l'équilibre et la stabilité du bassin — un exercice complet qui corrige les déséquilibres entre jambe droite et jambe gauche.",
-    execution:
-      "Debout, pieds écartés à largeur de hanches, regard droit devant. Faites un grand pas en avant avec une jambe en gardant le buste droit et les abdos contractés. Fléchissez les deux genoux simultanément jusqu'à ce que le genou arrière frôle le sol (les deux genoux forment un angle d'environ 90°). Le genou avant reste aligné avec la pointe du pied, sans dépasser excessivement les orteils. Poussez fermement dans le talon du pied avant pour revenir à la position de départ. Alternez les jambes ou enchaînez toutes les répétitions d'un même côté selon la variante choisie.",
-    breathing:
-      "Inspirez pendant la descente en contrôlant le mouvement, expirez en poussant pour remonter. Gardez une respiration régulière et profonde — ne bloquez jamais le souffle, surtout en fin de série quand la fatigue s'installe.",
-    benefits: [
-      'Développe la force unilatérale et corrige les déséquilibres musculaires entre les deux jambes',
-      'Sollicite intensément les fessiers, souvent sous-activés dans les mouvements bilatéraux comme le squat',
-      "Améliore l'équilibre, la proprioception et la stabilité du bassin",
-      'Renforce la mobilité des hanches et la souplesse des fléchisseurs de hanche',
-      "Transfert direct vers la marche, la course, la montée d'escaliers et les changements de direction",
-    ],
-    variants: [
-      {
-        name: 'Fentes alternées',
-        description:
-          'Un pas en avant jambe droite, retour, puis un pas en avant jambe gauche. Permet de travailler les deux côtés de manière équilibrée dans la même série. Le retour à la position debout entre chaque répétition ajoute un travail de stabilisation.',
-      },
-      {
-        name: 'Fentes arrière',
-        description:
-          "Le pas se fait vers l'arrière au lieu de vers l'avant. Plus douce pour les genoux car le poids reste naturellement sur le talon de la jambe d'appui. Idéale pour les pratiquants ayant des sensibilités au niveau des rotules.",
-      },
-      {
-        name: 'Fentes avec pause',
-        description:
-          "Maintenez la position basse pendant 2 à 3 secondes avant de remonter. La pause élimine l'élan et augmente le temps sous tension, ce qui intensifie le travail musculaire des quadriceps et des fessiers.",
-      },
-      {
-        name: 'Fentes bulgares',
-        description:
-          "Le pied arrière est surélevé sur une chaise ou un banc. Augmente considérablement la charge sur la jambe avant et l'étirement du fléchisseur de hanche arrière. Variante exigeante en force et en équilibre, réservée aux pratiquants à l'aise avec les fentes classiques.",
-      },
-      {
-        name: 'Fentes curtsy',
-        description:
-          "Le pied arrière se croise derrière la jambe d'appui, comme une révérence. Cible davantage le moyen fessier et les adducteurs, travaillant la stabilité latérale du bassin dans un plan de mouvement rarement sollicité.",
-      },
-      {
-        name: 'Fentes latérales',
-        description:
-          "Le pas se fait sur le côté au lieu de vers l'avant. Sollicite les adducteurs et les abducteurs en plus des quadriceps et fessiers. Excellent pour la mobilité des hanches et la préparation aux sports impliquant des déplacements latéraux.",
-      },
-      {
-        name: 'Fentes marchées',
-        description:
-          "Enchaînez les fentes en avançant à chaque pas, comme une marche. Le mouvement continu ajoute un défi d'équilibre dynamique et augmente la composante cardiovasculaire de l'exercice. Nécessite un espace de quelques mètres.",
-        video: '/videos/fentes-marchees.mp4',
-      },
-      {
-        name: 'Fentes sautées',
-        description:
-          "Effectuez un saut pour changer de jambe en position basse. Version plyométrique qui développe l'explosivité et fait monter le cardio rapidement. Réservée aux pratiquants maîtrisant parfaitement les fentes classiques et n'ayant aucune douleur articulaire.",
-      },
-    ],
-    tips: [
-      "Gardez le buste droit et le regard devant vous — la tendance naturelle est de se pencher vers l'avant quand la fatigue arrive",
-      "Le genou avant doit rester aligné avec le deuxième orteil : s'il rentre vers l'intérieur, activez consciemment le fessier",
-      'Faites un pas suffisamment long : un pas trop court met trop de pression sur le genou avant, un pas trop long déséquilibre',
-      "Si l'équilibre est un problème, commencez par les fentes arrière ou posez les mains sur les hanches pour abaisser le centre de gravité",
-    ],
-    commonMistakes: [
-      "Le genou avant qui dépasse largement les orteils ou qui rentre vers l'intérieur — raccourcissez le pas et poussez le genou vers l'extérieur",
-      "Le buste qui s'incline vers l'avant — gardez la poitrine ouverte et les épaules au-dessus des hanches",
-      'Le pas trop court qui transforme la fente en squat partiel — le tibia avant doit être quasi vertical en position basse',
-      'Le pied arrière à plat au sol — seule la pointe du pied arrière touche le sol, le talon reste décollé',
-      'La descente trop rapide et non contrôlée — contrôlez la phase excentrique sur 2 secondes pour protéger les genoux et maximiser le travail musculaire',
-    ],
+    variantVideos: {
+      6: '/videos/fentes-marchees.mp4',
+    },
   },
   {
     slug: 'glute-bridge',
-    name: 'Glute bridge',
-    aliases: ['Pont fessier', 'Hip thrust au sol'],
     category: 'lower',
-    muscles: ['Fessiers', 'Ischio-jambiers', 'Core (stabilisation)'],
     difficulty: 1,
     image: '/images/lower.webp',
     video: '/videos/glute-bridge.mp4',
-    shortDescription:
-      'Le mouvement de référence pour activer et renforcer les fessiers. Allongé au sol, vous soulevez le bassin en contractant les fessiers — un exercice simple, efficace et accessible à tous les niveaux.',
-    execution:
-      "Allongez-vous sur le dos, genoux fléchis, pieds à plat au sol écartés à largeur de hanches et positionnés de sorte que vos tibias soient verticaux en position haute. Bras le long du corps, paumes vers le sol. Poussez dans vos talons et contractez les fessiers pour soulever le bassin jusqu'à former une ligne droite des épaules aux genoux. Maintenez la contraction une seconde en haut en serrant les fessiers au maximum. Redescendez lentement sans poser complètement les fesses au sol entre chaque répétition pour maintenir la tension. Le mouvement vient des hanches — ne cambrez pas le bas du dos pour monter plus haut.",
-    breathing:
-      'Expirez en montant le bassin et en contractant les fessiers. Inspirez en redescendant de manière contrôlée. Cette respiration aide à engager le core et à stabiliser le mouvement.',
-    benefits: [
-      'Active et renforce les fessiers, souvent sous-utilisés à cause de la position assise prolongée',
-      'Protège le bas du dos en renforçant la chaîne postérieure',
-      'Améliore la stabilité du bassin et la posture en position debout',
-      'Mouvement sans impact, accessible même en cas de douleurs articulaires',
-      "Excellent exercice d'échauffement avant des mouvements plus intenses (squats, fentes)",
-    ],
-    variants: [
-      {
-        name: 'Glute bridge marché',
-        description:
-          "En position haute du pont, tendez une jambe devant vous puis reposez-la, et alternez. Cette variante ajoute un travail unilatéral et un défi d'équilibre qui intensifie l'activation des fessiers.",
-      },
-      {
-        name: 'Hip thrust au sol',
-        description:
-          "Haut du dos appuyé sur un canapé ou un banc, pieds au sol, soulevez le bassin. L'amplitude de mouvement est plus grande et la position permet d'ajouter du poids (sac, haltère) sur les hanches pour progresser en charge.",
-      },
-      {
-        name: 'Hip thrust unilatéral',
-        description:
-          "En position de hip thrust, une seule jambe au sol, l'autre tendue ou genou ramené vers la poitrine. Double la charge sur la jambe d'appui et révèle les déséquilibres de force entre les deux côtés.",
-      },
-    ],
-    tips: [
-      'Poussez à travers les talons, pas les orteils — vous devez pouvoir soulever les orteils du sol',
-      'Serrez les fessiers au maximum en haut du mouvement et maintenez une seconde',
-      'Ne cambrez pas le bas du dos pour monter plus haut — arrêtez-vous quand le corps forme une ligne droite',
-      'Placez les pieds de sorte que les tibias soient verticaux en position haute pour maximiser le recrutement des fessiers',
-    ],
-    commonMistakes: [
-      'Pousser avec les orteils au lieu des talons — transfère le travail vers les quadriceps au détriment des fessiers',
-      'Cambrer le bas du dos en position haute — signe que le bassin monte trop haut. Arrêtez-vous quand le corps est aligné.',
-      'Ne pas contracter les fessiers consciemment — le mouvement devient passif et les ischio-jambiers prennent le relais',
-      "Les genoux qui s'écartent ou se rapprochent — gardez-les stables et alignés avec les pieds tout au long du mouvement",
-      "Monter et descendre trop vite — contrôlez le tempo pour maximiser le temps sous tension et l'activation musculaire",
-    ],
   },
   {
     slug: 'box-jumps',
-    name: 'Box jumps (marche)',
-    aliases: ['Box jumps', 'Sauts sur marche'],
     category: 'lower',
-    muscles: ['Quadriceps', 'Fessiers', 'Mollets', 'Core'],
     difficulty: 2,
     image: '/images/explosive.webp',
-    shortDescription:
-      'Un exercice pliométrique accessible qui consiste à sauter sur une marche ou un support stable. Les box jumps développent la puissance explosive des jambes et la coordination tout en apprenant au corps à produire de la force rapidement.',
-    execution:
-      "Placez-vous face à une marche ou un support stable, pieds à largeur d'épaules, à environ 30 cm du bord. Fléchissez les genoux en envoyant les hanches vers l'arrière (comme un demi-squat) tout en balançant les bras en arrière. Poussez explosément dans le sol et balancez les bras vers l'avant et le haut pour propulser votre corps. Réceptionnez-vous sur la marche avec les deux pieds à plat, genoux fléchis pour amortir. Redressez-vous complètement en haut, hanches ouvertes. Redescendez en contrôle (un pied après l'autre ou en sautant légèrement en arrière) et enchaînez la répétition suivante.",
-    breathing:
-      'Prenez une inspiration rapide avant le saut, expirez pendant la phase de poussée et le vol. Respirez librement en haut de la marche avant de redescendre.',
-    benefits: [
-      'Développe la puissance explosive des membres inférieurs de manière fonctionnelle et progressive',
-      'Améliore la coordination, le timing et la proprioception dynamique',
-      'Renforce les quadriceps, les fessiers et les mollets en mode pliométrique',
-      'Enseigne au corps à absorber les impacts correctement (qualité de réception)',
-      "Progression naturelle : il suffit d'augmenter la hauteur de la marche pour monter en difficulté",
-    ],
-    variants: [
-      {
-        name: 'Broad jumps',
-        description:
-          "Saut en longueur debout vers l'avant. Développe la puissance horizontale et la capacité d'extension complète de la chaîne postérieure. Excellent pour le transfert vers les mouvements sportifs.",
-      },
-      {
-        name: 'Tuck jumps',
-        description:
-          "Saut vertical avec les genoux ramenés vers la poitrine en l'air. Augmente le temps de vol et l'explosivité. Demande un bon gainage pour contrôler la position en vol.",
-      },
-      {
-        name: 'Squat jumps',
-        description:
-          "Saut explosif vers le haut depuis une position de squat profond, sans support. Combine le travail de force du squat avec l'explosivité du saut. Très intense pour les quadriceps et les fessiers.",
-      },
-    ],
-    tips: [
-      'Commencez avec une marche basse (15-20 cm) et augmentez progressivement la hauteur',
-      'Réceptionnez-vous avec les deux pieds en même temps, genoux fléchis — jamais en atterrissant sur un seul pied',
-      'Utilisez le balancier des bras pour gagner en hauteur : ils jouent un rôle clé dans la propulsion',
-      'Redescendez toujours en contrôle — pas de saut en arrière incontrôlé qui met les chevilles à risque',
-    ],
-    commonMistakes: [
-      'Réception sur la pointe des pieds au bord de la marche — posez les pieds à plat et au centre du support pour la stabilité',
-      "Les genoux qui rentrent vers l'intérieur à la réception — poussez les genoux vers l'extérieur en atterrissant, comme pour un squat",
-      'Ne pas ouvrir les hanches en haut — redressez-vous complètement avant de redescendre, sinon le mouvement est incomplet',
-      "Utiliser un support instable ou trop haut — la sécurité prime sur l'ego, choisissez une hauteur que vous maîtrisez",
-      "Enchaîner les répétitions en tombant en arrière — redescendez de manière contrôlée à chaque fois pour préserver les tendons d'Achille",
-    ],
   },
   {
     slug: 'good-morning',
-    name: 'Good morning',
-    aliases: ['Good mornings'],
     category: 'lower',
-    muscles: ['Ischio-jambiers', 'Érecteurs du rachis', 'Fessiers'],
     difficulty: 2,
     image: '/images/lower.webp',
-    shortDescription:
-      'Un exercice de charnière de hanche qui cible la chaîne postérieure en profondeur. Le good morning renforce les ischio-jambiers, les érecteurs du rachis et les fessiers dans un mouvement de flexion contrôlée du buste — essentiel pour la santé du dos et la posture.',
-    execution:
-      "Debout, pieds à largeur d'épaules, genoux légèrement fléchis (jamais verrouillés). Placez les mains derrière la tête ou croisées sur la poitrine. En gardant le dos parfaitement droit et la poitrine ouverte, penchez le buste vers l'avant en poussant les hanches vers l'arrière, comme si vous vouliez toucher le mur derrière vous avec vos fessiers. Descendez jusqu'à sentir un étirement prononcé dans les ischio-jambiers (le buste arrive environ parallèle au sol selon votre souplesse). Contractez les fessiers et les ischio-jambiers pour remonter le buste en ramenant les hanches vers l'avant. Le mouvement part des hanches, jamais du bas du dos.",
-    breathing:
-      "Inspirez profondément en descendant le buste vers l'avant, expirez en remontant en contractant les fessiers. Gardez les abdominaux engagés tout au long du mouvement pour protéger la colonne vertébrale.",
-    benefits: [
-      'Renforce toute la chaîne postérieure : ischio-jambiers, érecteurs du rachis et fessiers',
-      'Améliore la mobilité de hanche et la souplesse des ischio-jambiers en dynamique',
-      'Enseigne le patron moteur de la charnière de hanche (hip hinge), fondamental pour soulever des charges au quotidien',
-      'Prévient les douleurs lombaires en renforçant les muscles stabilisateurs du dos',
-      'Prépare aux mouvements plus avancés comme le soulevé de terre et le kettlebell swing',
-    ],
-    variants: [
-      {
-        name: 'Romanian deadlift unilatéral',
-        description:
-          "Même mouvement de charnière de hanche mais sur une seule jambe, la jambe libre partant en arrière. Augmente considérablement le travail d'équilibre et la sollicitation des stabilisateurs de hanche.",
-      },
-      {
-        name: 'Single leg deadlift',
-        description:
-          "Similaire au Romanian deadlift unilatéral avec un défi d'équilibre encore plus marqué. La jambe libre s'aligne avec le buste pour former une ligne horizontale. Excellent pour corriger les déséquilibres musculaires entre les deux côtés.",
-      },
-    ],
-    tips: [
-      'Gardez une légère flexion des genoux en permanence — les jambes tendues mettent trop de stress sur les lombaires',
-      'Le mouvement vient des hanches, pas du dos : imaginez que vos hanches sont une charnière de porte',
-      'Gardez le regard vers le sol à environ un mètre devant vous pour maintenir la nuque alignée avec la colonne',
-      "Descendez uniquement jusqu'où votre dos reste droit — ne sacrifiez jamais la posture pour l'amplitude",
-    ],
-    commonMistakes: [
-      "Le dos qui s'arrondit pendant la descente — signe que vous descendez trop bas ou que les ischio-jambiers manquent de souplesse. Réduisez l'amplitude.",
-      'Les genoux verrouillés — gardez toujours une micro-flexion pour protéger les lombaires et permettre aux hanches de bouger librement',
-      "Le mouvement qui part du bas du dos au lieu des hanches — poussez les fessiers vers l'arrière en premier, le buste suit naturellement",
-      'La tête qui se relève pour regarder devant — gardez la nuque neutre, le regard suit le mouvement du buste',
-      'Descente trop rapide et incontrôlée — contrôlez la descente sur 2-3 secondes pour maximiser le travail musculaire et protéger le dos',
-    ],
   },
 
   // ─── Core ───────────────────────────────────────────────────────
   {
     slug: 'gainage-planche',
-    name: 'Gainage planche',
-    aliases: ['Planche', 'Plank', 'Gainage', 'Bear crawl', 'Hollow body hold'],
     category: 'core',
-    muscles: ["Transverse de l'abdomen", 'Grand droit', 'Obliques', 'Deltoïdes', 'Érecteurs du rachis'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      "L'exercice de base pour un tronc solide et un dos protégé. Le gainage en planche renforce la sangle abdominale en profondeur sans aucun mouvement : il suffit de maintenir la position et de résister à la gravité. Un fondamental accessible à tous.",
-    execution:
-      "Au sol, placez-vous en appui sur les avant-bras et les pointes de pieds. Les coudes sont placés directement sous les épaules, les avant-bras parallèles ou les mains jointes devant vous. Le corps forme une ligne droite de la tête aux talons : contractez les abdominaux en rentrant le nombril vers la colonne vertébrale, serrez les fessiers et poussez les talons vers l'arrière. Le regard est dirigé vers le sol, entre les mains, nuque dans le prolongement de la colonne. Maintenez la position le temps indiqué en respirant régulièrement, sans jamais laisser le bassin s'affaisser ou monter.",
-    breathing:
-      'Respirez normalement et régulièrement par le nez et la bouche. La tendance naturelle est de bloquer le souffle — résistez : adoptez une respiration abdominale contrôlée, en gardant la contraction du transverse à chaque expiration.',
-    benefits: [
-      "Renforce le transverse de l'abdomen, le muscle profond essentiel à la stabilité du tronc",
-      'Protège le bas du dos en améliorant le contrôle de la posture et la rigidité du caisson abdominal',
-      "Sollicite l'ensemble du corps en isométrie : épaules, dos, fessiers et cuisses participent au maintien",
-      'Aucun matériel nécessaire et risque de blessure très faible — accessible dès le premier jour',
-      'Fondation indispensable pour tous les autres exercices : pompes, squats, burpees, et mouvements du quotidien',
-    ],
-    variants: [
-      {
-        name: 'Gainage latéral',
-        description:
-          'En appui sur un avant-bras et le bord extérieur du pied, corps de profil. Cible les obliques et le moyen fessier pour renforcer la stabilité latérale du tronc. Alternez les deux côtés pour un travail équilibré.',
-      },
-      {
-        name: 'Gainage latéral sur genoux',
-        description:
-          "Version accessible du gainage latéral : en appui sur l'avant-bras et le genou plutôt que le pied. Réduit le bras de levier pour les débutants tout en travaillant les obliques et la stabilité latérale. Idéal pour construire la force avant de passer à la version complète.",
-      },
-      {
-        name: 'Gainage Superman',
-        description:
-          "En position de planche classique, tendez les bras vers l'avant comme Superman en vol. Augmente considérablement le bras de levier et la difficulté en sollicitant davantage les érecteurs du rachis et les épaules.",
-      },
-      {
-        name: 'Planche épaule',
-        description:
-          "En position de planche haute (bras tendus), touchez l'épaule opposée avec chaque main en alternance. Ajoute un défi anti-rotation : le tronc doit résister à la torsion pendant que vous levez une main.",
-      },
-      {
-        name: 'Planche RKC',
-        description:
-          'Planche sur les avant-bras avec une contraction maximale de tout le corps : rapprochez les coudes des pieds (sans bouger), serrez les poings et contractez chaque muscle à fond. Beaucoup plus intense que la planche classique — 10 secondes en RKC valent 30 secondes en planche standard.',
-      },
-      {
-        name: 'Bear hold',
-        description:
-          'À quatre pattes, mains sous les épaules, genoux sous les hanches, soulevez les genoux de 2-3 cm du sol et maintenez. Travaille le gainage dans une position raccourcie qui sollicite intensément les quadriceps et le transverse. Excellent exercice de transition avant la planche.',
-      },
-      {
-        name: 'Hollow hold',
-        description:
-          'Allongé sur le dos, bras tendus au-dessus de la tête et jambes tendues, soulevez les épaules et les pieds du sol en pressant le bas du dos contre le sol. Position de gymnastique qui renforce puissamment le grand droit et le transverse en position allongée.',
-      },
-      {
-        name: 'Planche to downward dog',
-        description:
-          "En position de planche haute, poussez les hanches vers le haut et l'arrière pour passer en position du chien tête en bas, puis revenez en planche. L'alternance travaille la mobilité des épaules, la souplesse des ischio-jambiers et le gainage dynamique. Excellent mouvement de transition en échauffement.",
-      },
-    ],
-    tips: [
-      "Pensez à pousser le sol loin de vous avec les avant-bras — cet engagement actif des épaules protège l'articulation et augmente le recrutement musculaire",
-      "Contractez les fessiers aussi fort que les abdos : ce sont eux qui empêchent le bassin de basculer vers l'avant",
-      'Préférez plusieurs séries courtes avec une bonne forme (4 x 20 s) à une longue série où la posture se dégrade',
-      "Si vous tremblez, c'est normal et signe que les muscles travaillent — si le dos se creuse, arrêtez et reposez-vous",
-    ],
-    commonMistakes: [
-      "Le bassin qui s'affaisse vers le sol (dos creux) — le signe le plus courant de fatigue. Contractez les abdos et les fessiers ou arrêtez la série.",
-      "Les fesses qui montent en pic — facilite l'exercice mais supprime le travail du gainage. Le corps doit rester en ligne droite.",
-      'Les coudes placés trop en avant des épaules — crée une contrainte excessive sur les épaules. Les coudes doivent être directement sous les articulations.',
-      "La tête qui se relève pour regarder devant soi — comprime les cervicales. Gardez le regard vers le sol, nuque neutre dans l'axe de la colonne.",
-      'Bloquer la respiration — augmente la pression sanguine et limite la durée du maintien. Respirez calmement et régulièrement.',
-    ],
   },
   {
     slug: 'crunchs',
-    name: 'Crunchs',
-    aliases: ['Crunch', 'Abdominaux', 'Crunchs vélo'],
     category: 'core',
-    muscles: ["Grand droit de l'abdomen", 'Obliques'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      'Le mouvement de base pour cibler les abdominaux. Le crunch isole le grand droit grâce à une flexion courte et contrôlée du tronc, sans élan ni traction sur la nuque. Simple en apparence, il demande une vraie connexion esprit-muscle pour être efficace.',
-    execution:
-      "Allongez-vous sur le dos, genoux fléchis, pieds à plat au sol à largeur de hanches. Placez les mains derrière la tête (doigts qui effleurent les oreilles, sans tirer sur la nuque) ou croisées sur la poitrine. Contractez les abdominaux pour décoller les épaules et le haut du dos du sol en enroulant le buste vers le bassin. Montez jusqu'à sentir une contraction maximale des abdos (environ 30 degrés), marquez un temps d'arrêt en haut, puis redescendez lentement sans reposer complètement les épaules au sol. Le bas du dos reste plaqué au sol pendant tout le mouvement.",
-    breathing:
-      "Expirez en montant (soufflez fort, ventre rentré vers la colonne) et inspirez en redescendant. L'expiration forcée sur la contraction active le transverse et maximise le recrutement des abdominaux.",
-    benefits: [
-      "Isole efficacement le grand droit de l'abdomen sans matériel",
-      'Renforce la sangle abdominale pour une meilleure posture au quotidien',
-      "Mouvement accessible qui s'adapte à tous les niveaux grâce à ses nombreuses variantes",
-      'Faible stress articulaire comparé aux sit-ups complets',
-      'Améliore la connexion esprit-muscle sur la zone abdominale',
-    ],
-    variants: [
-      {
-        name: 'Bicycle crunchs',
-        description:
-          'En position de crunch, amenez le coude droit vers le genou gauche pendant que la jambe droite se tend, puis alternez. Le pédalage rotatif sollicite intensément les obliques en plus du grand droit.',
-      },
-      {
-        name: 'Sit-ups',
-        description:
-          "Remontée complète du buste jusqu'en position assise, le dos décolle entièrement du sol. Mouvement plus complet qui recrute les fléchisseurs de hanche en plus des abdominaux, mais plus exigeant pour le bas du dos.",
-        video: '/videos/sit-ups.mp4',
-      },
-      {
-        name: 'V-ups',
-        description:
-          'Les jambes et le buste montent simultanément pour former un V, les mains cherchent à toucher les pieds. Variante avancée qui demande force abdominale et souplesse des ischio-jambiers.',
-        video: '/videos/v-ups.mp4',
-      },
-      {
-        name: 'Russian twists',
-        description:
-          "Assis en équilibre sur les fessiers, pieds décollés du sol, effectuez des rotations du buste de gauche à droite. Cible les obliques et le transverse avec un travail d'antirotation dynamique.",
-      },
-      {
-        name: 'Toe touches',
-        description:
-          'Allongé sur le dos, jambes tendues à la verticale, montez les mains pour toucher les orteils. Le mouvement court et ciblé isole la partie haute du grand droit avec une contraction intense.',
-      },
-    ],
-    tips: [
-      "Gardez un espace d'un poing entre le menton et la poitrine pour protéger la nuque",
-      'Concentrez-vous sur le rapprochement des côtes vers le bassin, pas sur la hauteur de la montée',
-      "Maintenez le bas du dos collé au sol : s'il se cambre, c'est que les abdos ont lâché",
-      'Ralentissez la descente (2-3 secondes) pour doubler le temps sous tension',
-    ],
-    commonMistakes: [
-      'Tirer sur la nuque avec les mains — relâchez la pression des doigts, ils ne font que soutenir la tête sans la tirer',
-      'Monter trop haut en décollant les lombaires — le crunch est un mouvement court, pas un sit-up',
-      "Utiliser l'élan pour enchaîner les répétitions — chaque montée doit être initiée par la contraction abdominale, pas par un balancier",
-      "Gonfler le ventre en montant — le ventre doit se creuser vers l'intérieur à l'effort pour engager le transverse",
-      'Reposer complètement les épaules entre chaque répétition — gardez une tension continue en restant légèrement décollé',
-    ],
+    variantVideos: {
+      1: '/videos/sit-ups.mp4',
+      2: '/videos/v-ups.mp4',
+    },
   },
   {
     slug: 'superman',
-    name: 'Superman',
-    aliases: ['Superman alterne', 'Back extension au sol'],
     category: 'core',
-    muscles: ['Erecteurs du rachis', 'Fessiers', 'Trapèzes', 'Rhomboïdes', 'Deltoïdes postérieurs'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      "L'antidote aux heures passées assis. Le superman renforce toute la chaîne postérieure en un seul mouvement au sol. En soulevant bras et jambes simultanément, vous travaillez les érecteurs du rachis, les fessiers et le haut du dos pour un dos solide et une posture redressée.",
-    execution:
-      "Allongez-vous face au sol, bras tendus devant vous (position \"superman en vol\"), jambes tendues et serrées. Le front peut reposer sur le sol ou rester légèrement décollé. Contractez simultanément les fessiers et les muscles du dos pour soulever les bras, la poitrine et les jambes du sol. Montez aussi haut que votre mobilité le permet sans forcer dans les lombaires, en gardant le regard vers le sol (nuque neutre). Tenez la position haute 1 à 2 secondes en serrant les omoplates l'une vers l'autre, puis redescendez lentement. Le mouvement part des fessiers et du dos, pas d'un coup de rein.",
-    breathing:
-      'Inspirez en position basse pour préparer le mouvement, expirez en montant tout en contractant le dos et les fessiers. Maintenez une respiration fluide si vous tenez la position en isométrie.',
-    benefits: [
-      'Renforce toute la chaîne postérieure : érecteurs du rachis, fessiers, haut du dos',
-      'Corrige la posture en contrebalançant les effets de la position assise prolongée',
-      "Prévient les douleurs lombaires en développant l'endurance des muscles stabilisateurs du rachis",
-      "Aucun matériel nécessaire, peut se pratiquer sur n'importe quelle surface plane",
-      'Améliore la proprioception et la coordination entre le haut et le bas du corps',
-    ],
-    variants: [
-      {
-        name: 'Superman alterné',
-        description:
-          'Soulevez le bras droit et la jambe gauche simultanément, puis alternez. Réduit la difficulté et ajoute un travail de stabilisation anti-rotation du bassin.',
-        video: '/videos/superman-alterne.mp4',
-      },
-      {
-        name: 'Back extensions',
-        description:
-          'Seul le haut du corps se soulève, les jambes restent au sol. Concentre le travail sur les érecteurs du rachis et le haut du dos, idéal pour les débutants ou en pré-fatigue.',
-      },
-      {
-        name: 'Reverse hyper sur table',
-        description:
-          "Allongé sur le ventre au bord d'une table, hanches en appui, soulevez les jambes vers l'horizontal. Cible les fessiers et les lombaires avec une amplitude accrue et sans compression discale.",
-      },
-      {
-        name: 'Reverse snow angels',
-        description:
-          'En position de superman maintenue, effectuez un arc de cercle avec les bras, du devant vers les hanches et retour. Le mouvement continu sous tension brûle les rhomboïdes et les trapèzes.',
-      },
-      {
-        name: 'Prone T raises',
-        description:
-          'Face au sol, bras écartés sur les côtés, soulevez-les pour former un T. Cible spécifiquement les trapèzes moyens et les rhomboïdes, parfait pour corriger les épaules enroulées.',
-        video: '/videos/prone-t-raises.mp4',
-      },
-      {
-        name: 'Prone Y raises',
-        description:
-          "Face au sol, bras tendus vers l'avant à 45 degrés, soulevez-les pour former un Y. Recrute les trapèzes inférieurs et les deltoïdes postérieurs, renforçant la stabilité de l'omoplate.",
-      },
-    ],
-    tips: [
-      'Gardez le regard vers le sol pour maintenir la nuque neutre — ne levez pas la tête pour regarder devant',
-      'Serrez les omoplates en haut du mouvement comme si vous vouliez coincer un crayon entre elles',
-      'Initiez le mouvement par les fessiers, pas par une cambrure excessive des lombaires',
-      'Commencez par la variante alternée si le superman complet provoque des tensions dans le bas du dos',
-    ],
-    commonMistakes: [
-      'Lever la tête pour regarder devant soi — crée une hyperextension cervicale. Gardez le regard au sol, nuque dans le prolongement de la colonne.',
-      "Forcer la montée en cambrant excessivement les lombaires — la hauteur vient de la contraction musculaire, pas d'un coup de rein. Limitez l'amplitude si nécessaire.",
-      'Plier les genoux pour monter les jambes plus haut — gardez les jambes tendues et laissez les fessiers faire le travail',
-      'Relâcher les bras entre les répétitions — maintenez une légère tension dans le haut du dos même en position basse',
-      "Aller trop vite sans contrôler le mouvement — le superman est un exercice de contrôle, pas de vitesse. Marquez un temps d'arrêt en haut.",
-    ],
+    variantVideos: {
+      0: '/videos/superman-alterne.mp4',
+      4: '/videos/prone-t-raises.mp4',
+    },
   },
   {
     slug: 'leg-raises',
-    name: 'Leg raises',
-    aliases: ['Relevés de jambes'],
     category: 'core',
-    muscles: ['Grand droit (portion basse)', 'Fléchisseurs de hanche', 'Obliques (stabilisation)'],
     difficulty: 2,
     image: '/images/core.webp',
-    shortDescription:
-      "L'exercice de référence pour cibler la partie basse des abdominaux. Le leg raise demande un contrôle réel du bassin pour empêcher le dos de se cambrer, ce qui en fait un mouvement bien plus technique qu'il n'y paraît.",
-    execution:
-      "Allongez-vous sur le dos, bras le long du corps (paumes vers le sol) ou mains glissées sous les fessiers pour stabiliser le bassin. Jambes tendues et serrées, décollez les pieds du sol de quelques centimètres. En gardant le bas du dos plaqué au sol, montez les jambes tendues à la verticale (90 degrés) en contractant les abdominaux. Redescendez lentement, en contrôlant la descente sur 3 à 4 secondes, jusqu'à ce que les pieds frôlent le sol sans le toucher. Si les jambes tendues sont trop difficiles, pliez légèrement les genoux pour réduire le bras de levier. La clé du mouvement est de ne jamais laisser le bas du dos décoller du sol.",
-    breathing:
-      "Expirez en montant les jambes (ventre creux, bas du dos plaqué), inspirez en redescendant. L'expiration forcée en montée aide à maintenir la rétroversion du bassin et protège les lombaires.",
-    benefits: [
-      'Cible la portion basse du grand droit, souvent sous-développée par rapport à la portion haute',
-      'Renforce les fléchisseurs de hanche, essentiels pour la course et la marche',
-      'Développe le contrôle du bassin et la stabilisation lombaire',
-      'Progression naturelle vers des mouvements avancés (toes-to-bar, L-sit)',
-      'Améliore la conscience corporelle et la proprioception de la zone lombo-pelvienne',
-    ],
-    variants: [
-      {
-        name: 'Flutter kicks',
-        description:
-          'Jambes tendues à quelques centimètres du sol, effectuez de petits battements alternés rapides. Le maintien continu sous tension avec le bas du dos plaqué au sol brûle les abdominaux et les fléchisseurs de hanche.',
-      },
-      {
-        name: 'Scissors',
-        description:
-          "Jambes tendues décollées du sol, croisez-les en alternance comme des ciseaux. Le mouvement de croisement ajoute une composante d'adduction et un travail des obliques à l'effort de maintien abdominal.",
-      },
-    ],
-    tips: [
-      'Placez les mains sous les fessiers si votre dos se cambre — cela aide à maintenir la rétroversion du bassin',
-      "Contrôlez la descente : c'est la phase excentrique qui construit la force. Si les jambes tombent, c'est trop lourd.",
-      'Ne touchez jamais le sol avec les pieds entre les répétitions pour garder la tension continue',
-      "Pliez légèrement les genoux si les jambes tendues provoquent des tensions dans le bas du dos — la qualité du mouvement prime sur l'amplitude",
-    ],
-    commonMistakes: [
-      "Le bas du dos qui se cambre à la descente — c'est l'erreur la plus courante et la plus dangereuse. Réduisez l'amplitude ou pliez les genoux tant que vous ne contrôlez pas la position du bassin.",
-      "Utiliser l'élan pour remonter les jambes — chaque montée doit être initiée par la contraction abdominale, pas par un balancement",
-      "Laisser les jambes tomber sous la gravité — la descente doit durer 3-4 secondes minimum. Si vous ne contrôlez pas, réduisez l'amplitude.",
-      'Tirer sur la nuque ou lever la tête — gardez la tête posée au sol, nuque détendue, le travail est dans les abdos pas dans le cou',
-      "Retenir sa respiration par réflexe — l'apnée augmente la pression intra-abdominale de manière incontrôlée et empêche un gainage efficace",
-    ],
   },
   {
     slug: 'dead-bug',
-    name: 'Dead bug',
-    aliases: ['Bird dog'],
     category: 'core',
-    muscles: ["Transverse de l'abdomen", 'Grand droit', 'Obliques', 'Fléchisseurs de hanche'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      'Un exercice de gainage anti-extension allongé sur le dos. Le dead bug apprend au corps à stabiliser le tronc pendant que les bras et les jambes bougent — exactement ce que fait le core dans la vie quotidienne et le sport.',
-    execution:
-      "Allongez-vous sur le dos, bras tendus vers le plafond à la verticale des épaules, genoux fléchis à 90° au-dessus des hanches (tibias parallèles au sol). Avant de bouger, plaquez le bas du dos contre le sol en contractant les abdominaux — ce contact ne doit jamais se perdre. Tendez simultanément le bras droit au-dessus de la tête et la jambe gauche vers le sol, sans que l'un ou l'autre ne touche le sol. Ramenez-les à la position de départ puis répétez du côté opposé. Le mouvement est lent et contrôlé — chaque répétition dure 3 à 4 secondes. Si le bas du dos décolle du sol, réduisez l'amplitude du mouvement.",
-    breathing:
-      'Expirez lentement en tendant le bras et la jambe opposés — cette expiration aide à maintenir le bas du dos plaqué au sol. Inspirez en revenant à la position de départ.',
-    benefits: [
-      'Renforce le core en anti-extension, le schéma de stabilisation le plus fonctionnel',
-      'Apprend la dissociation membres-tronc : bouger les bras et jambes sans compenser avec le dos',
-      'Extrêmement doux pour le dos — recommandé en rééducation et en prévention des lombalgies',
-      'Améliore la coordination controlatérale (bras droit / jambe gauche) essentielle en course et marche',
-      "Excellent exercice d'échauffement pour préparer le core avant des mouvements plus intenses",
-    ],
-    variants: [],
-    tips: [
-      "Le bas du dos doit rester collé au sol en permanence — c'est LE critère de qualité du mouvement",
-      "Allez lentement : 3-4 secondes par extension, 2 secondes pour revenir. La vitesse est l'ennemi du dead bug.",
-      "Si vous n'arrivez pas à maintenir le dos au sol, réduisez l'amplitude : ne descendez pas le bras et la jambe aussi loin",
-      "Concentrez-vous sur l'expiration pendant l'extension — elle verrouille naturellement la position du tronc",
-    ],
-    commonMistakes: [
-      "Le bas du dos qui décolle du sol — signe que l'amplitude est trop grande ou que le core n'est pas assez engagé. Réduisez le mouvement.",
-      'Aller trop vite — le dead bug est un exercice de contrôle, pas de vitesse. Chaque répétition doit être délibérée.',
-      'Bouger le bras et la jambe du même côté (homolatéral) au lieu du côté opposé (controlatéral)',
-      "Retenir sa respiration — l'expiration pendant l'extension est essentielle pour maintenir la stabilité du tronc",
-      "Négliger la phase de retour — ramenez le bras et la jambe avec le même contrôle que l'extension",
-    ],
   },
 
   // ─── Cardio ─────────────────────────────────────────────────────
   {
     slug: 'mountain-climbers',
-    name: 'Mountain climbers',
-    aliases: ['Mountain climber', 'Spider-Man mountain climbers'],
     category: 'cardio',
-    muscles: ['Core', 'Épaules', 'Quadriceps', 'Fléchisseurs de hanche'],
     difficulty: 2,
     image: '/images/cardio.webp',
-    shortDescription:
-      'Un exercice cardio explosif réalisé en position de planche. Les mountain climbers combinent gainage, travail des jambes et endurance cardiovasculaire dans un mouvement rapide et rythmé qui fait grimper la fréquence cardiaque en quelques secondes.',
-    execution:
-      "Placez-vous en position de planche haute : mains sous les épaules, bras tendus, corps aligné de la tête aux talons. Ramenez un genou vers la poitrine en contractant les abdominaux, puis renvoyez-le en arrière tout en ramenant simultanément l'autre genou vers la poitrine. Alternez rapidement les jambes dans un mouvement de course horizontale. Les hanches restent basses et stables — elles ne doivent ni monter en pic ni rebondir de haut en bas. Gardez les épaules au-dessus des poignets et le regard dirigé vers le sol, légèrement devant les mains.",
-    breathing:
-      "Adoptez un rythme respiratoire naturel et régulier, calqué sur le mouvement des jambes : inspirez sur un cycle de deux pas, expirez sur le suivant. Ne bloquez jamais votre respiration même quand le rythme s'accélère.",
-    benefits: [
-      'Fait monter la fréquence cardiaque très rapidement sans aucun matériel',
-      'Renforce le gainage dynamique en sollicitant le core sous instabilité',
-      'Travaille les fléchisseurs de hanche et les quadriceps en mode explosif',
-      "Améliore la coordination et l'agilité grâce à l'alternance rapide des jambes",
-      "S'intègre facilement dans un circuit ou un HIIT comme pic d'intensité",
-    ],
-    variants: [],
-    tips: [
-      "Commencez lentement pour bien maîtriser la position de planche avant d'accélérer",
-      'Gardez les épaules verrouillées au-dessus des poignets — ne reculez pas le buste',
-      'Contractez les abdos en permanence pour empêcher le bassin de rebondir',
-      'Préférez un rythme régulier et soutenu à des accélérations incontrôlées suivies de pauses',
-    ],
-    commonMistakes: [
-      'Les fesses qui montent en pic — signe que le core lâche. Abaissez les hanches au niveau des épaules.',
-      'Les hanches qui rebondissent de haut en bas — gardez le bassin stable en contractant le ventre',
-      'Les épaules qui reculent derrière les poignets — maintenez les mains directement sous les épaules',
-      'Les pieds qui traînent au sol au lieu de décoller — ramenez les genoux avec énergie, comme une course',
-      'La respiration bloquée — respirez de manière fluide et continue, même à haute intensité',
-    ],
   },
   {
     slug: 'jumping-jacks',
-    name: 'Jumping jacks',
-    aliases: ['Jumping jack'],
     category: 'cardio',
-    muscles: ['Deltoïdes', 'Mollets', 'Quadriceps', 'Adducteurs'],
     difficulty: 1,
     image: '/images/cardio.webp',
     video: '/videos/jumping-jacks.mp4',
-    shortDescription:
-      "L'échauffement par excellence. Les jumping jacks combinent un saut avec un écartement simultané des bras et des jambes dans un mouvement rythmique qui active rapidement le système cardiovasculaire. Simple, efficace et accessible à tous les niveaux.",
-    execution:
-      "Debout, pieds joints, bras le long du corps. En un seul saut, écartez les pieds à environ une fois et demie la largeur des épaules tout en levant les bras latéralement au-dessus de la tête (les mains se touchent ou se rapprochent en haut). Revenez en position de départ d'un second saut : pieds joints, bras le long du corps. Le mouvement est fluide et continu, les bras et les jambes se synchronisent parfaitement. Réceptionnez-vous sur l'avant du pied avec les genoux légèrement fléchis pour amortir chaque saut.",
-    breathing:
-      "Inspirez en écartant les bras et les jambes, expirez en revenant en position de départ. Le rythme respiratoire s'adapte naturellement à la cadence du mouvement — gardez une respiration fluide et régulière.",
-    benefits: [
-      'Échauffement complet du corps en quelques secondes : active le cardio, les épaules et les jambes simultanément',
-      'Améliore la coordination motrice bras-jambes et le sens du rythme',
-      'Zéro matériel, zéro technique complexe : accessible dès la première séance',
-      'Sollicite les adducteurs et les deltoïdes, souvent sous-travaillés dans les routines classiques',
-      'Augmente rapidement la fréquence cardiaque pour préparer le corps à un effort plus intense',
-    ],
-    variants: [
-      {
-        name: 'Star jumps',
-        description:
-          "Saut explosif où bras et jambes s'écartent au maximum en l'air pour former une étoile. Plus intense que le jumping jack classique, cette variante développe la puissance et sollicite davantage les fessiers et les épaules.",
-      },
-    ],
-    tips: [
-      'Gardez les genoux légèrement fléchis à la réception pour protéger les articulations',
-      'Les bras montent bien tendus sur les côtés, pas devant vous — le mouvement part des épaules',
-      "Restez sur l'avant du pied, ne retombez jamais talons en premier",
-      "Trouvez un rythme régulier et soutenable plutôt que d'accélérer au maximum dès le départ",
-    ],
-    commonMistakes: [
-      "Retomber sur les talons — crée un impact excessif sur les genoux et les chevilles. Restez sur l'avant du pied.",
-      'Les bras qui passent devant le corps au lieu de monter latéralement — réduit le travail des deltoïdes et casse le rythme',
-      'Les genoux raides à la réception — fléchissez toujours légèrement les genoux pour absorber le choc',
-      'Amplitude trop faible (les mains ne montent pas au-dessus de la tête) — faites le mouvement complet pour un travail efficace',
-      "Rythme irrégulier ou saccadé — gardez une cadence constante et fluide pour maximiser l'effet cardiovasculaire",
-    ],
   },
   {
     slug: 'high-knees',
-    name: 'High knees',
-    aliases: [
-      'Montées de genoux',
-      'Montees de genoux moderees',
-      'Butt kicks',
-      'Sprint sur place',
-      'Talons-fesses',
-      'Skipping',
-    ],
     category: 'cardio',
-    muscles: ['Fléchisseurs de hanche', 'Quadriceps', 'Mollets', 'Core'],
     difficulty: 2,
     image: '/images/cardio.webp',
-    shortDescription:
-      'Un exercice de cardio dynamique qui imite la course sur place avec les genoux montés haut. Les high knees travaillent intensément les fléchisseurs de hanche et le gainage tout en faisant grimper la fréquence cardiaque en quelques secondes.',
-    execution:
-      "Debout, pieds à largeur de hanches, bras fléchis à 90° comme en position de sprint. Montez un genou à hauteur de hanche (cuisse parallèle au sol ou plus haut) tout en poussant le bras opposé vers l'avant. Reposez le pied et enchaînez immédiatement avec l'autre jambe. Le mouvement est rapide et dynamique, semblable à une course sur place à haute fréquence. Restez sur la pointe des pieds, le tronc légèrement incliné vers l'avant et les abdominaux bien engagés pour stabiliser le bassin.",
-    breathing:
-      "Respirez de manière rythmique et courte, comme pendant un sprint : deux temps d'inspiration, deux temps d'expiration. Évitez de bloquer la respiration, même quand l'intensité monte.",
-    benefits: [
-      'Fait exploser la fréquence cardiaque en quelques secondes — parfait pour les intervalles haute intensité',
-      'Renforce les fléchisseurs de hanche, un groupe musculaire clé pour la course et la mobilité quotidienne',
-      'Travaille la coordination bras-jambes et la proprioception dynamique',
-      'Sollicite fortement le gainage pour stabiliser le bassin à chaque montée de genou',
-      'Améliore la vitesse de pied et la réactivité musculaire des membres inférieurs',
-    ],
-    variants: [
-      {
-        name: 'Talon-fesses',
-        description:
-          'Au lieu de monter les genoux, les talons viennent frapper les fessiers en arrière. Cible davantage les ischio-jambiers et les mollets tout en réduisant le stress sur les fléchisseurs de hanche.',
-      },
-    ],
-    tips: [
-      "Montez les genoux au minimum à hauteur de hanche — en dessous, l'exercice perd son intérêt",
-      "Gardez le buste droit ou très légèrement penché vers l'avant, pas en arrière",
-      'Utilisez vos bras activement : ils donnent le rythme et aident à la montée des genoux',
-      'Commencez à un rythme modéré et augmentez progressivement la vitesse sur les premières répétitions',
-    ],
-    commonMistakes: [
-      'Les genoux qui ne montent pas assez haut — la cuisse doit atteindre la parallèle au sol pour un travail efficace des fléchisseurs de hanche',
-      'Le buste qui part en arrière pour compenser — signe que les fléchisseurs de hanche sont faibles. Réduisez la vitesse et gardez le tronc engagé.',
-      'Retomber sur les talons — restez sur la pointe des pieds pour protéger les articulations et garder du dynamisme',
-      "Les bras immobiles le long du corps — les bras opposés doivent accompagner le mouvement pour la coordination et l'équilibre",
-      "Rythme trop rapide au détriment de l'amplitude — mieux vaut monter haut et un peu moins vite que de piétiner sans amplitude",
-    ],
   },
   {
     slug: 'skaters',
-    name: 'Skaters',
-    aliases: ['Skater', 'Patineur', 'Speed skaters'],
     category: 'cardio',
-    muscles: ['Fessiers', 'Quadriceps', 'Adducteurs', 'Mollets'],
     difficulty: 2,
     image: '/images/explosive.webp',
-    shortDescription:
-      "Un exercice de cardio latéral inspiré du mouvement du patineur de vitesse. Les skaters développent la puissance des jambes, l'équilibre unipodal et la stabilité de hanche dans un mouvement explosif et fluide.",
-    execution:
-      "Debout, transférez votre poids sur la jambe droite et poussez latéralement vers la gauche en décollant du sol. Réceptionnez-vous sur le pied gauche, genou légèrement fléchi, en amenant la jambe droite derrière la jambe d'appui (sans poser le pied au sol ou en le posant à peine). Simultanément, le bras droit vient vers l'avant et le bras gauche part en arrière, comme un patineur. Enchaînez immédiatement en poussant vers la droite. Le mouvement est continu, fluide et contrôlé : chaque réception est amortie par une flexion de genou avant de repartir dans l'autre direction.",
-    breathing:
-      'Expirez à chaque impulsion latérale, inspirez brièvement pendant la phase de vol. Le rythme respiratoire se cale naturellement sur les allers-retours.',
-    benefits: [
-      'Travaille la puissance latérale des jambes, un plan de mouvement souvent négligé dans les entraînements classiques',
-      'Renforce les fessiers et les adducteurs en mode dynamique et fonctionnel',
-      "Développe l'équilibre unipodal et la stabilité de hanche et de cheville",
-      'Effet cardio élevé avec un faible impact par rapport aux sauts verticaux',
-      "Améliore l'agilité et la capacité de changement de direction rapide",
-    ],
-    variants: [
-      {
-        name: 'Lateral bounds',
-        description:
-          "Sauts latéraux plus amples et plus explosifs, avec un temps de vol plus long. Développe davantage la puissance et l'explosivité des membres inférieurs. Nécessite une bonne stabilité de cheville.",
-      },
-      {
-        name: 'Pas chassés',
-        description:
-          "Déplacement latéral en pas glissés sans phase de vol. Réduit l'impact articulaire tout en travaillant les adducteurs et la coordination latérale. Idéal pour l'échauffement ou les débutants.",
-        video: '/videos/pas-chasses.mp4',
-      },
-    ],
-    tips: [
-      "Poussez fort avec la jambe d'appui dans le sol — c'est l'explosivité de cette poussée qui fait la qualité du mouvement",
-      'Fléchissez le genou à la réception pour amortir et préparer la prochaine impulsion',
-      "Gardez le buste légèrement penché vers l'avant, comme un vrai patineur — cela aide l'équilibre",
-      'Commencez avec une amplitude modérée et augmentez progressivement la largeur des sauts',
-    ],
-    commonMistakes: [
-      "Réception jambe tendue — fléchissez toujours le genou à l'atterrissage pour protéger les articulations et maintenir l'équilibre",
-      "Le buste trop vertical — penchez-vous légèrement vers l'avant pour abaisser votre centre de gravité et améliorer la stabilité",
-      'Amplitude trop faible (petits pas au lieu de vrais sauts latéraux) — poussez réellement dans le sol pour couvrir de la distance',
-      "Les bras qui restent immobiles — utilisez le balancier naturel des bras pour l'équilibre et la puissance",
-      "Le genou de réception qui s'effondre vers l'intérieur (valgus) — concentrez-vous sur l'alignement genou-pied à chaque atterrissage",
-    ],
+    variantVideos: {
+      1: '/videos/pas-chasses.mp4',
+    },
   },
 
   // ─── Full body ──────────────────────────────────────────────────
   {
     slug: 'burpees',
-    name: 'Burpees',
-    aliases: ['Burpee', 'Sprawls', 'Sprawl', 'Push-up burpees', 'Tuck jump burpees', 'Broad jump burpees'],
     category: 'full-body',
-    muscles: ['Pectoraux', 'Quadriceps', 'Fessiers', 'Épaules', 'Triceps', 'Core'],
     difficulty: 3,
     image: '/images/cardio.webp',
-    shortDescription:
-      "L'exercice au poids du corps le plus complet et le plus redouté. Le burpee combine une pompe, un squat et un saut dans un mouvement fluide qui fait exploser le cardio et sollicite chaque muscle du corps.",
-    execution:
-      "Debout, pieds à largeur d'épaules. Descendez en squat et posez les mains au sol devant vous. Lancez les pieds vers l'arrière d'un bond pour arriver en position de pompe. Effectuez une pompe complète (poitrine au sol). Ramenez les pieds vers les mains d'un bond. Sautez verticalement en levant les bras au-dessus de la tête. Réceptionnez-vous souplement et enchaînez immédiatement la répétition suivante.",
-    breathing:
-      "Inspirez en descendant au sol, expirez en remontant du sol et pendant le saut. Le rythme respiratoire s'adapte naturellement à l'intensité — l'important est de ne jamais bloquer la respiration.",
-    benefits: [
-      'Travail complet du corps en un seul mouvement : poussée, squat, saut, gainage',
-      "Développe simultanément la force, l'endurance et la puissance",
-      'Effet cardio maximal : fait monter la fréquence cardiaque en quelques répétitions',
-      'Brûle énormément de calories grâce à la sollicitation de grandes chaînes musculaires',
-      "Aucun matériel, très peu d'espace nécessaire",
-    ],
-    variants: [
-      {
-        name: 'Burpees sans pompe',
-        description:
-          "On saute en planche et on revient sans effectuer la pompe. Réduit la difficulté tout en gardant l'effet cardio. Bon point de départ pour construire l'endurance.",
-      },
-      {
-        name: 'Burpees sans saut',
-        description:
-          "On remplace le saut final par une simple extension debout. Moins d'impact sur les articulations, idéal en appartement ou pour les pratiquants avec des sensibilités aux genoux.",
-      },
-      {
-        name: 'Burpees avec tuck jump',
-        description:
-          "Le saut final est remplacé par un saut genoux poitrine. Version avancée qui augmente l'explosivité et la demande cardiovasculaire.",
-      },
-    ],
-    tips: [
-      'Trouvez un rythme soutenable. Mieux vaut un rythme régulier que 5 burpees rapides suivis de 30 secondes à reprendre son souffle',
-      "La pompe doit être complète — si vous n'y arrivez plus, passez aux burpees sans pompe plutôt que de tricher",
-      "Réceptionnez-vous souplement sur l'avant du pied, pas les jambes raides",
-      'Gardez les abdos contractés pendant toute la phase au sol pour protéger le bas du dos',
-    ],
-    commonMistakes: [
-      "Sauter la pompe ou faire une demi-pompe — c'est une partie intégrante du mouvement",
-      'Le dos qui se creuse en position de planche — gainez le tronc avant de lancer les pieds en arrière',
-      "Se réceptionner jambes tendues après le saut — fléchissez les genoux pour absorber l'impact",
-      "Partir trop vite et s'effondrer après 4-5 reps — le burpee est un marathon, pas un sprint",
-      "Oublier de respirer — l'apnée d'effort est le piège numéro un sur cet exercice",
-    ],
   },
   {
     slug: 'inchworms',
-    name: 'Inchworms',
-    aliases: ['Inchworm'],
     category: 'full-body',
-    muscles: ['Épaules', 'Core', 'Ischio-jambiers (souplesse)', 'Pectoraux'],
     difficulty: 1,
     image: '/images/fullbody.webp',
     video: '/videos/inchworms.mp4',
-    shortDescription:
-      "Un exercice de mobilité dynamique qui combine marche des mains et étirement des ischio-jambiers. L'inchworm réchauffe tout le corps en passant de la position debout à la planche et retour — parfait en échauffement ou en récupération active.",
-    execution:
-      "Debout, pieds joints ou légèrement écartés. Penchez-vous en avant et posez les mains au sol devant vos pieds (fléchissez les genoux si nécessaire pour atteindre le sol). Avancez les mains pas à pas jusqu'à arriver en position de planche haute, corps aligné de la tête aux talons. Marquez un temps d'arrêt en planche, épaules au-dessus des poignets. Puis ramenez les pieds vers les mains en marchant à petits pas, jambes aussi tendues que possible pour étirer les ischio-jambiers. Redressez-vous à la position debout et enchaînez la répétition suivante. Chaque transition main-pied doit être fluide et contrôlée.",
-    breathing:
-      "Inspirez en marchant les mains vers l'avant, expirez en ramenant les pieds vers les mains. Maintenez un rythme respiratoire calme et régulier — cet exercice n'est pas un sprint.",
-    benefits: [
-      "Échauffe l'ensemble du corps en un seul mouvement fluide : épaules, core, ischio-jambiers",
-      'Améliore la souplesse dynamique des ischio-jambiers et des mollets',
-      'Renforce les épaules et le core en position de planche à chaque répétition',
-      'Prépare les articulations et les muscles à des mouvements plus intenses',
-      'Mouvement lent et contrôlé qui peut servir de récupération active entre des séries intenses',
-    ],
-    variants: [],
-    tips: [
-      "Gardez les jambes aussi tendues que possible en ramenant les pieds — c'est là que se fait l'étirement",
-      "Ne vous précipitez pas : l'inchworm est un exercice de mobilité, pas de vitesse",
-      'En position de planche, vérifiez que vos épaules sont bien au-dessus des poignets avant de repartir',
-      'Si vous ne pouvez pas toucher le sol jambes tendues, fléchissez légèrement les genoux — la souplesse viendra avec la pratique',
-    ],
-    commonMistakes: [
-      "Se précipiter et bâcler les transitions — chaque phase (marche des mains, planche, marche des pieds) mérite d'être contrôlée",
-      "Plier excessivement les genoux en ramenant les pieds — l'objectif est de sentir l'étirement des ischio-jambiers",
-      'Les hanches qui montent ou descendent en planche — maintenez un alignement tête-talons comme pour une planche statique',
-      "Oublier de marquer la position de planche — ne faites pas qu'un aller-retour, stabilisez-vous une seconde en planche",
-      'Les mains qui avancent trop loin devant les épaules — en planche, les poignets doivent être sous les épaules',
-    ],
   },
 
   // ─── Mobilité & Échauffement ───────────────────────────────────
   {
     slug: 'etirements',
-    name: 'Étirements',
-    aliases: ['Stretching', 'Étirement', 'Torsion', 'Cobra', 'Savasana', 'Devil press'],
     category: 'mobility',
-    muscles: ['Ischio-jambiers', 'Quadriceps', 'Pectoraux', 'Psoas', 'Triceps'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      "Les étirements statiques en fin de séance permettent de ramener les muscles à leur longueur de repos, d'améliorer la souplesse et de favoriser la récupération. Chaque position est maintenue 20 à 30 secondes en respirant calmement.",
-    execution:
-      "Adoptez chaque position d'étirement lentement, sans à-coups. Maintenez la posture 20 à 30 secondes en respirant profondément. Vous devez ressentir une tension modérée, jamais une douleur. Relâchez doucement et passez à l'étirement suivant. Pour les étirements unilatéraux, travaillez toujours les deux côtés en maintenant le même temps de chaque côté.",
-    breathing:
-      'Respirez lentement et profondément par le nez. À chaque expiration, relâchez un peu plus la tension musculaire pour gagner en amplitude. Ne bloquez jamais votre respiration.',
-    benefits: [
-      "Améliore la souplesse musculaire et l'amplitude articulaire",
-      'Favorise la récupération en réduisant les tensions post-effort',
-      "Diminue le risque de blessures en maintenant l'élasticité des tissus",
-      'Réduit les courbatures et les raideurs musculaires du lendemain',
-      'Moment de retour au calme qui aide à la transition vers le repos',
-    ],
-    variants: [
-      {
-        name: 'Étirement ischio-jambiers',
-        description:
-          "Jambe tendue posée devant vous sur un support bas ou au sol, penchez le buste en avant en gardant le dos droit jusqu'à sentir l'étirement à l'arrière de la cuisse. Maintenez 20 à 30 secondes de chaque côté.",
-      },
-      {
-        name: 'Étirement pectoraux',
-        description:
-          "Bras tendu contre un mur ou un encadrement de porte à 90°, pivotez lentement le buste vers l'extérieur jusqu'à sentir l'étirement dans la poitrine et l'avant de l'épaule. Maintenez 20 à 30 secondes de chaque côté.",
-      },
-      {
-        name: 'Étirement psoas',
-        description:
-          "En position de fente basse, genou arrière au sol, poussez les hanches vers l'avant jusqu'à sentir l'étirement à l'avant de la hanche arrière. Le buste reste droit. Maintenez 20 à 30 secondes de chaque côté.",
-        video: '/videos/etirement-psoas.mp4',
-      },
-      {
-        name: 'Étirement quadriceps debout',
-        description:
-          "Debout sur une jambe, attrapez le pied de l'autre jambe derrière vous et tirez le talon vers la fesse en gardant les genoux serrés. Gardez le bassin neutre. Maintenez 20 à 30 secondes de chaque côté.",
-      },
-      {
-        name: 'Étirement triceps',
-        description:
-          "Bras levé, pliez le coude pour amener la main derrière la tête entre les omoplates. Avec l'autre main, poussez doucement le coude vers le bas. Maintenez 20 à 30 secondes de chaque côté.",
-        video: '/videos/etirement-triceps.mp4',
-      },
-    ],
-    tips: [
-      'Étirez-vous toujours sur des muscles chauds — jamais à froid en début de séance',
-      "Recherchez la sensation d'étirement, pas la douleur : si ça fait mal, relâchez",
-      'Ne rebondissez jamais dans un étirement : maintenez la position de manière statique',
-      'Respectez la symétrie : étirez toujours les deux côtés le même temps',
-    ],
-    commonMistakes: [
-      "S'étirer à froid avant l'effort — les étirements statiques réduisent la performance s'ils sont faits avant l'entraînement",
-      "Forcer l'amplitude au point de ressentir une douleur — un étirement doit être confortable, jamais douloureux",
-      'Faire des à-coups ou rebondir dans la position — augmente le risque de micro-déchirures musculaires',
-      "Tenir moins de 15 secondes — en dessous, l'étirement n'a pas le temps de produire un effet significatif",
-      'Bloquer la respiration — empêche le relâchement musculaire et augmente la tension',
-    ],
+    variantVideos: {
+      2: '/videos/etirement-psoas.mp4',
+      4: '/videos/etirement-triceps.mp4',
+    },
   },
   {
     slug: 'mobilite',
-    name: 'Mobilité articulaire',
-    aliases: [
-      'Mobilité',
-      'Mobility',
-      'Chat-vache',
-      "Posture de l'enfant",
-      'Pigeon allongé',
-      'Scorpion stretches',
-      'Squat to stand',
-      'Rotation thoracique',
-    ],
     category: 'mobility',
-    muscles: ['Hanches', 'Colonne vertébrale', 'Épaules', 'Chevilles'],
     difficulty: 1,
     image: '/images/core.webp',
-    shortDescription:
-      "Les exercices de mobilité améliorent l'amplitude de mouvement des articulations et la qualité du mouvement. Ils préparent le corps à l'effort en échauffement et favorisent la récupération en fin de séance.",
-    execution:
-      "Effectuez chaque mouvement de mobilité lentement et de manière contrôlée, en explorant toute l'amplitude disponible sans forcer. Enchaînez les positions de manière fluide en respirant régulièrement. Le travail de mobilité n'est pas un effort intense : c'est un dialogue avec votre corps pour identifier et réduire les restrictions de mouvement.",
-    breathing:
-      "Respirez calmement et profondément. Utilisez l'expiration pour relâcher les tensions et gagner en amplitude. La respiration guide le rythme du mouvement.",
-    benefits: [
-      "Améliore l'amplitude articulaire et la qualité de mouvement",
-      "Prévient les blessures en préparant les articulations à l'effort",
-      'Réduit les raideurs liées à la sédentarité et à la position assise',
-      'Favorise la récupération et réduit les douleurs post-entraînement',
-      'Améliore la posture et la conscience corporelle au quotidien',
-    ],
-    variants: [
-      {
-        name: 'Cat-cow',
-        description:
-          'À quatre pattes, alternez lentement entre dos rond (chat : tête baissée, nombril rentré, dos vers le plafond) et dos creux (vache : tête levée, ventre vers le sol, poitrine ouverte). Mobilise toute la colonne vertébrale segment par segment.',
-        video: '/videos/cat-cow.mp4',
-      },
-      {
-        name: "Child's pose",
-        description:
-          "À genoux, asseyez-vous sur les talons et tendez les bras devant vous, front au sol. Respirez profondément dans le bas du dos. Position de repos et d'étirement qui relâche les lombaires, les épaules et les hanches.",
-        video: '/videos/childs-pose.mp4',
-      },
-      {
-        name: 'Deep squat hold',
-        description:
-          "Maintenez un squat profond (fesses près du sol), pieds à plat, coudes contre l'intérieur des genoux pour les pousser vers l'extérieur. Améliore la mobilité des hanches, des chevilles et du bas du dos. Maintenez 30 à 60 secondes.",
-        video: '/videos/deep-squat-hold.mp4',
-      },
-      {
-        name: 'Hip 90/90',
-        description:
-          "Assis au sol, une jambe pliée à 90° devant vous (rotation externe de hanche) et l'autre à 90° sur le côté (rotation interne). Pivotez pour alterner les côtés. Travaille la mobilité en rotation des hanches dans les deux directions.",
-      },
-      {
-        name: 'Pigeon stretch',
-        description:
-          "En position de fente, amenez le tibia avant au sol devant vous (parallèle ou en diagonale) et allongez la jambe arrière. Penchez le buste vers l'avant pour intensifier l'étirement du fessier et du piriforme. Maintenez 30 secondes de chaque côté.",
-      },
-      {
-        name: 'Scorpion stretch',
-        description:
-          'Allongé sur le ventre, bras écartés en croix. Amenez le pied droit vers la main gauche en tournant le bassin, puis alternez. Mobilise la colonne thoracique en rotation et étire les fléchisseurs de hanche.',
-        video: '/videos/scorpion-stretch.mp4',
-      },
-      {
-        name: "World's greatest stretch",
-        description:
-          "En position de fente basse, posez la main intérieure au sol, puis effectuez une rotation du buste en levant l'autre bras vers le ciel. Combine fente, rotation thoracique et ouverture de hanche en un seul mouvement complet. Le roi des échauffements.",
-        video: '/videos/worlds-greatest-stretch.mp4',
-      },
-    ],
-    tips: [
-      'Pratiquez la mobilité quotidiennement, même quelques minutes suffisent pour maintenir les gains',
-      'Respectez les limites de votre corps : la mobilité se construit progressivement, pas en forçant',
-      'Associez la mobilité articulaire à une respiration profonde pour maximiser le relâchement',
-      'Les exercices de mobilité sont parfaits au réveil pour "réveiller" les articulations après la nuit',
-    ],
-    commonMistakes: [
-      "Aller trop vite — la mobilité demande de la lenteur pour être efficace. Prenez le temps d'explorer chaque position.",
-      "Forcer l'amplitude au-delà de ce que le corps permet — respectez les limitations actuelles et progressez graduellement",
-      'Négliger la respiration — une respiration superficielle empêche le relâchement musculaire nécessaire',
-      "Ne travailler la mobilité qu'en cas de douleur — la prévention est bien plus efficace que la correction",
-      'Confondre mobilité et étirement — la mobilité est un mouvement actif et contrôlé, pas un maintien passif',
-    ],
+    variantVideos: {
+      0: '/videos/cat-cow.mp4',
+      1: '/videos/childs-pose.mp4',
+      2: '/videos/deep-squat-hold.mp4',
+      5: '/videos/scorpion-stretch.mp4',
+      6: '/videos/worlds-greatest-stretch.mp4',
+    },
   },
   {
     slug: 'echauffement',
-    name: 'Échauffement dynamique',
-    aliases: [
-      'Échauffement',
-      'Warm-up',
-      'Arm circles',
-      'Respiration',
-      'Rotations',
-      'Marche',
-      'Course sur place',
-      'Cercles',
-      'Balancement',
-      'A-skips',
-      'Carioca',
-      'Lateral shuffles',
-    ],
     category: 'mobility',
-    muscles: ['Corps entier'],
     difficulty: 1,
     image: '/images/cardio.webp',
-    shortDescription:
-      "Les exercices d'échauffement dynamique préparent le corps à l'effort en augmentant progressivement la température corporelle, la fréquence cardiaque et la lubrification articulaire. Indispensables avant chaque séance pour performer et prévenir les blessures.",
-    execution:
-      "Commencez par des mouvements lents et de faible amplitude, puis augmentez progressivement la vitesse et l'intensité. L'échauffement dure généralement 5 à 10 minutes. L'objectif est de sentir le corps monter en température et les articulations se \"déverrouiller\" — vous devez être légèrement essoufflé à la fin.",
-    breathing:
-      "Respirez naturellement en suivant le rythme des mouvements. La respiration s'accélère progressivement avec l'intensité. Gardez une respiration fluide et régulière.",
-    benefits: [
-      'Augmente la température corporelle et la vascularisation musculaire',
-      'Prépare les articulations en stimulant la production de liquide synovial',
-      'Réduit significativement le risque de blessures musculaires et articulaires',
-      'Améliore la performance en activant les connexions neuromusculaires',
-      "Crée une transition mentale entre le quotidien et l'entraînement",
-    ],
-    variants: [
-      {
-        name: 'Rotations articulaires',
-        description:
-          'Effectuez des cercles lents et contrôlés avec chaque articulation : cou, épaules, coudes, poignets, hanches, genoux et chevilles. Commencez petit et agrandissez progressivement les cercles. 10 rotations dans chaque sens par articulation.',
-        video: '/videos/rotations-articulaires.mp4',
-      },
-      {
-        name: 'Marche rapide sur place',
-        description:
-          "Marchez vigoureusement sur place en levant les genoux et en balançant les bras de manière coordonnée. Augmente progressivement la fréquence cardiaque sans impact. Parfait pour commencer l'échauffement avant des mouvements plus intenses.",
-      },
-      {
-        name: 'Toe taps (marche)',
-        description:
-          "Face à une marche ou un step bas, tapez alternativement la pointe de chaque pied sur le bord. Le rythme est rapide et régulier, comme un petit pas de course. Travaille la coordination, l'agilité et échauffe les mollets et les fléchisseurs de hanche.",
-      },
-      {
-        name: 'Respiration profonde',
-        description:
-          'Inspirez lentement par le nez pendant 4 secondes en gonflant le ventre, retenez 4 secondes, puis expirez par la bouche pendant 6 secondes. Utilisé en fin de séance pour ramener le système nerveux au calme et accélérer la récupération. 5 à 10 cycles suffisent.',
-      },
-    ],
-    tips: [
-      "Ne sautez jamais l'échauffement — même 3 minutes valent mieux que rien",
-      "Adaptez l'intensité : l'échauffement prépare à l'effort, il ne doit pas vous fatiguer",
-      'Ciblez les zones qui seront le plus sollicitées dans la séance à venir',
-      "En hiver ou par temps froid, allongez la durée de l'échauffement",
-    ],
-    commonMistakes: [
-      'Sauter directement aux exercices intenses — le corps a besoin de 5 minutes minimum pour se préparer',
-      "Faire des étirements statiques en guise d'échauffement — l'échauffement doit être dynamique et actif",
-      "Aller trop vite et trop fort — l'échauffement est progressif, pas un sprint",
-      'Se contenter de quelques mouvements de bras — tout le corps doit être échauffé, des chevilles aux épaules',
-      "Considérer l'échauffement comme du temps perdu — c'est un investissement pour la performance et la prévention des blessures",
-    ],
+    variantVideos: {
+      0: '/videos/rotations-articulaires.mp4',
+    },
   },
 ];
 

--- a/src/data/formats.ts
+++ b/src/data/formats.ts
@@ -4,282 +4,58 @@ export const FORMATS_DATA: FormatData[] = [
   {
     type: 'pyramid',
     slug: 'pyramide',
-    name: 'Pyramide',
-    subtitle: 'Montée-descente progressive',
     duration: '30-38',
     intensity: 1,
     image: '/images/explosive.webp',
-    shortDescription: 'Séries croissantes puis décroissantes pour une montée en charge progressive.',
-    principle:
-      "Le format Pyramide structure la séance autour d'une montée progressive en répétitions (2, 4, 6, 8…) suivie d'une redescente symétrique. L'intensité augmente naturellement avec le nombre de répétitions, puis diminue, ce qui permet au corps de monter en température graduellement sans choc initial.",
-    protocol:
-      'Chaque exercice est répété selon un schéma pyramidal. Par exemple : 2 reps → 4 reps → 6 reps → 8 reps → 6 reps → 4 reps → 2 reps. Le repos entre chaque palier est court (15-30s). Le temps de travail par exercice est fixe, le nombre de répétitions monte et descend.',
-    benefits: [
-      'Échauffement naturellement intégré grâce à la montée progressive',
-      "Auto-régulation : le corps s'adapte à chaque palier",
-      'Travail en endurance musculaire sur les paliers hauts',
-      'Retour au calme facilité par la descente',
-      'Format accessible à tous les niveaux de pratique',
-    ],
-    targetAudience:
-      "Idéal pour les débutants et ceux qui reprennent le sport. La montée progressive réduit le risque de blessure et permet de trouver son rythme. Convient aussi aux pratiquants intermédiaires qui veulent travailler l'endurance musculaire.",
-    tips: [
-      'Concentrez-vous sur la qualité du mouvement plutôt que la vitesse, surtout dans les paliers hauts',
-      'Utilisez les paliers bas pour bien placer votre respiration',
-      'Si un palier est trop difficile, restez au palier précédent plutôt que de bâcler les répétitions',
-      "La descente n'est pas un moment de relâchement : maintenez la technique",
-    ],
-    commonMistakes: [
-      "Aller trop vite sur les premiers paliers et s'épuiser avant le sommet",
-      'Négliger la technique quand le nombre de répétitions augmente',
-      'Sauter des paliers pour aller plus vite',
-      'Ne pas respecter les temps de repos entre les paliers',
-    ],
   },
   {
     type: 'classic',
     slug: 'renforcement',
-    name: 'Renforcement',
-    subtitle: 'Classique par séries',
     duration: '30-35',
     intensity: 2,
     image: '/images/upper.webp',
-    shortDescription: 'Travail ciblé en séries classiques avec temps de repos structurés.',
-    principle:
-      "Le renforcement musculaire classique est le format le plus traditionnel de l'entraînement au poids du corps. Chaque exercice est réalisé en séries successives avec un nombre de répétitions défini et un temps de repos entre les séries. Ce format permet de cibler précisément un groupe musculaire et de lui appliquer un volume de travail suffisant pour progresser.",
-    protocol:
-      'Les exercices sont organisés par groupes musculaires (haut du corps, bas du corps, core). Chaque exercice est réalisé en 3-4 séries de 8-15 répétitions, avec 30-60 secondes de repos entre les séries. Les séances alternent entre des jours « push » (pompes, dips, épaules) et « pull/legs » (squats, fentes, pont fessier).',
-    benefits: [
-      'Développement ciblé de la force et de la masse musculaire',
-      "Progression mesurable : on peut suivre l'évolution du nombre de reps",
-      'Structure simple et familière, facile à suivre',
-      'Temps de repos suffisants pour maintenir la qualité du mouvement',
-      'Adaptable à tous les niveaux en ajustant reps et séries',
-    ],
-    targetAudience:
-      'Convient à tous les niveaux. Les débutants apprécieront la structure claire et les temps de repos. Les pratiquants avancés peuvent augmenter le nombre de répétitions ou passer à des variantes plus difficiles (pompes déclinées, pistol squats, etc.).',
-    tips: [
-      "Privilégiez l'amplitude complète du mouvement à la vitesse",
-      'Utilisez les temps de repos pour vous hydrater et respirer profondément',
-      'Si vous ne pouvez plus maintenir la technique, réduisez les reps plutôt que de tricher',
-      "Alternez haut du corps et bas du corps d'un jour à l'autre pour la récupération",
-    ],
-    commonMistakes: [
-      "Raccourcir l'amplitude pour faire plus de répétitions",
-      'Ne pas respecter les temps de repos (trop courts ou trop longs)',
-      'Toujours travailler les mêmes groupes musculaires au détriment des autres',
-      "Bloquer sa respiration pendant l'effort",
-    ],
   },
   {
     type: 'superset',
     slug: 'superset',
-    name: 'Superset',
-    subtitle: 'Paires antagonistes',
     duration: '30-35',
     intensity: 2,
     image: '/images/fullbody.webp',
-    shortDescription: 'Deux exercices complémentaires enchaînés sans repos pour un travail équilibré.',
-    principle:
-      "Le superset consiste à enchaîner deux exercices complémentaires (généralement des muscles antagonistes) sans temps de repos entre eux. Pendant que le premier muscle travaille, l'autre récupère, ce qui permet de doubler le volume de travail dans le même temps. Par exemple : pompes (pectoraux) suivies immédiatement de tirage (dos).",
-    protocol:
-      "Les exercices sont organisés en paires complémentaires. Chaque paire est réalisée en 3-4 séries. Au sein d'une paire, les deux exercices s'enchaînent sans pause. Le repos (30-60s) intervient entre les paires, pas entre les exercices. Ce rythme maintient un effort constant tout en permettant la récupération musculaire.",
-    benefits: [
-      'Efficacité temporelle : deux fois plus de travail dans le même temps',
-      'Équilibre musculaire grâce au travail des antagonistes',
-      "Maintien d'une fréquence cardiaque élevée pour un effet cardio",
-      "Récupération active : un muscle récupère pendant que l'autre travaille",
-      'Réduction du temps total de la séance sans perte de qualité',
-    ],
-    targetAudience:
-      "Pour les pratiquants qui ont déjà une bonne base technique et qui souhaitent optimiser leur temps d'entraînement. La demande cardiovasculaire est modérée mais supérieure au renforcement classique, ce qui en fait un bon format de transition.",
-    tips: [
-      'Choisissez des paires qui travaillent des groupes musculaires opposés (push/pull, flexion/extension)',
-      "Passez rapidement d'un exercice à l'autre pour maintenir l'effet superset",
-      'Si la fatigue compromet votre technique, prenez quelques secondes de transition',
-      'Hydratez-vous pendant les repos entre les paires',
-    ],
-    commonMistakes: [
-      "Prendre trop de repos entre les deux exercices d'une paire, ce qui annule l'effet superset",
-      'Choisir deux exercices qui sollicitent le même groupe musculaire',
-      'Négliger la technique sur le deuxième exercice par fatigue',
-      'Ne pas adapter le nombre de répétitions entre les exercices de la paire',
-    ],
   },
   {
     type: 'emom',
     slug: 'emom',
-    name: 'EMOM',
-    subtitle: 'Every Minute On the Minute',
     duration: '28-32',
     intensity: 2,
     image: '/images/endurance.webp',
-    shortDescription: "Chaque minute, un effort à compléter. Le temps restant, c'est votre repos.",
-    principle:
-      "L'EMOM (Every Minute On the Minute) impose un nombre défini de répétitions à réaliser au début de chaque minute. Une fois les répétitions terminées, le temps restant avant la minute suivante est votre repos. Plus vous êtes rapide et efficace, plus vous récupérez. Ce format enseigne la gestion de l'effort : aller trop vite fatigue, aller trop lentement supprime le repos.",
-    protocol:
-      "Le minuteur tourne par intervalles d'une minute. Au top de chaque minute, réalisez le nombre de répétitions prescrit (ex : 10 squats + 5 pompes). Le temps restant est votre repos. Au top suivant, on repart. La séance dure entre 10 et 16 minutes pour le bloc EMOM, avec échauffement et retour au calme en plus.",
-    benefits: [
-      "Développe l'endurance musculaire et cardiovasculaire",
-      "Enseigne la gestion de l'effort et du rythme",
-      "Auto-régulation naturelle : le repos s'adapte à votre vitesse",
-      'Motivation par le défi de terminer avant la fin de la minute',
-      'Structure claire et prévisible qui facilite le focus mental',
-    ],
-    targetAudience:
-      'Accessible aux débutants si le nombre de répétitions est bien calibré (viser 30-40s de travail par minute pour garder 20-30s de repos). Les pratiquants avancés peuvent augmenter le volume ou la difficulté des mouvements.',
-    tips: [
-      "Visez un rythme régulier plutôt que d'aller à fond la première minute",
-      'Si vous finissez avec moins de 10 secondes de repos, réduisez les reps',
-      'Utilisez le repos pour respirer profondément et vous recentrer',
-      'Gardez un œil sur le chrono pour anticiper le départ de la minute suivante',
-    ],
-    commonMistakes: [
-      'Partir trop vite les premières minutes et ne plus avoir de repos ensuite',
-      'Bâcler les dernières répétitions pour grappiller du repos',
-      'Ne pas adapter le volume quand on sent que le repos disparaît',
-      'Oublier de compter ses répétitions dans la précipitation',
-    ],
   },
   {
     type: 'circuit',
     slug: 'circuit',
-    name: 'Circuit',
-    subtitle: 'Enchaînement full body',
     duration: '30-38',
     intensity: 3,
     image: '/images/fullbody.webp',
-    shortDescription: "Rotation d'exercices variés en boucle, mêlant renforcement et cardio.",
-    principle:
-      "Le circuit training enchaîne plusieurs exercices différents avec un repos minimal entre chacun. Chaque exercice cible un groupe musculaire ou une capacité physique différente, ce qui permet de maintenir l'effort global tout en laissant chaque muscle récupérer partiellement. Le circuit est répété plusieurs fois (rounds) pour augmenter le volume total.",
-    protocol:
-      'Un circuit typique comprend 4 à 6 exercices variés (haut du corps, bas du corps, core, cardio). Chaque exercice est réalisé pendant 30-45 secondes ou un nombre fixe de répétitions. Le repos entre les exercices est court (10-15s de transition). Le repos entre les rounds est de 60-90 secondes. La séance comprend généralement 3 à 5 rounds.',
-    benefits: [
-      'Travail complet du corps en une seule séance',
-      'Combinaison efficace de renforcement musculaire et de cardio',
-      "Variété d'exercices qui maintient la motivation et l'engagement",
-      'Adaptable en intensité : on peut jouer sur le nombre de rounds et le temps de repos',
-      "Brûle beaucoup de calories grâce au maintien d'une fréquence cardiaque élevée",
-    ],
-    targetAudience:
-      "Format polyvalent qui convient aux pratiquants de niveau intermédiaire. Les débutants peuvent l'aborder en allongeant les temps de repos. C'est le format idéal quand on veut un entraînement complet sans se spécialiser.",
-    tips: [
-      "Alternez les groupes musculaires dans l'ordre du circuit pour éviter la fatigue locale",
-      "Gardez un rythme constant plutôt que d'alterner sprints et pauses longues",
-      'Le premier round est un échauffement : montez progressivement en intensité',
-      'Si un exercice est trop difficile, passez à sa variante simplifiée plutôt que de sauter',
-    ],
-    commonMistakes: [
-      'Mettre deux exercices sollicitant le même muscle à la suite',
-      "Sprinter sur les premiers rounds et s'effondrer sur les derniers",
-      'Couper les temps de repos au point de compromettre la technique',
-      'Négliger les exercices de core ou de mobilité dans le circuit',
-    ],
   },
   {
     type: 'amrap',
     slug: 'amrap',
-    name: 'AMRAP',
-    subtitle: 'As Many Rounds As Possible',
     duration: '28-32',
     intensity: 3,
     image: '/images/endurance.webp',
-    shortDescription: 'Maximum de tours dans le temps imparti. Vous gérez votre propre rythme.',
-    principle:
-      "L'AMRAP (As Many Rounds As Possible) donne un circuit court d'exercices et un temps total à remplir. L'objectif : réaliser le plus de tours complets possible avant la fin du chrono. Chacun avance à son rythme — il n'y a pas de « bon » nombre de tours, seulement votre record personnel à battre la prochaine fois.",
-    protocol:
-      'Un circuit de 3-5 exercices avec un nombre de répétitions fixe par exercice (ex : 10 squats, 8 pompes, 6 burpees). Le chrono tourne en continu pendant 8-15 minutes. Pas de repos imposé : vous gérez vos pauses. À la fin, comptez le nombre total de rounds complétés et les répétitions du round en cours.',
-    benefits: [
-      'Mesure objective de la progression : le nombre de rounds est un indicateur clair',
-      "Liberté totale de rythme : chacun s'adapte à son niveau",
-      'Motivation par le défi personnel de battre son score',
-      "Développe la capacité à gérer l'effort sur la durée",
-      'Format simple à comprendre et à suivre',
-    ],
-    targetAudience:
-      "Excellent format pour tous les niveaux. Le débutant fera 3 rounds là où l'avancé en fera 7, mais les deux auront un entraînement adapté. Le côté « score » est très motivant pour les compétiteurs dans l'âme.",
-    tips: [
-      'Trouvez un rythme soutenable dès le premier round et maintenez-le',
-      "Il vaut mieux un rythme constant qu'un départ rapide suivi d'une chute",
-      'Notez votre score pour le comparer la prochaine fois',
-      'Respirez entre les exercices plutôt que de vous arrêter complètement',
-    ],
-    commonMistakes: [
-      'Partir comme un sprint sur le premier round et cramer en 3 minutes',
-      'Sacrifier la technique pour grappiller des reps',
-      'Prendre de longues pauses entre les exercices au lieu de ralentir le rythme global',
-      'Ne pas noter son score, ce qui empêche de mesurer la progression',
-    ],
   },
   {
     type: 'hiit',
     slug: 'hiit',
-    name: 'HIIT',
-    subtitle: 'High-Intensity Interval Training',
     duration: '25-30',
     intensity: 4,
     image: '/images/cardio.webp',
-    shortDescription: 'Efforts explosifs suivis de récupération courte. Court, intense, efficace.',
-    principle:
-      "Le HIIT alterne des phases d'effort maximal avec des phases de repos ou de récupération active. L'objectif est de pousser le corps dans sa zone d'effort intense pendant les phases de travail, puis de récupérer juste assez pour repartir. Ce format exploite l'effet « afterburn » (EPOC) : le corps continue de brûler des calories plusieurs heures après l'entraînement.",
-    protocol:
-      "Les intervalles typiques sont de 30 secondes d'effort suivi de 30 secondes de repos (ratio 1:1). Chaque round comprend un exercice réalisé à intensité maximale. La séance comprend 8-12 rounds, soit 8-12 minutes de HIIT pur, encadrées par un échauffement et un retour au calme.",
-    benefits: [
-      'Efficacité maximale : des résultats significatifs en peu de temps',
-      'Effet afterburn : le métabolisme reste élevé pendant des heures après la séance',
-      'Amélioration rapide de la capacité cardiovasculaire',
-      'Pas de matériel nécessaire : les exercices au poids du corps suffisent',
-      "Format court qui s'intègre facilement dans un emploi du temps chargé",
-    ],
-    targetAudience:
-      "Réservé aux pratiquants qui ont déjà une bonne condition physique de base et qui maîtrisent la technique des mouvements fondamentaux. L'intensité élevée demande un système cardiovasculaire en bon état et une conscience corporelle développée pour ne pas se blesser.",
-    tips: [
-      "Donnez vraiment tout pendant les phases de travail — c'est court, profitez-en",
-      'Utilisez les phases de repos pour respirer activement, pas pour consulter votre téléphone',
-      'Choisissez des exercices que vous maîtrisez bien, car la fatigue va dégrader votre technique',
-      'Ne faites pas de HIIT deux jours consécutifs : votre corps a besoin de récupérer',
-    ],
-    commonMistakes: [
-      "Ne pas donner assez d'intensité pendant les phases de travail (le « I » de HIIT veut dire Intense)",
-      'Enchaîner les séances HIIT sans jours de repos entre elles',
-      'Choisir des mouvements trop complexes qui deviennent dangereux sous fatigue',
-      "Ignorer l'échauffement sous prétexte que la séance est courte",
-    ],
   },
   {
     type: 'tabata',
     slug: 'tabata',
-    name: 'Tabata',
-    subtitle: 'Protocole 20/10',
     duration: '25-28',
     intensity: 5,
     image: '/images/cardio.webp',
-    shortDescription: '20 secondes à fond, 10 secondes de repos. Le format le plus court et le plus intense.',
-    principle:
-      "Le protocole Tabata, développé par le Dr Izumi Tabata en 1996, est un format d'entraînement par intervalles ultra-courts. Le ratio travail/repos de 2:1 (20s d'effort / 10s de repos) est conçu pour pousser le corps à son maximum absolu. En seulement 4 minutes par set (8 rounds de 30 secondes), ce protocole développe simultanément les filières aérobie et anaérobie.",
-    protocol:
-      "Un set Tabata classique : 8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Total : 4 minutes. Sur Wan2Fit, les séances Tabata incluent 1 à 2 sets avec un repos de 60 secondes entre les sets. L'effort pendant les 20 secondes doit être maximal : si vous pouvez parler, vous n'allez pas assez fort.",
-    benefits: [
-      'Format le plus court : 4 minutes de travail intense par set',
-      'Amélioration prouvée scientifiquement des capacités aérobie et anaérobie',
-      'Effet afterburn significatif malgré la durée courte',
-      "Développe la puissance, l'explosivité et l'endurance simultanément",
-      "Défi mental : apprendre à maintenir l'intensité quand le corps dit stop",
-    ],
-    targetAudience:
-      "Réservé aux pratiquants avancés avec une excellente condition cardiovasculaire. Ce n'est pas un format pour débuter le sport. Il demande une maîtrise parfaite des mouvements car les 20 secondes d'effort maximal sous fatigue exigent un contrôle technique irréprochable.",
-    tips: [
-      'Choisissez des mouvements simples et explosifs (burpees, mountain climbers, squats sautés)',
-      'Les 10 secondes de repos passent très vite : positionnez-vous immédiatement pour le round suivant',
-      "L'effort doit être véritablement maximal : à la fin des 8 rounds, vous devez être épuisé",
-      'Limitez-vous à 1-2 séances Tabata par semaine maximum',
-    ],
-    commonMistakes: [
-      "Garder du rythme en réserve « au cas où » — le Tabata exige 100% d'effort à chaque round",
-      'Utiliser des mouvements complexes qui deviennent dangereux sous fatigue extrême',
-      'Faire des séances Tabata trop fréquemment (plus de 2 fois par semaine)',
-      'Confondre Tabata avec du HIIT classique : 20/10 est beaucoup plus intense que 30/30',
-    ],
   },
 ];
 

--- a/src/data/programContent.ts
+++ b/src/data/programContent.ts
@@ -1,168 +1,47 @@
-export interface ProgramWeekOverview {
+/**
+ * Metadata for fixed programs: non-translatable structural data (week numbers, format tags).
+ * All translatable content (headline, intro, audience, etc.) lives in
+ * src/i18n/locales/{fr,en}/programs_data.json under the `programs_data` namespace.
+ */
+
+export interface ProgramWeekMeta {
   week: number;
-  title: string;
-  description: string;
   formats: string[];
 }
 
-export interface ProgramContent {
+export interface ProgramContentMeta {
   slug: string;
-  headline: string;
-  intro: string;
-  audience: string;
-  duration: string;
-  frequency: string;
-  sessionLength: string;
-  approach: string;
-  weeks: ProgramWeekOverview[];
-  benefits: string[];
-  tip: string;
+  weeks: ProgramWeekMeta[];
 }
 
-export const PROGRAM_CONTENT: Record<string, ProgramContent> = {
+export const PROGRAM_CONTENT_META: Record<string, ProgramContentMeta> = {
   'debutant-4-semaines': {
     slug: 'debutant-4-semaines',
-    headline: 'Construis tes fondations',
-    intro:
-      "Tu reprends le sport ou tu débutes ? Ce programme de 4 semaines t'accompagne pas à pas. Chaque semaine ajoute un peu d'intensité pour que tu progresses sans jamais te sentir dépassé.",
-    audience: "Reprise d'activité, vrai débutant, ou toute personne qui veut (re)partir sur de bonnes bases.",
-    duration: '4 semaines',
-    frequency: '3 séances par semaine',
-    sessionLength: '~25 min',
-    approach:
-      'La progression est pensée pour que tu ne brûles pas les étapes. On commence par des mouvements simples avec beaucoup de repos, puis on raccourcit les pauses et on ajoute des variantes plus complètes au fil des semaines.',
     weeks: [
-      {
-        week: 1,
-        title: 'Découverte',
-        description:
-          'Mouvements de base, 2 séries, repos généreux. On apprend les gestes fondamentaux : squats, pompes adaptées, gainage.',
-        formats: ['Classic', 'Pyramide'],
-      },
-      {
-        week: 2,
-        title: 'Installation',
-        description:
-          'Mêmes patterns améliorés, 2-3 séries, reps en hausse. Le corps commence à mémoriser les mouvements.',
-        formats: ['Classic', 'Circuit'],
-      },
-      {
-        week: 3,
-        title: 'Progression',
-        description:
-          'Variantes complètes (planche pieds, pompes standard), 3 séries. On introduit le format EMOM pour apprendre à gérer son effort.',
-        formats: ['Classic', 'EMOM'],
-      },
-      {
-        week: 4,
-        title: 'Consolidation',
-        description:
-          'Circuits combinés, supersets, volume augmenté. Tu maîtrises les bases et tu es prêt pour la suite.',
-        formats: ['Circuit', 'Superset'],
-      },
+      { week: 1, formats: ['Classic', 'Pyramide'] },
+      { week: 2, formats: ['Classic', 'Circuit'] },
+      { week: 3, formats: ['Classic', 'EMOM'] },
+      { week: 4, formats: ['Circuit', 'Superset'] },
     ],
-    benefits: [
-      'Apprendre les mouvements fondamentaux en toute sécurité',
-      'Créer une habitude sportive régulière',
-      'Gagner en confiance et en mobilité',
-      'Préparer le corps pour des programmes plus intenses',
-    ],
-    tip: "Pas besoin de forcer dès le début. Le plus important, c'est la régularité. 3 séances par semaine suffisent pour voir des résultats concrets en un mois.",
   },
 
   'remise-en-forme': {
     slug: 'remise-en-forme',
-    headline: 'Retrouve ton rythme',
-    intro:
-      'Tu as déjà fait du sport mais tu as décroché ? Ce programme remet les choses en place. Formats variés dès la première semaine, intensité progressive — tu retrouves tes sensations rapidement.',
-    audience: 'Ancien sportif en reprise, ou niveau intermédiaire qui veut structurer son entraînement.',
-    duration: '4 semaines',
-    frequency: '4 séances par semaine',
-    sessionLength: '~30 min',
-    approach:
-      'Pas de phase de découverte ici : on attaque directement avec des formats variés. Chaque semaine alterne haut du corps, bas du corps, full-body et cardio pour un travail complet et équilibré.',
     weeks: [
-      {
-        week: 1,
-        title: 'Reprise active',
-        description:
-          'Renforcement ciblé et premiers circuits. On réveille les groupes musculaires avec des séances structurées.',
-        formats: ['Classic', 'Circuit'],
-      },
-      {
-        week: 2,
-        title: 'Montée en charge',
-        description: "Volume et intensité augmentent. Supersets et EMOM pour travailler l'endurance musculaire.",
-        formats: ['Superset', 'EMOM'],
-      },
-      {
-        week: 3,
-        title: "Pic d'intensité",
-        description:
-          'Formats exigeants : AMRAP, HIIT. Le corps est prêt à être poussé. Les séances sont plus courtes mais plus intenses.',
-        formats: ['AMRAP', 'HIIT'],
-      },
-      {
-        week: 4,
-        title: 'Maîtrise',
-        description:
-          'Combinaisons avancées, circuits complexes. Tu termines le programme en pleine forme, prêt pour un nouveau challenge.',
-        formats: ['Circuit', 'Pyramide'],
-      },
+      { week: 1, formats: ['Classic', 'Circuit'] },
+      { week: 2, formats: ['Superset', 'EMOM'] },
+      { week: 3, formats: ['AMRAP', 'HIIT'] },
+      { week: 4, formats: ['Circuit', 'Pyramide'] },
     ],
-    benefits: [
-      'Retrouver rapidement un bon niveau de condition physique',
-      'Travailler tout le corps de manière équilibrée',
-      "Découvrir plusieurs formats d'entraînement",
-      "Relancer le métabolisme et l'endurance",
-    ],
-    tip: "Si une séance te semble facile, c'est normal — c'est le signe que tu es en forme pour ça. La semaine suivante ajustera le curseur.",
   },
 
   'cardio-express': {
     slug: 'cardio-express',
-    headline: 'Court, intense, efficace',
-    intro:
-      'Pas le temps de faire une heure de sport ? Ce programme mise sur des séances courtes à haute intensité. 20 minutes suffisent pour transpirer, progresser et repartir.',
-    audience: 'Emploi du temps chargé, sportif qui veut du résultat sans y passer des heures.',
-    duration: '4 semaines',
-    frequency: '3 séances par semaine',
-    sessionLength: '~20 min',
-    approach:
-      "Chaque séance utilise des formats conçus pour maximiser l'effort en peu de temps : HIIT, Tabata, EMOM. L'intensité monte progressivement pour que ton cardio et ton explosivité s'améliorent semaine après semaine.",
     weeks: [
-      {
-        week: 1,
-        title: 'Mise en route',
-        description: "HIIT et intervalles classiques. On calibre l'intensité et on installe le rythme.",
-        formats: ['HIIT', 'Circuit'],
-      },
-      {
-        week: 2,
-        title: 'Accélération',
-        description: "Tabata et EMOM entrent en jeu. Les repos se raccourcissent, le cardio monte d'un cran.",
-        formats: ['Tabata', 'EMOM'],
-      },
-      {
-        week: 3,
-        title: 'Haute intensité',
-        description: 'Séances plus denses, combinaisons explosives. Le cœur travaille à plein régime.',
-        formats: ['HIIT', 'Tabata'],
-      },
-      {
-        week: 4,
-        title: 'Full throttle',
-        description:
-          'Les séances les plus intenses du programme. Tu mesures tes progrès avec des formats chronométrés.',
-        formats: ['AMRAP', 'Tabata', 'HIIT'],
-      },
+      { week: 1, formats: ['HIIT', 'Circuit'] },
+      { week: 2, formats: ['Tabata', 'EMOM'] },
+      { week: 3, formats: ['HIIT', 'Tabata'] },
+      { week: 4, formats: ['AMRAP', 'Tabata', 'HIIT'] },
     ],
-    benefits: [
-      'Améliorer son cardio en moins de temps',
-      'Brûler un maximum de calories en 20 minutes',
-      "Développer l'explosivité et la résistance",
-      "S'entraîner même avec un planning chargé",
-    ],
-    tip: "L'intensité est la clé. Mieux vaut 20 minutes à fond que 45 minutes à mi-régime. Donne tout pendant les phases d'effort, récupère à fond pendant les pauses.",
   },
 };

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -1,12 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import { isSupportedLocale } from '../i18n';
 import { supabase } from '../lib/supabase.ts';
 import type { GenerateProgramResponse, ProgramOnboardingInput } from '../types/custom-program.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useGenerateProgram() {
   const { user } = useAuth();
+  const { i18n } = useTranslation();
   const queryClient = useQueryClient();
   const userId = user?.id;
   const [loading, setLoading] = useState(false);
@@ -27,8 +30,9 @@ export function useGenerateProgram() {
       setError(null);
 
       try {
+        const locale = isSupportedLocale(i18n.language) ? i18n.language : 'fr';
         const { data, error: fnError } = await supabase.functions.invoke('generate-program', {
-          body: input,
+          body: { ...input, locale },
         });
 
         if (fnError) {
@@ -61,7 +65,7 @@ export function useGenerateProgram() {
         inflightRef.current = false;
       }
     },
-    [queryClient, userId],
+    [queryClient, userId, i18n.language],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -1,12 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import { isSupportedLocale } from '../i18n';
 import { supabase } from '../lib/supabase.ts';
 import type { CustomSessionInput, GenerateSessionResponse } from '../types/custom-session.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
 
 export function useGenerateSession() {
   const { user } = useAuth();
+  const { i18n } = useTranslation();
   const queryClient = useQueryClient();
   const userId = user?.id;
   const [loading, setLoading] = useState(false);
@@ -27,8 +30,9 @@ export function useGenerateSession() {
       setError(null);
 
       try {
+        const locale = isSupportedLocale(i18n.language) ? i18n.language : 'fr';
         const { data, error: fnError } = await supabase.functions.invoke('generate-session', {
-          body: input,
+          body: { ...input, locale },
         });
 
         if (fnError) {
@@ -61,7 +65,7 @@ export function useGenerateSession() {
         inflightRef.current = false;
       }
     },
-    [queryClient, userId],
+    [queryClient, userId, i18n.language],
   );
 
   return { generate, loading, error };

--- a/src/i18n/locales/en/exercises_data.json
+++ b/src/i18n/locales/en/exercises_data.json
@@ -1,0 +1,1000 @@
+{
+  "pompes-classiques": {
+    "name": "Push-ups",
+    "aliases": ["Push-up", "Classic push-ups", "Scapular push-ups", "Pike push-ups"],
+    "muscles": ["Chest", "Triceps", "Front deltoids", "Core (stabilization)"],
+    "shortDescription": "The fundamental upper-body bodyweight exercise. Push-ups develop horizontal pushing strength by engaging the chest, triceps and shoulders in a complete, functional movement.",
+    "execution": "Starting position: hands on the floor slightly wider than shoulder-width, arms extended, body aligned from head to heels. Feet together or slightly apart. Lower by bending your elbows until your chest nearly touches the floor (elbows at roughly 45° from your body, not flared to 90°). Push back to the starting position by locking out your arms. Keep your body braced throughout: no sagging lower back, no hips in the air.",
+    "breathing": "Inhale on the way down, exhale on the push. Never hold your breath, even when the effort becomes intense.",
+    "benefits": [
+      "Strengthens the entire push chain (chest, triceps, shoulders)",
+      "Works core stability in a dynamic plank position",
+      "Requires no equipment and can be done anywhere",
+      "Direct carry-over to everyday movements (getting up, pushing a door)",
+      "Dozens of progressions allow indefinite improvement"
+    ],
+    "variants": [
+      {
+        "name": "Incline push-ups",
+        "description": "Hands on an elevated surface (chair, step). Reduces load and makes the movement easier — ideal for beginners or at the end of a set when fatigue sets in."
+      },
+      {
+        "name": "Diamond push-ups",
+        "description": "Hands close together under your chest, thumbs and index fingers forming a diamond. Increases triceps and inner-chest recruitment."
+      },
+      {
+        "name": "Decline push-ups",
+        "description": "Feet elevated on a surface. Increases load on the shoulders and upper chest. Reserved for those who have mastered standard push-ups."
+      },
+      {
+        "name": "Explosive push-ups",
+        "description": "Push explosively enough for your hands to leave the floor. Develops power and muscular contraction speed."
+      },
+      {
+        "name": "Archer push-ups",
+        "description": "One arm extended to the side while the other arm performs most of the push. Develops unilateral strength and gradually prepares you for one-arm push-ups."
+      },
+      {
+        "name": "Commando push-ups",
+        "description": "Start in a forearm plank, push up to a high plank one arm at a time, then lower back down. Works transition strength and core stability under asymmetric load."
+      },
+      {
+        "name": "Hindu push-ups",
+        "description": "Start in downward dog, swoop your body forward close to the floor then rise into cobra. A dynamic movement combining flexibility, strength and spinal mobility."
+      },
+      {
+        "name": "Wide push-ups",
+        "description": "Hands placed well beyond shoulder-width. Increases pectoral recruitment and reduces triceps involvement — ideal for targeting the chest with bodyweight."
+      },
+      {
+        "name": "Pike push-ups",
+        "description": "Hips high in an inverted V, push vertically toward the floor. Targets the shoulders similarly to an overhead press — excellent progression toward the handstand push-up."
+      },
+      {
+        "name": "Scapular push-ups",
+        "description": "In a high plank, only the shoulder blades move (protraction and retraction) without bending the elbows. Strengthens the serratus anterior and improves scapular stability."
+      }
+    ],
+    "tips": [
+      "Keep elbows at 45° from your body (not tucked tight, not flared to 90°) to protect your shoulders",
+      "Squeeze your abs and glutes as if holding a plank — your body must not 'break'",
+      "Go all the way down: half-reps don't count and limit progress",
+      "If you can't do a full push-up, start with incline push-ups rather than knee push-ups"
+    ],
+    "commonMistakes": [
+      "Hips sagging (lower back arched) — a sign of insufficient core engagement. Contract your abs.",
+      "Hips piking up — shortens the movement and eliminates chest work",
+      "Elbows flared to 90° — places excessive stress on the shoulder joint",
+      "Incomplete range of motion — not going low enough limits strength and mobility gains",
+      "Head dropping toward the floor — keep your gaze at the floor about 30 cm in front of your hands, neck neutral"
+    ]
+  },
+  "dips-sur-chaise": {
+    "name": "Chair dips",
+    "aliases": ["Dips", "Triceps dips"],
+    "muscles": ["Triceps", "Front deltoids", "Chest (lower)"],
+    "shortDescription": "A vertical pushing exercise that targets the triceps using a chair or stable support. Chair dips are one of the best bodyweight movements to sculpt the back of the arms and build pushing strength.",
+    "execution": "Sit on the edge of a stable chair or bench, hands gripping the edge on either side of your hips, fingers pointing forward. Walk your feet forward to lift your hips off the support, arms extended. Lower by bending your elbows straight back (not out) until your arms form roughly a 90° angle. Push through your palms to rise back up, locking out at the top. Keep your back close to the support throughout — don't drift away from the chair. Shoulders stay low and pulled back, away from your ears.",
+    "breathing": "Inhale as you lower under control. Exhale as you push back up. Don't hold your breath at the bottom position.",
+    "benefits": [
+      "Effectively isolates the triceps with a natural pushing motion",
+      "Strengthens the front deltoids and lower chest",
+      "Requires only a chair, bench or step — can be done anywhere",
+      "Develops vertical pushing strength useful in daily life",
+      "Intensity easily scaled by adjusting foot position"
+    ],
+    "variants": [],
+    "tips": [
+      "Use a perfectly stable support — a chair that slides can cause a fall",
+      "Keep your elbows tight and pointing straight back, never out to the sides",
+      "To make the movement easier, bend your knees and bring your feet closer to the support",
+      "To increase difficulty, extend your legs or elevate your feet on a second support"
+    ],
+    "commonMistakes": [
+      "Elbows flaring outward — keep them tight and pointing backward to protect your shoulders",
+      "Dipping too low (past 90°) — places excessive stress on the shoulder joint",
+      "Shoulders rising toward your ears — pull your shoulder blades down and back",
+      "Back drifting away from the chair — stay close to the support to keep the work on the triceps",
+      "Pushing with your legs instead of your arms — your feet are a support, not the engine of the movement"
+    ]
+  },
+  "rowing-inverse": {
+    "name": "Inverted row (table)",
+    "aliases": ["Inverted row", "Table row"],
+    "muscles": ["Lats", "Rhomboids", "Traps", "Biceps", "Rear deltoids"],
+    "shortDescription": "The push-up's counterpart for the upper back. The inverted row under a table or low bar trains horizontal pulling with bodyweight, targeting the lats, rhomboids and biceps. A fundamental exercise for postural balance.",
+    "execution": "Lie under a sturdy table (or low bar) and grip the edge with hands shoulder-width apart, palms facing you or in a neutral grip. Your body is aligned from head to heels, arms extended, heels on the floor. Keeping your body fully braced, pull your chest toward the table by squeezing your shoulder blades together. Elbows travel along your sides (not flared). Rise until your chest touches or approaches the table, pause at the top contracting your upper back, then lower slowly back to full arm extension.",
+    "breathing": "Exhale as you pull your chest toward the table; inhale as you lower under control. Keep your abs engaged to maintain body alignment throughout the set.",
+    "benefits": [
+      "Strengthens the full pulling chain: lats, rhomboids, traps and biceps",
+      "Corrects postural imbalances by targeting upper-back muscles that are often neglected",
+      "Prepares you for pull-ups by developing horizontal pulling strength",
+      "Improves scapular retraction, essential for shoulder health",
+      "Requires only a sturdy table or low bar — doable at home"
+    ],
+    "variants": [
+      {
+        "name": "Face pulls on the floor",
+        "description": "Lying face down, arms extended in front, pull your elbows back while squeezing your shoulder blades. Isolates the rhomboids and rear deltoids with no equipment. Excellent for posture and upper-back activation."
+      }
+    ],
+    "tips": [
+      "Choose a solid, stable table — test it before hanging underneath",
+      "Squeeze your shoulder blades at the top and hold the contraction for a second before lowering",
+      "The more horizontal your body (feet further out), the harder it gets — walk your feet back to reduce the load",
+      "Keep your body rigid like a plank: glutes and abs stay contracted throughout"
+    ],
+    "commonMistakes": [
+      "Hips sagging — your body must stay aligned like a plank. Contract your glutes and abs.",
+      "Shoulders shrugging toward your ears while pulling — lower your shoulders and focus on squeezing the shoulder blades together",
+      "Incomplete range of motion — lower to full arm extension and pull your chest to the table. Half-reps don't count.",
+      "Elbows flaring to 90° — keep them at 45° maximum to protect your shoulders and target the right muscles",
+      "Using momentum by swinging the hips — the movement must be slow and controlled; only the arms and back work"
+    ]
+  },
+  "squats": {
+    "name": "Squats",
+    "aliases": ["Squat", "Bodyweight squat", "Jump squats", "Speed squats"],
+    "muscles": ["Quads", "Glutes", "Hamstrings", "Core (stabilization)"],
+    "shortDescription": "The king of lower-body movements. The squat is a fundamental motor pattern that engages the entire lower chain: thighs, glutes and core. It's the movement you perform every time you sit down and stand back up.",
+    "execution": "Stand with feet shoulder-width apart or slightly wider, toes turned out 15–30°. Initiate by pushing your hips back as if sitting into a chair. Lower while keeping your weight through your heels and mid-foot, knees tracking over your toes. Descend at least until your thighs are parallel to the floor (deeper if your mobility allows). Drive through the floor to rise, squeezing your glutes at the top.",
+    "breathing": "Inhale deeply on the way down (belly expands), exhale forcefully on the way up. For heavy or intense sets, take a breath before descending and exhale past the sticking point on the way up.",
+    "benefits": [
+      "Strengthens the entire lower body: quads, glutes, hamstrings",
+      "Improves hip, knee and ankle mobility",
+      "An essential functional movement: sitting, standing, carrying loads",
+      "Strongly engages core stability to keep the back straight",
+      "Triggers a significant hormonal response due to the large muscle mass involved"
+    ],
+    "variants": [
+      {
+        "name": "Sumo squats",
+        "description": "Feet very wide, toes pointing out. Targets the inner thighs (adductors) and glutes more. Easier on ankle mobility."
+      },
+      {
+        "name": "Pulse squats",
+        "description": "Stay in the bottom position and perform small bouncing movements. Increases time under tension and burns out the quads."
+      },
+      {
+        "name": "Jump squats",
+        "description": "Add an explosive jump at the top. Develops power and cardio. Reserved for those without knee issues."
+      },
+      {
+        "name": "Assisted pistol squat",
+        "description": "Single-leg squat holding onto a support. Works balance, unilateral strength and mobility. An advanced goal to build gradually."
+      },
+      {
+        "name": "1.5 squats",
+        "description": "Full descent, rise halfway, descend again, then rise completely — that counts as one rep. Greatly increases time under tension in the bottom portion of the movement."
+      },
+      {
+        "name": "Pop squats",
+        "description": "Jump to spread your feet into a wide squat, then jump to bring them back together. Combines cardio work and leg strengthening in a dynamic, rhythmic movement."
+      },
+      {
+        "name": "Goblet squat (no weight)",
+        "description": "Hands clasped in front of your chest, elbows pushing between your knees at the bottom. Helps keep the torso upright and deepen the squat — an excellent technique correction tool."
+      },
+      {
+        "name": "Sissy squat",
+        "description": "Lean your torso back, push your knees forward, heels off the floor. Intensely isolates the quads. An advanced movement requiring good balance and healthy knees."
+      },
+      {
+        "name": "Wall sit",
+        "description": "Back flat against a wall, thighs parallel to the floor, held isometrically. A pure endurance challenge for the quads — deceptively simple, brutal after 30 seconds."
+      }
+    ],
+    "tips": [
+      "Push your knees outward on the way down — they must never cave inward",
+      "Keep your weight through your heels: you should be able to wiggle your toes at any moment",
+      "Back stays straight, chest tall and proud. Imagine you're wearing a logo on your chest that everyone should see",
+      "Go at least to parallel thighs — quarter squats develop neither strength nor mobility"
+    ],
+    "commonMistakes": [
+      "Knees caving inward (valgus) — consciously activate your glutes to push your knees out",
+      "Heels lifting off the floor — a sign of limited ankle mobility. Work on mobility or place a small wedge under your heels",
+      "Torso collapsing too far forward — strengthen your upper back and core. Try goblet squats to correct this",
+      "Insufficient depth — going only halfway robs the movement of its main benefits",
+      "Excessive speed — control the descent (2–3 seconds) before rising dynamically"
+    ]
+  },
+  "fentes": {
+    "name": "Lunges",
+    "aliases": ["Lunge", "Forward lunges", "Alternating lunges", "Jump lunges", "Jumping lunges"],
+    "muscles": ["Quads", "Glutes", "Hamstrings", "Calves", "Core (stabilization)"],
+    "shortDescription": "The essential unilateral movement for powerful, balanced legs. Lunges engage the quads, glutes and hamstrings while training balance and hip stability — a complete exercise that corrects imbalances between the right and left leg.",
+    "execution": "Stand with feet hip-width apart, eyes forward. Take a large step forward with one leg, keeping your torso upright and abs engaged. Bend both knees simultaneously until your back knee nearly grazes the floor (both knees at roughly 90°). Your front knee stays aligned with your toes without excessively passing over them. Drive firmly through the front heel to return to the starting position. Alternate legs or complete all reps on one side depending on the variation.",
+    "breathing": "Inhale as you lower under control, exhale as you push back up. Maintain deep, regular breathing — never hold your breath, especially at the end of a set when fatigue sets in.",
+    "benefits": [
+      "Develops unilateral strength and corrects muscular imbalances between the two legs",
+      "Intensely engages the glutes, which are often under-activated in bilateral movements like squats",
+      "Improves balance, proprioception and hip stability",
+      "Strengthens hip mobility and hip flexor flexibility",
+      "Direct carry-over to walking, running, climbing stairs and changes of direction"
+    ],
+    "variants": [
+      {
+        "name": "Alternating lunges",
+        "description": "Step forward with the right leg, return, then step forward with the left. Trains both sides equally in the same set. Returning to standing between each rep adds a stabilization challenge."
+      },
+      {
+        "name": "Reverse lunges",
+        "description": "The step goes backward instead of forward. Gentler on the knees because your weight stays naturally over the front heel. Ideal for those with patellar sensitivity."
+      },
+      {
+        "name": "Pause lunges",
+        "description": "Hold the bottom position for 2–3 seconds before rising. The pause eliminates momentum and increases time under tension, intensifying quad and glute work."
+      },
+      {
+        "name": "Bulgarian split squats",
+        "description": "Rear foot elevated on a chair or bench. Greatly increases load on the front leg and the stretch on the rear hip flexor. A demanding variation in strength and balance, reserved for those comfortable with standard lunges."
+      },
+      {
+        "name": "Curtsy lunges",
+        "description": "The back foot crosses behind the standing leg in a curtsy. Targets the glute medius and adductors more, working lateral hip stability in a rarely trained plane of motion."
+      },
+      {
+        "name": "Lateral lunges",
+        "description": "The step goes to the side instead of forward. Engages adductors and abductors in addition to quads and glutes. Excellent for hip mobility and preparation for lateral sports movements."
+      },
+      {
+        "name": "Walking lunges",
+        "description": "Chain lunges by stepping forward continuously, like walking. The continuous motion adds a dynamic balance challenge and increases the cardiovascular component. Requires a few metres of space."
+      },
+      {
+        "name": "Jump lunges",
+        "description": "Jump to switch legs in the lunge position. A plyometric version that develops explosiveness and spikes your heart rate quickly. Reserved for those who have mastered standard lunges and have no joint pain."
+      }
+    ],
+    "tips": [
+      "Keep your torso upright and eyes forward — the natural tendency is to lean forward as fatigue sets in",
+      "The front knee must stay aligned with your second toe: if it caves inward, consciously activate your glute",
+      "Take a long enough step: too short puts excessive pressure on the front knee; too long throws off your balance",
+      "If balance is an issue, start with reverse lunges or place your hands on your hips to lower your center of gravity"
+    ],
+    "commonMistakes": [
+      "Front knee diving past the toes or caving inward — shorten your step and push the knee outward",
+      "Torso leaning forward — keep your chest tall and shoulders over your hips",
+      "Step too short turning the lunge into a partial squat — the front shin should be nearly vertical at the bottom",
+      "Back foot flat on the floor — only the ball of the back foot touches the floor; the heel stays raised",
+      "Lowering too fast without control — control the eccentric phase over 2 seconds to protect the knees and maximize muscle work"
+    ]
+  },
+  "glute-bridge": {
+    "name": "Glute bridge",
+    "aliases": ["Hip thrust on floor", "Bridge"],
+    "muscles": ["Glutes", "Hamstrings", "Core (stabilization)"],
+    "shortDescription": "The go-to movement to activate and strengthen the glutes. Lying on the floor, you lift your hips by contracting your glutes — a simple, effective exercise accessible to all levels.",
+    "execution": "Lie on your back, knees bent, feet flat on the floor hip-width apart, positioned so your shins are vertical at the top. Arms along your body, palms down. Drive through your heels and squeeze your glutes to lift your hips until you form a straight line from shoulders to knees. Hold the contraction for one second at the top, squeezing your glutes as hard as possible. Lower slowly without fully setting your hips on the floor between reps to maintain tension. The movement comes from the hips — don't arch your lower back to go higher.",
+    "breathing": "Exhale as you lift your hips and squeeze your glutes. Inhale as you lower under control. This breathing pattern helps engage the core and stabilize the movement.",
+    "benefits": [
+      "Activates and strengthens the glutes, which are often underused due to prolonged sitting",
+      "Protects the lower back by strengthening the posterior chain",
+      "Improves hip stability and standing posture",
+      "A low-impact movement, accessible even with joint discomfort",
+      "Excellent warm-up exercise before more intense movements (squats, lunges)"
+    ],
+    "variants": [
+      {
+        "name": "Marching glute bridge",
+        "description": "In the top position of the bridge, extend one leg in front of you then place it back, and alternate. This variation adds unilateral work and a balance challenge that intensifies glute activation."
+      },
+      {
+        "name": "Hip thrust on floor",
+        "description": "Upper back resting on a sofa or bench, feet on the floor, lift your hips. The range of motion is greater and the position allows you to add weight (bag, dumbbell) on your hips to progress in load."
+      },
+      {
+        "name": "Unilateral hip thrust",
+        "description": "In the hip thrust position, only one foot on the floor, the other leg extended or knee pulled toward the chest. Doubles the load on the working leg and reveals strength imbalances between the two sides."
+      }
+    ],
+    "tips": [
+      "Drive through your heels, not your toes — you should be able to lift your toes off the floor",
+      "Squeeze your glutes as hard as possible at the top and hold for one second",
+      "Don't arch your lower back to rise higher — stop when your body forms a straight line",
+      "Position your feet so your shins are vertical at the top to maximize glute recruitment"
+    ],
+    "commonMistakes": [
+      "Pushing with your toes instead of your heels — shifts the work from glutes to quads",
+      "Arching the lower back at the top — a sign your hips are going too high. Stop when your body is aligned.",
+      "Not consciously contracting the glutes — the movement becomes passive and the hamstrings take over",
+      "Knees spreading or caving — keep them stable and aligned with your feet throughout",
+      "Rising and lowering too fast — control the tempo to maximize time under tension and muscle activation"
+    ]
+  },
+  "box-jumps": {
+    "name": "Box jumps (step)",
+    "aliases": ["Box jumps", "Step jumps"],
+    "muscles": ["Quads", "Glutes", "Calves", "Core"],
+    "shortDescription": "An accessible plyometric exercise that involves jumping onto a step or stable platform. Box jumps develop explosive leg power and coordination while teaching the body to produce force rapidly.",
+    "execution": "Stand facing a step or stable surface, feet shoulder-width apart, about 30 cm from the edge. Bend your knees while pushing your hips back (like a half squat) while swinging your arms back. Drive explosively into the floor and swing your arms forward and up to propel your body. Land on the step with both feet flat, knees bent to absorb impact. Stand fully upright at the top, hips open. Step back down in control (one foot at a time or with a slight backward hop) and chain the next rep.",
+    "breathing": "Take a quick breath before the jump, exhale during the push phase and flight. Breathe freely at the top of the step before stepping back down.",
+    "benefits": [
+      "Develops explosive lower-limb power in a functional and progressive way",
+      "Improves coordination, timing and dynamic proprioception",
+      "Strengthens quads, glutes and calves in plyometric mode",
+      "Teaches the body to absorb impacts correctly (landing quality)",
+      "Natural progression: simply increase the step height to advance"
+    ],
+    "variants": [
+      {
+        "name": "Broad jumps",
+        "description": "Standing long jump forward. Develops horizontal power and the ability to fully extend the posterior chain. Excellent for carry-over to athletic movements."
+      },
+      {
+        "name": "Tuck jumps",
+        "description": "Vertical jump with knees pulled toward the chest in the air. Increases air time and explosiveness. Requires good core control to maintain position in flight."
+      },
+      {
+        "name": "Squat jumps",
+        "description": "Explosive jump upward from a deep squat position, no platform needed. Combines squat strength work with jumping explosiveness. Very intense on the quads and glutes."
+      }
+    ],
+    "tips": [
+      "Start with a low step (15–20 cm) and progressively increase the height",
+      "Land with both feet simultaneously, knees bent — never landing on one foot",
+      "Use your arm swing to gain height: they play a key role in propulsion",
+      "Always step or jump back down under control — no uncontrolled backward jump that risks your ankles"
+    ],
+    "commonMistakes": [
+      "Landing on the tips of your toes at the edge of the step — land flat-footed in the center of the surface for stability",
+      "Knees caving inward on landing — push your knees outward as you land, just like a squat",
+      "Not opening your hips at the top — stand fully upright before stepping back down, otherwise the movement is incomplete",
+      "Using an unstable or too-high platform — safety over ego; choose a height you can control",
+      "Chaining reps by falling backward — step down in control each time to protect your Achilles tendons"
+    ]
+  },
+  "good-morning": {
+    "name": "Good morning",
+    "aliases": ["Good mornings"],
+    "muscles": ["Hamstrings", "Spinal erectors", "Glutes"],
+    "shortDescription": "A hip hinge exercise that deeply targets the posterior chain. The good morning strengthens the hamstrings, spinal erectors and glutes through a controlled forward trunk flexion — essential for back health and posture.",
+    "execution": "Stand with feet shoulder-width apart, knees slightly bent (never locked). Place your hands behind your head or crossed on your chest. Keeping your back perfectly straight and chest tall, hinge your torso forward by pushing your hips back, as if trying to touch the wall behind you with your glutes. Lower until you feel a strong stretch in your hamstrings (torso roughly parallel to the floor depending on your flexibility). Contract your glutes and hamstrings to return your torso upright by driving your hips forward. The movement comes from the hips, never the lower back.",
+    "breathing": "Inhale deeply as you hinge forward, exhale as you rise while contracting your glutes. Keep your abs engaged throughout to protect your spine.",
+    "benefits": [
+      "Strengthens the entire posterior chain: hamstrings, spinal erectors and glutes",
+      "Improves hip mobility and hamstring flexibility dynamically",
+      "Teaches the hip hinge motor pattern, fundamental for lifting objects in daily life",
+      "Prevents lower back pain by strengthening the spinal stabilizer muscles",
+      "Prepares you for more advanced movements like the deadlift and kettlebell swing"
+    ],
+    "variants": [
+      {
+        "name": "Single-leg Romanian deadlift",
+        "description": "The same hip hinge movement but on one leg, the free leg extending behind. Greatly increases balance work and hip stabilizer engagement."
+      },
+      {
+        "name": "Single-leg deadlift",
+        "description": "Similar to the unilateral Romanian deadlift with an even greater balance challenge. The free leg aligns with the torso to form a horizontal line. Excellent for correcting muscular imbalances between the two sides."
+      }
+    ],
+    "tips": [
+      "Maintain a slight knee bend throughout — locked knees place too much stress on the lower back",
+      "The movement comes from the hips, not the back: imagine your hips are a door hinge",
+      "Keep your gaze toward the floor about one metre in front of you to keep your neck aligned with your spine",
+      "Only lower as far as your back stays straight — never sacrifice posture for range of motion"
+    ],
+    "commonMistakes": [
+      "Back rounding on the way down — a sign you're going too low or your hamstrings lack flexibility. Reduce the range of motion.",
+      "Locked knees — always maintain a micro-bend to protect the lower back and allow free hip movement",
+      "Movement originating from the lower back instead of the hips — push your glutes back first; your torso follows naturally",
+      "Head lifting to look forward — keep your neck neutral; your gaze follows the movement of your torso",
+      "Uncontrolled fast descent — control the lowering phase over 2–3 seconds to maximize muscle work and protect your back"
+    ]
+  },
+  "gainage-planche": {
+    "name": "Plank",
+    "aliases": ["Plank hold", "Forearm plank", "Plank", "Bear crawl", "Hollow body hold"],
+    "muscles": ["Transverse abdominis", "Rectus abdominis", "Obliques", "Deltoids", "Spinal erectors"],
+    "shortDescription": "The foundational exercise for a strong core and a protected back. The forearm plank strengthens the deep abdominal belt without any movement: simply hold the position and resist gravity. A fundamental accessible to everyone.",
+    "execution": "On the floor, brace yourself on your forearms and the balls of your feet. Elbows placed directly under your shoulders, forearms parallel or hands clasped in front. Your body forms a straight line from head to heels: contract your abs by pulling your navel toward your spine, squeeze your glutes and push your heels backward. Eyes directed at the floor, between your hands, neck in line with your spine. Hold for the prescribed time while breathing steadily, never letting your hips sag or rise.",
+    "breathing": "Breathe normally and regularly through your nose and mouth. The natural tendency is to hold your breath — resist: use controlled diaphragmatic breathing, maintaining transverse contraction on each exhale.",
+    "benefits": [
+      "Strengthens the transverse abdominis, the deep muscle essential for core stability",
+      "Protects the lower back by improving posture control and intra-abdominal pressure",
+      "Engages the entire body isometrically: shoulders, back, glutes and thighs all contribute",
+      "No equipment needed and very low injury risk — accessible from day one",
+      "An essential foundation for all other exercises: push-ups, squats, burpees and everyday movements"
+    ],
+    "variants": [
+      {
+        "name": "Side plank",
+        "description": "Supported on one forearm and the outer edge of the foot, body in profile. Targets the obliques and glute medius to strengthen lateral core stability. Alternate sides for balanced work."
+      },
+      {
+        "name": "Side plank on knees",
+        "description": "Accessible version of the side plank: supported on the forearm and knee rather than the foot. Reduces leverage for beginners while still working the obliques and lateral stability. Ideal for building strength before progressing to the full version."
+      },
+      {
+        "name": "Superman plank",
+        "description": "In the standard plank position, extend your arms forward like Superman in flight. Greatly increases leverage and difficulty by engaging the spinal erectors and shoulders more."
+      },
+      {
+        "name": "Shoulder tap plank",
+        "description": "In a high plank, touch the opposite shoulder with each hand alternately. Adds an anti-rotation challenge: the core must resist twisting while you lift one hand."
+      },
+      {
+        "name": "RKC plank",
+        "description": "Forearm plank with maximum full-body tension: try to bring your elbows toward your feet (without moving), make fists and contract every muscle. Much more intense than a standard plank — 10 seconds RKC equals 30 seconds standard plank."
+      },
+      {
+        "name": "Bear hold",
+        "description": "On all fours, hands under shoulders, knees under hips, lift your knees 2–3 cm off the floor and hold. Works core stability in a shortened position that intensely engages the quads and transverse abdominis. An excellent transition exercise before the plank."
+      },
+      {
+        "name": "Hollow hold",
+        "description": "Lying on your back, arms extended overhead and legs extended, lift your shoulders and feet off the floor while pressing your lower back into the floor. A gymnastics position that powerfully strengthens the rectus abdominis and transverse in a supine position."
+      },
+      {
+        "name": "Plank to downward dog",
+        "description": "From a high plank, push your hips up and back into downward dog, then return to plank. The alternation trains shoulder mobility, hamstring flexibility and dynamic core stability. An excellent warm-up transition movement."
+      }
+    ],
+    "tips": [
+      "Think about pushing the floor away from you with your forearms — this active shoulder engagement protects the joint and increases muscle recruitment",
+      "Squeeze your glutes as hard as your abs: they prevent the pelvis from tilting forward",
+      "Prefer several short sets with good form (4 x 20 s) over one long set where posture breaks down",
+      "Shaking is normal and means the muscles are working — if your back arches, stop and rest"
+    ],
+    "commonMistakes": [
+      "Hips sagging toward the floor (lower back arch) — the most common sign of fatigue. Contract your abs and glutes or stop the set.",
+      "Hips piking up — makes the exercise easier but eliminates the core training benefit. Your body must remain a straight line.",
+      "Elbows placed too far in front of your shoulders — places excessive strain on the shoulders. Elbows must be directly under the joints.",
+      "Head lifting to look forward — compresses the cervical spine. Keep your gaze at the floor, neck neutral in line with your spine.",
+      "Holding your breath — raises blood pressure and limits how long you can hold. Breathe calmly and steadily."
+    ]
+  },
+  "crunchs": {
+    "name": "Crunches",
+    "aliases": ["Crunch", "Abs", "Bicycle crunches"],
+    "muscles": ["Rectus abdominis", "Obliques"],
+    "shortDescription": "The basic movement to target the abs. The crunch isolates the rectus abdominis through a short, controlled trunk flexion — no momentum, no neck pulling. Simple in appearance, it demands a genuine mind-muscle connection to be effective.",
+    "execution": "Lie on your back, knees bent, feet flat on the floor hip-width apart. Place your hands behind your head (fingers lightly touching your ears, not pulling your neck) or crossed on your chest. Contract your abs to lift your shoulders and upper back off the floor by curling your torso toward your pelvis. Rise until you feel maximum ab contraction (about 30 degrees), pause at the top, then lower slowly without fully resting your shoulders on the floor. Your lower back stays pressed to the floor throughout.",
+    "breathing": "Exhale on the way up (blow hard, belly drawn in toward your spine) and inhale on the way down. Forced exhalation on the contraction activates the transverse abdominis and maximizes ab recruitment.",
+    "benefits": [
+      "Effectively isolates the rectus abdominis without equipment",
+      "Strengthens the abdominal belt for better daily posture",
+      "An accessible movement that adapts to all levels with its many variations",
+      "Low joint stress compared to full sit-ups",
+      "Improves the mind-muscle connection in the abdominal area"
+    ],
+    "variants": [
+      {
+        "name": "Bicycle crunches",
+        "description": "In a crunch position, bring your right elbow toward your left knee while your right leg extends, then alternate. The rotational pedaling intensely engages the obliques in addition to the rectus abdominis."
+      },
+      {
+        "name": "Sit-ups",
+        "description": "Full rise of the torso to a seated position, with the entire back lifting off the floor. A more complete movement that recruits the hip flexors in addition to the abs, but more demanding on the lower back."
+      },
+      {
+        "name": "V-ups",
+        "description": "Legs and torso rise simultaneously to form a V, hands reaching for the feet. An advanced variation requiring abdominal strength and hamstring flexibility."
+      },
+      {
+        "name": "Russian twists",
+        "description": "Seated balancing on your glutes, feet off the floor, rotate your torso left and right. Targets the obliques and transverse with dynamic anti-rotation work."
+      },
+      {
+        "name": "Toe touches",
+        "description": "Lying on your back, legs extended vertically, reach your hands up to touch your toes. The short, targeted movement isolates the upper portion of the rectus abdominis with an intense contraction."
+      }
+    ],
+    "tips": [
+      "Keep a fist's distance between your chin and your chest to protect your neck",
+      "Focus on bringing your ribs toward your pelvis, not on how high you rise",
+      "Keep your lower back pressed to the floor: if it arches, your abs have let go",
+      "Slow down the descent (2–3 seconds) to double the time under tension"
+    ],
+    "commonMistakes": [
+      "Pulling on your neck with your hands — ease the finger pressure; they only support the head without pulling it",
+      "Rising too high by lifting the lower back off the floor — a crunch is a short movement, not a sit-up",
+      "Using momentum to chain reps — each rise must be initiated by the ab contraction, not a swing",
+      "Puffing the belly on the way up — the belly must draw inward at the effort to engage the transverse abdominis",
+      "Fully resting your shoulders between reps — maintain continuous tension by staying slightly lifted"
+    ]
+  },
+  "superman": {
+    "name": "Superman",
+    "aliases": ["Alternating superman", "Back extension on floor"],
+    "muscles": ["Spinal erectors", "Glutes", "Traps", "Rhomboids", "Rear deltoids"],
+    "shortDescription": "The antidote to hours spent sitting. The superman strengthens the entire posterior chain in a single floor movement. By lifting your arms and legs simultaneously, you work the spinal erectors, glutes and upper back for a strong back and upright posture.",
+    "execution": "Lie face down, arms extended in front of you (superman-in-flight position), legs extended and together. Your forehead can rest on the floor or stay slightly raised. Contract your glutes and back muscles simultaneously to lift your arms, chest and legs off the floor. Rise as high as your mobility allows without straining your lower back, keeping your gaze toward the floor (neck neutral). Hold the top position 1–2 seconds while squeezing your shoulder blades together, then lower slowly. The movement comes from the glutes and back, not from a lower-back jerk.",
+    "breathing": "Inhale at the bottom to prepare, exhale as you rise while contracting your back and glutes. Maintain fluid breathing if you hold the position isometrically.",
+    "benefits": [
+      "Strengthens the entire posterior chain: spinal erectors, glutes, upper back",
+      "Corrects posture by counterbalancing the effects of prolonged sitting",
+      "Prevents lower back pain by building endurance in the spinal stabilizer muscles",
+      "No equipment needed, can be done on any flat surface",
+      "Improves proprioception and coordination between the upper and lower body"
+    ],
+    "variants": [
+      {
+        "name": "Alternating superman",
+        "description": "Lift your right arm and left leg simultaneously, then alternate. Reduces difficulty and adds anti-rotation hip stabilization work."
+      },
+      {
+        "name": "Back extensions",
+        "description": "Only the upper body lifts; legs remain on the floor. Focuses work on the spinal erectors and upper back — ideal for beginners or as a pre-fatigue exercise."
+      },
+      {
+        "name": "Reverse hyper on table",
+        "description": "Lying face down at the edge of a table, hips supported, lift your legs toward horizontal. Targets the glutes and lower back with greater range of motion and no disc compression."
+      },
+      {
+        "name": "Reverse snow angels",
+        "description": "In a held superman position, arc your arms from in front to your hips and back. The continuous movement under tension burns the rhomboids and traps."
+      },
+      {
+        "name": "Prone T raises",
+        "description": "Face down, arms spread to the sides, lift them to form a T. Specifically targets the mid-traps and rhomboids — perfect for correcting rounded shoulders."
+      },
+      {
+        "name": "Prone Y raises",
+        "description": "Face down, arms extended forward at 45 degrees, lift them to form a Y. Recruits the lower traps and rear deltoids, reinforcing scapular stability."
+      }
+    ],
+    "tips": [
+      "Keep your gaze toward the floor to maintain neck neutrality — don't lift your head to look forward",
+      "Squeeze your shoulder blades together at the top as if you were trying to hold a pencil between them",
+      "Initiate the movement from your glutes, not from an excessive lower-back arch",
+      "Start with the alternating variation if the full superman causes tension in your lower back"
+    ],
+    "commonMistakes": [
+      "Lifting your head to look forward — creates cervical hyperextension. Keep your gaze at the floor, neck in line with your spine.",
+      "Forcing the rise by excessively arching your lower back — height comes from muscle contraction, not a back jerk. Limit range of motion if needed.",
+      "Bending your knees to lift your legs higher — keep your legs straight and let your glutes do the work",
+      "Letting your arms relax between reps — maintain slight tension in your upper back even at the bottom",
+      "Going too fast without controlling the movement — the superman is a control exercise, not a speed drill. Pause at the top."
+    ]
+  },
+  "leg-raises": {
+    "name": "Leg raises",
+    "aliases": ["Hanging leg raises"],
+    "muscles": ["Rectus abdominis (lower)", "Hip flexors", "Obliques (stabilization)"],
+    "shortDescription": "The reference exercise for targeting the lower abs. The leg raise requires real pelvic control to prevent the back from arching, making it a far more technical movement than it appears.",
+    "execution": "Lie on your back, arms alongside your body (palms down) or hands tucked under your glutes to stabilize your pelvis. Legs extended and together, lift your feet a few centimetres off the floor. Keeping your lower back pressed to the floor, raise your straight legs to vertical (90 degrees) by contracting your abs. Lower slowly, controlling the descent over 3–4 seconds, until your feet nearly touch the floor without touching it. If straight legs are too challenging, bend your knees slightly to reduce leverage. The key to the movement is never letting your lower back lift off the floor.",
+    "breathing": "Exhale as you raise your legs (belly drawn in, lower back pressed to floor); inhale as you lower. Forced exhalation on the way up helps maintain pelvic retroversion and protects the lower back.",
+    "benefits": [
+      "Targets the lower portion of the rectus abdominis, often underdeveloped compared to the upper portion",
+      "Strengthens hip flexors, essential for running and walking",
+      "Develops pelvic control and lumbar stabilization",
+      "A natural progression toward advanced movements (toes-to-bar, L-sit)",
+      "Improves body awareness and proprioception in the lumbo-pelvic region"
+    ],
+    "variants": [
+      {
+        "name": "Flutter kicks",
+        "description": "Legs extended a few centimetres off the floor, perform small rapid alternating kicks. Sustained tension with the lower back pressed to the floor burns the abs and hip flexors."
+      },
+      {
+        "name": "Scissors",
+        "description": "Legs extended off the floor, cross them alternately like scissors. The crossing motion adds an adduction component and oblique work to the abdominal holding effort."
+      }
+    ],
+    "tips": [
+      "Place your hands under your glutes if your back arches — it helps maintain pelvic retroversion",
+      "Control the descent: it's the eccentric phase that builds strength. If your legs drop, the load is too heavy.",
+      "Never touch the floor with your feet between reps to maintain continuous tension",
+      "Bend your knees slightly if straight legs cause tension in your lower back — movement quality trumps range of motion"
+    ],
+    "commonMistakes": [
+      "Lower back arching on the descent — the most common and dangerous error. Reduce range of motion or bend your knees until you can control your pelvic position.",
+      "Using momentum to raise the legs — each rise must be initiated by ab contraction, not a swing",
+      "Letting your legs fall under gravity — the descent must last at least 3–4 seconds. If you can't control it, reduce the range of motion.",
+      "Pulling on your neck or lifting your head — keep your head resting on the floor, neck relaxed; the work is in your abs, not your neck",
+      "Reflexively holding your breath — breath-holding uncontrollably increases intra-abdominal pressure and prevents effective core engagement"
+    ]
+  },
+  "dead-bug": {
+    "name": "Dead bug",
+    "aliases": ["Bird dog"],
+    "muscles": ["Transverse abdominis", "Rectus abdominis", "Obliques", "Hip flexors"],
+    "shortDescription": "An anti-extension core exercise performed lying on your back. The dead bug teaches the body to stabilize the trunk while the arms and legs move — exactly what the core does in everyday life and sport.",
+    "execution": "Lie on your back, arms extended toward the ceiling directly over your shoulders, knees bent to 90° over your hips (shins parallel to the floor). Before moving, press your lower back into the floor by contracting your abs — this contact must never be lost. Simultaneously extend your right arm overhead and your left leg toward the floor, without either touching the floor. Return to the starting position then repeat on the opposite side. The movement is slow and controlled — each rep lasts 3–4 seconds. If your lower back lifts off the floor, reduce your range of motion.",
+    "breathing": "Exhale slowly as you extend the opposite arm and leg — this exhalation helps press your lower back to the floor. Inhale as you return to the starting position.",
+    "benefits": [
+      "Strengthens the core in anti-extension, the most functional stabilization pattern",
+      "Teaches limb-trunk dissociation: moving arms and legs without compensating with the back",
+      "Extremely gentle on the back — recommended in rehabilitation and lower back pain prevention",
+      "Improves contralateral coordination (right arm / left leg) essential in running and walking",
+      "An excellent warm-up exercise to prepare the core before more intense movements"
+    ],
+    "variants": [],
+    "tips": [
+      "Your lower back must remain pressed to the floor at all times — this IS the quality criterion for the movement",
+      "Go slow: 3–4 seconds per extension, 2 seconds to return. Speed is the enemy of the dead bug.",
+      "If you can't keep your back on the floor, reduce range of motion: don't lower your arm and leg as far",
+      "Focus on exhaling during extension — it naturally locks your trunk position"
+    ],
+    "commonMistakes": [
+      "Lower back lifting off the floor — a sign the range of motion is too great or the core isn't engaged enough. Reduce the movement.",
+      "Going too fast — the dead bug is a control exercise, not a speed drill. Each rep must be deliberate.",
+      "Moving the arm and leg on the same side (ipsilateral) instead of opposite sides (contralateral)",
+      "Holding your breath — exhaling during extension is essential to maintain trunk stability",
+      "Neglecting the return phase — bring your arm and leg back with the same control as the extension"
+    ]
+  },
+  "mountain-climbers": {
+    "name": "Mountain climbers",
+    "aliases": ["Mountain climber", "Spider-Man mountain climbers"],
+    "muscles": ["Core", "Shoulders", "Quads", "Hip flexors"],
+    "shortDescription": "An explosive cardio exercise performed in a plank position. Mountain climbers combine core stability, leg work and cardiovascular endurance in a fast, rhythmic movement that spikes your heart rate within seconds.",
+    "execution": "Get into a high plank: hands under your shoulders, arms extended, body aligned from head to heels. Drive one knee toward your chest by contracting your abs, then send it back while simultaneously bringing the other knee toward your chest. Alternate your legs rapidly in a horizontal running motion. Hips stay low and stable — they must neither pike up nor bounce up and down. Keep your shoulders over your wrists and your gaze at the floor, slightly in front of your hands.",
+    "breathing": "Adopt a natural, steady breathing rhythm matched to your leg movement: inhale over a two-stride cycle, exhale over the next. Never hold your breath even as the pace increases.",
+    "benefits": [
+      "Spikes your heart rate very quickly with no equipment",
+      "Strengthens dynamic core stability by engaging the core under instability",
+      "Works hip flexors and quads in explosive mode",
+      "Improves coordination and agility through rapid leg alternation",
+      "Easily integrated into a circuit or HIIT as a high-intensity burst"
+    ],
+    "variants": [],
+    "tips": [
+      "Start slow to master the plank position before picking up speed",
+      "Lock your shoulders over your wrists — don't let your torso drift back",
+      "Keep your abs contracted throughout to prevent your hips from bouncing",
+      "Prefer a steady, sustained pace over uncontrolled bursts followed by breaks"
+    ],
+    "commonMistakes": [
+      "Hips piking up — a sign the core is letting go. Lower your hips to shoulder level.",
+      "Hips bouncing up and down — keep the pelvis stable by contracting your core",
+      "Shoulders drifting behind your wrists — keep your hands directly under your shoulders",
+      "Feet dragging on the floor instead of lifting — drive your knees with energy, as in a run",
+      "Holding your breath — breathe fluidly and continuously, even at high intensity"
+    ]
+  },
+  "jumping-jacks": {
+    "name": "Jumping jacks",
+    "aliases": ["Jumping jack"],
+    "muscles": ["Deltoids", "Calves", "Quads", "Adductors"],
+    "shortDescription": "The classic warm-up exercise. Jumping jacks combine a jump with a simultaneous spread of arms and legs in a rhythmic movement that quickly activates the cardiovascular system. Simple, effective and accessible to all levels.",
+    "execution": "Stand with feet together, arms at your sides. In a single jump, spread your feet to about one and a half times shoulder-width while raising your arms laterally overhead (hands meet or nearly meet at the top). Return to the starting position with a second jump: feet together, arms at your sides. The movement is fluid and continuous; arms and legs synchronize perfectly. Land on the balls of your feet with your knees slightly bent to absorb each jump.",
+    "breathing": "Inhale as you spread your arms and legs; exhale as you return to the starting position. Your breathing rhythm adapts naturally to the movement cadence — keep it fluid and steady.",
+    "benefits": [
+      "Full-body warm-up in seconds: simultaneously activates cardio, shoulders and legs",
+      "Improves arm-leg motor coordination and sense of rhythm",
+      "Zero equipment, zero complex technique: accessible from the very first session",
+      "Engages the adductors and deltoids, often undertrained in classic routines",
+      "Quickly raises heart rate to prepare the body for more intense effort"
+    ],
+    "variants": [
+      {
+        "name": "Star jumps",
+        "description": "Explosive jump where arms and legs spread as wide as possible in the air to form a star. More intense than standard jumping jacks, this variation develops power and engages glutes and shoulders more."
+      }
+    ],
+    "tips": [
+      "Keep your knees slightly bent on landing to protect your joints",
+      "Arms rise straight out to the sides, not in front of you — the movement comes from the shoulders",
+      "Stay on the balls of your feet, never land heel-first",
+      "Find a steady, sustainable rhythm rather than going maximum speed from the start"
+    ],
+    "commonMistakes": [
+      "Landing on your heels — creates excessive impact on knees and ankles. Stay on the balls of your feet.",
+      "Arms passing in front of the body instead of rising laterally — reduces deltoid work and breaks the rhythm",
+      "Stiff knees on landing — always bend your knees slightly to absorb the impact",
+      "Too small a range of motion (hands don't reach overhead) — perform the full movement for effective work",
+      "Irregular or jerky rhythm — maintain a constant, fluid cadence to maximize the cardiovascular effect"
+    ]
+  },
+  "high-knees": {
+    "name": "High knees",
+    "aliases": ["Running in place", "High knee run", "Butt kicks", "Sprint on spot", "Heel kicks", "Skipping"],
+    "muscles": ["Hip flexors", "Quads", "Calves", "Core"],
+    "shortDescription": "A dynamic cardio exercise that mimics running in place with knees driven high. High knees intensely work the hip flexors and core while spiking your heart rate within seconds.",
+    "execution": "Stand with feet hip-width apart, arms bent at 90° as in a sprint position. Drive one knee up to hip height (thigh parallel to the floor or higher) while pumping the opposite arm forward. Plant your foot and immediately drive the other knee up. The movement is fast and dynamic, like high-frequency running in place. Stay on the balls of your feet, torso slightly forward and abs engaged to stabilize the pelvis.",
+    "breathing": "Breathe rhythmically and shortly, as in a sprint: two counts in, two counts out. Avoid holding your breath, even as intensity rises.",
+    "benefits": [
+      "Explodes your heart rate in seconds — perfect for high-intensity intervals",
+      "Strengthens hip flexors, a key muscle group for running and daily mobility",
+      "Works arm-leg coordination and dynamic proprioception",
+      "Strongly engages core stability to stabilize the pelvis with each knee drive",
+      "Improves foot speed and muscular reactivity in the lower limbs"
+    ],
+    "variants": [
+      {
+        "name": "Butt kicks",
+        "description": "Instead of driving your knees up, your heels kick back toward your glutes. Targets the hamstrings and calves more while reducing stress on the hip flexors."
+      }
+    ],
+    "tips": [
+      "Drive knees to at least hip height — below that, the exercise loses its purpose",
+      "Keep your torso upright or very slightly forward, not leaning back",
+      "Use your arms actively: they set the rhythm and help drive the knees",
+      "Start at a moderate pace and progressively increase speed over the first few reps"
+    ],
+    "commonMistakes": [
+      "Knees not rising high enough — the thigh must reach parallel to the floor for effective hip flexor work",
+      "Torso leaning back to compensate — a sign of weak hip flexors. Reduce speed and keep the core engaged.",
+      "Landing on your heels — stay on the balls of your feet to protect your joints and maintain dynamism",
+      "Arms still at your sides — opposite arms must accompany the movement for coordination and balance",
+      "Too fast a pace at the expense of range of motion — better to drive high and go slightly slower than to shuffle with no amplitude"
+    ]
+  },
+  "skaters": {
+    "name": "Skaters",
+    "aliases": ["Skater", "Speed skaters", "Lateral skaters"],
+    "muscles": ["Glutes", "Quads", "Adductors", "Calves"],
+    "shortDescription": "A lateral cardio exercise inspired by the speed skater's movement. Skaters develop leg power, single-leg balance and hip stability in an explosive, fluid motion.",
+    "execution": "Stand upright, shift your weight onto your right leg and push laterally to the left, leaving the floor. Land on your left foot, knee slightly bent, bringing your right leg behind your standing leg (foot barely touching the floor or not at all). Simultaneously, your right arm swings forward and your left arm swings back, like a skater. Immediately push back to the right. The movement is continuous, fluid and controlled: each landing is cushioned by a knee bend before exploding in the other direction.",
+    "breathing": "Exhale on each lateral push, inhale briefly during the flight phase. Your breathing rhythm naturally syncs with the back-and-forth motion.",
+    "benefits": [
+      "Works lateral leg power, a movement plane often neglected in standard training",
+      "Strengthens the glutes and adductors dynamically and functionally",
+      "Develops single-leg balance and hip and ankle stability",
+      "High cardio effect with lower impact than vertical jumps",
+      "Improves agility and rapid direction-change ability"
+    ],
+    "variants": [
+      {
+        "name": "Lateral bounds",
+        "description": "Wider, more explosive lateral jumps with longer air time. Develops more power and lower-limb explosiveness. Requires good ankle stability."
+      },
+      {
+        "name": "Side shuffles",
+        "description": "Lateral gliding steps without a flight phase. Reduces joint impact while working the adductors and lateral coordination. Ideal for warm-ups or beginners."
+      }
+    ],
+    "tips": [
+      "Push hard through your standing leg into the floor — the explosiveness of that push is what makes the quality of the movement",
+      "Bend your knee on landing to absorb impact and prepare for the next push",
+      "Keep your torso slightly forward, like a real skater — it helps your balance",
+      "Start with moderate amplitude and progressively increase the width of your jumps"
+    ],
+    "commonMistakes": [
+      "Landing with a straight leg — always bend your knee on landing to protect your joints and maintain balance",
+      "Torso too upright — lean slightly forward to lower your center of gravity and improve stability",
+      "Too little amplitude (small steps instead of real lateral jumps) — actually push into the floor to cover ground",
+      "Arms staying still — use the natural arm swing for balance and power",
+      "Landing knee collapsing inward (valgus) — focus on knee-foot alignment on every landing"
+    ]
+  },
+  "burpees": {
+    "name": "Burpees",
+    "aliases": ["Burpee", "Sprawls", "Sprawl", "Push-up burpees", "Tuck jump burpees", "Broad jump burpees"],
+    "muscles": ["Chest", "Quads", "Glutes", "Shoulders", "Triceps", "Core"],
+    "shortDescription": "The most complete and most dreaded bodyweight exercise. The burpee combines a push-up, a squat and a jump in a fluid movement that explodes your cardio and engages every muscle in your body.",
+    "execution": "Stand with feet shoulder-width apart. Squat down and place your hands on the floor in front of you. Jump your feet back to land in a push-up position. Perform a full push-up (chest to the floor). Jump your feet back toward your hands. Jump vertically, raising your arms overhead. Land softly and immediately chain the next rep.",
+    "breathing": "Inhale on the way down to the floor, exhale on the way back up and during the jump. Your breathing rhythm naturally adapts to the intensity — the key is to never hold your breath.",
+    "benefits": [
+      "Full-body work in a single movement: push, squat, jump, core",
+      "Simultaneously develops strength, endurance and power",
+      "Maximum cardio effect: raises heart rate in just a few reps",
+      "Burns a large number of calories by engaging major muscle chains",
+      "No equipment, minimal space required"
+    ],
+    "variants": [
+      {
+        "name": "Burpees without push-up",
+        "description": "Jump to plank and return without performing the push-up. Reduces difficulty while keeping the cardio effect. A good starting point to build endurance."
+      },
+      {
+        "name": "Burpees without jump",
+        "description": "Replace the final jump with a simple stand-up. Less joint impact — ideal in an apartment or for those with knee sensitivities."
+      },
+      {
+        "name": "Burpees with tuck jump",
+        "description": "The final jump is replaced by a tuck jump (knees to chest). An advanced version that increases explosiveness and cardiovascular demand."
+      }
+    ],
+    "tips": [
+      "Find a sustainable pace. A steady rhythm beats 5 fast burpees followed by 30 seconds gasping for breath",
+      "The push-up must be complete — if you can no longer do full push-ups, switch to burpees without push-up rather than cheating",
+      "Land softly on the balls of your feet, not stiff-legged",
+      "Keep your abs contracted throughout the floor phase to protect your lower back"
+    ],
+    "commonMistakes": [
+      "Skipping the push-up or doing a half push-up — it's an integral part of the movement",
+      "Lower back sagging in the plank position — brace your core before jumping your feet back",
+      "Landing with straight legs after the jump — bend your knees to absorb the impact",
+      "Going out too fast and collapsing after 4–5 reps — the burpee is a marathon, not a sprint",
+      "Forgetting to breathe — breath-holding under effort is the number-one trap with this exercise"
+    ]
+  },
+  "inchworms": {
+    "name": "Inchworms",
+    "aliases": ["Inchworm"],
+    "muscles": ["Shoulders", "Core", "Hamstrings (flexibility)", "Chest"],
+    "shortDescription": "A dynamic mobility exercise combining hand walking and hamstring stretching. The inchworm warms up your entire body by transitioning from standing to plank and back — perfect as a warm-up or active recovery.",
+    "execution": "Stand with feet together or slightly apart. Hinge forward and place your hands on the floor in front of your feet (bend your knees slightly if needed to reach the floor). Walk your hands out step by step until you reach a high plank, body aligned from head to heels. Pause in the plank, shoulders over wrists. Then walk your feet toward your hands in small steps, keeping your legs as straight as possible to stretch the hamstrings. Stand back up and chain the next rep. Each hand-to-foot transition must be fluid and controlled.",
+    "breathing": "Inhale as you walk your hands forward; exhale as you walk your feet toward your hands. Maintain a calm, regular breathing rhythm — this exercise is not a sprint.",
+    "benefits": [
+      "Warms up your entire body in a single fluid movement: shoulders, core, hamstrings",
+      "Improves dynamic hamstring and calf flexibility",
+      "Strengthens shoulders and core in the plank position with each rep",
+      "Prepares joints and muscles for more intense movements",
+      "A slow, controlled movement that can serve as active recovery between intense sets"
+    ],
+    "variants": [],
+    "tips": [
+      "Keep your legs as straight as possible when walking your feet in — that's where the stretch happens",
+      "Don't rush: the inchworm is a mobility exercise, not a speed drill",
+      "In the plank position, verify your shoulders are directly over your wrists before moving on",
+      "If you can't touch the floor with straight legs, bend your knees slightly — flexibility will come with practice"
+    ],
+    "commonMistakes": [
+      "Rushing through the transitions — each phase (hand walk, plank, foot walk) deserves control",
+      "Excessively bending the knees when walking feet in — the goal is to feel the hamstring stretch",
+      "Hips rising or dropping in the plank — maintain head-to-heel alignment as in a static plank",
+      "Skipping the plank pause — don't just pass through; stabilize for a second in the plank",
+      "Hands walking too far past the shoulders — in the plank, wrists must be under the shoulders"
+    ]
+  },
+  "etirements": {
+    "name": "Stretches",
+    "aliases": ["Stretching", "Static stretching", "Twist", "Cobra", "Savasana", "Cool-down"],
+    "muscles": ["Hamstrings", "Quads", "Chest", "Hip flexors", "Triceps"],
+    "shortDescription": "Static stretches at the end of a session return muscles to their resting length, improve flexibility and promote recovery. Each position is held for 20–30 seconds while breathing calmly.",
+    "execution": "Move into each stretch position slowly, without jerking. Hold the posture for 20–30 seconds while breathing deeply. You should feel a moderate tension, never pain. Release gently and move to the next stretch. For unilateral stretches, always work both sides, holding for the same duration on each side.",
+    "breathing": "Breathe slowly and deeply through your nose. With each exhale, release a little more muscular tension to gain range of motion. Never hold your breath.",
+    "benefits": [
+      "Improves muscular flexibility and joint range of motion",
+      "Promotes recovery by reducing post-workout tension",
+      "Decreases injury risk by maintaining tissue elasticity",
+      "Reduces soreness and muscle stiffness the next day",
+      "A cool-down moment that helps the transition to rest"
+    ],
+    "variants": [
+      {
+        "name": "Hamstring stretch",
+        "description": "One leg extended on a low support or on the floor in front of you, hinge your torso forward keeping your back straight until you feel the stretch at the back of the thigh. Hold 20–30 seconds on each side."
+      },
+      {
+        "name": "Chest stretch",
+        "description": "One arm extended against a wall or doorframe at 90°, slowly rotate your torso away until you feel the stretch across your chest and the front of your shoulder. Hold 20–30 seconds on each side."
+      },
+      {
+        "name": "Hip flexor stretch",
+        "description": "In a low lunge position, rear knee on the floor, push your hips forward until you feel the stretch at the front of the rear hip. Keep your torso upright. Hold 20–30 seconds on each side."
+      },
+      {
+        "name": "Standing quad stretch",
+        "description": "Standing on one leg, grab the foot of the other leg behind you and pull the heel toward your glute, keeping knees together. Keep your pelvis neutral. Hold 20–30 seconds on each side."
+      },
+      {
+        "name": "Triceps stretch",
+        "description": "Raise one arm, bend your elbow to bring your hand behind your head between your shoulder blades. Use your other hand to gently push the elbow down. Hold 20–30 seconds on each side."
+      }
+    ],
+    "tips": [
+      "Always stretch warm muscles — never stretch cold at the start of a session",
+      "Seek the feeling of a stretch, not pain: if it hurts, ease off",
+      "Never bounce in a stretch: hold the position statically",
+      "Respect symmetry: always stretch both sides for the same duration"
+    ],
+    "commonMistakes": [
+      "Stretching cold before exercise — static stretches reduce performance if done before training",
+      "Forcing range of motion to the point of pain — a stretch should be comfortable, never painful",
+      "Bouncing or jerking in the position — increases the risk of micro-tears in the muscle",
+      "Holding for less than 15 seconds — below that, the stretch doesn't have time to produce a meaningful effect",
+      "Holding your breath — prevents muscular relaxation and increases tension"
+    ]
+  },
+  "mobilite": {
+    "name": "Joint mobility",
+    "aliases": [
+      "Mobility",
+      "Joint mobility",
+      "Cat-cow",
+      "Child's pose",
+      "Pigeon stretch",
+      "Scorpion stretches",
+      "Squat to stand",
+      "Thoracic rotation"
+    ],
+    "muscles": ["Hips", "Spine", "Shoulders", "Ankles"],
+    "shortDescription": "Mobility exercises improve joint range of motion and movement quality. They prepare the body for effort during warm-up and promote recovery at the end of a session.",
+    "execution": "Perform each mobility movement slowly and under control, exploring the full available range without forcing. Transition fluidly between positions while breathing steadily. Mobility work is not intense effort: it's a conversation with your body to identify and reduce movement restrictions.",
+    "breathing": "Breathe calmly and deeply. Use the exhale to release tension and gain range of motion. Your breathing guides the pace of movement.",
+    "benefits": [
+      "Improves joint range of motion and movement quality",
+      "Prevents injuries by preparing joints for effort",
+      "Reduces stiffness caused by sedentary behavior and prolonged sitting",
+      "Promotes recovery and reduces post-workout aches",
+      "Improves posture and body awareness in daily life"
+    ],
+    "variants": [
+      {
+        "name": "Cat-cow",
+        "description": "On all fours, slowly alternate between a rounded back (cat: head down, navel drawn in, back toward the ceiling) and an arched back (cow: head up, belly toward the floor, chest open). Mobilizes the entire spine segment by segment."
+      },
+      {
+        "name": "Child's pose",
+        "description": "Kneeling, sit back on your heels and extend your arms in front of you, forehead to the floor. Breathe deeply into your lower back. A rest and stretch position that releases the lower back, shoulders and hips."
+      },
+      {
+        "name": "Deep squat hold",
+        "description": "Hold a deep squat (hips close to the floor), feet flat, elbows against the inside of your knees to push them outward. Improves hip, ankle and lower back mobility. Hold 30–60 seconds."
+      },
+      {
+        "name": "Hip 90/90",
+        "description": "Seated on the floor, one leg bent to 90° in front of you (external hip rotation) and the other at 90° to the side (internal rotation). Pivot to alternate sides. Works hip rotation mobility in both directions."
+      },
+      {
+        "name": "Pigeon stretch",
+        "description": "From a lunge, bring your front shin to the floor in front of you (parallel or diagonal) and extend the back leg. Lean your torso forward to intensify the glute and piriform stretch. Hold 30 seconds on each side."
+      },
+      {
+        "name": "Scorpion stretch",
+        "description": "Lying face down, arms spread in a cross. Bring your right foot toward your left hand by rotating your hips, then alternate. Mobilizes the thoracic spine in rotation and stretches the hip flexors."
+      },
+      {
+        "name": "World's greatest stretch",
+        "description": "In a low lunge, place your inside hand on the floor, then rotate your torso by lifting your other arm toward the sky. Combines lunge, thoracic rotation and hip opening in a single complete movement. The king of warm-up exercises."
+      }
+    ],
+    "tips": [
+      "Practice mobility daily — even a few minutes is enough to maintain your gains",
+      "Respect your body's limits: mobility is built gradually, not by forcing",
+      "Pair joint mobility with deep breathing to maximize relaxation",
+      "Mobility exercises are perfect upon waking to 'wake up' your joints after the night"
+    ],
+    "commonMistakes": [
+      "Going too fast — mobility requires slowness to be effective. Take your time to explore each position.",
+      "Forcing range of motion beyond what your body allows — respect current limitations and progress gradually",
+      "Neglecting breathing — shallow breathing prevents the muscular relaxation needed",
+      "Only doing mobility when in pain — prevention is far more effective than correction",
+      "Confusing mobility and stretching — mobility is active and controlled movement, not passive holding"
+    ]
+  },
+  "echauffement": {
+    "name": "Dynamic warm-up",
+    "aliases": [
+      "Warm-up",
+      "Warm up",
+      "Arm circles",
+      "Breathing",
+      "Rotations",
+      "March",
+      "Running on the spot",
+      "Circles",
+      "Swings",
+      "A-skips",
+      "Carioca",
+      "Lateral shuffles"
+    ],
+    "muscles": ["Full body"],
+    "shortDescription": "Dynamic warm-up exercises prepare the body for effort by progressively raising core temperature, heart rate and joint lubrication. Essential before every session to perform well and prevent injuries.",
+    "execution": "Begin with slow, small movements, then progressively increase speed and intensity. The warm-up typically lasts 5–10 minutes. The goal is to feel your body temperature rise and your joints 'unlock' — you should be slightly out of breath at the end.",
+    "breathing": "Breathe naturally following the rhythm of the movements. Breathing accelerates progressively with intensity. Keep it fluid and steady.",
+    "benefits": [
+      "Raises core temperature and muscle blood flow",
+      "Prepares joints by stimulating synovial fluid production",
+      "Significantly reduces the risk of muscle and joint injuries",
+      "Improves performance by activating neuromuscular connections",
+      "Creates a mental transition between daily life and training"
+    ],
+    "variants": [
+      {
+        "name": "Joint circles",
+        "description": "Perform slow, controlled circles with each joint: neck, shoulders, elbows, wrists, hips, knees and ankles. Start small and progressively widen the circles. 10 rotations in each direction per joint."
+      },
+      {
+        "name": "Brisk march in place",
+        "description": "March vigorously in place, lifting your knees and swinging your arms in a coordinated way. Progressively raises your heart rate without impact. Perfect to start the warm-up before more intense movements."
+      },
+      {
+        "name": "Toe taps (step)",
+        "description": "Facing a low step or platform, alternately tap the ball of each foot on the edge. Keep a fast, steady rhythm, like quick running steps. Works coordination, agility and warms up calves and hip flexors."
+      },
+      {
+        "name": "Deep breathing",
+        "description": "Inhale slowly through your nose for 4 seconds, expanding your belly; hold for 4 seconds; then exhale through your mouth for 6 seconds. Used at the end of a session to bring the nervous system back to calm and accelerate recovery. 5–10 cycles is enough."
+      }
+    ],
+    "tips": [
+      "Never skip the warm-up — even 3 minutes is better than nothing",
+      "Adjust the intensity: the warm-up prepares you for effort, it must not tire you out",
+      "Target the areas that will be most taxed in the upcoming session",
+      "In winter or cold weather, extend the duration of the warm-up"
+    ],
+    "commonMistakes": [
+      "Jumping straight to intense exercises — your body needs at least 5 minutes to prepare",
+      "Using static stretches as a warm-up — the warm-up must be dynamic and active",
+      "Going too fast and too hard — the warm-up is progressive, not a sprint",
+      "Only warming up a few arm movements — your entire body needs warming up, from ankles to shoulders",
+      "Treating the warm-up as wasted time — it's an investment in performance and injury prevention"
+    ]
+  }
+}

--- a/src/i18n/locales/en/explore.json
+++ b/src/i18n/locales/en/explore.json
@@ -20,6 +20,11 @@
     "footer_note": "Durations shown include warm-up and cool-down.",
     "img_alt": "Format {{name}}"
   },
+  "format_page_meta": {
+    "doc_title": "{{name}} — Training format",
+    "doc_title_fallback": "Format",
+    "doc_description": "{{name}}: {{short}} Discover the principle, protocol, benefits and tips for this no-equipment training format."
+  },
   "format_page": {
     "back_aria": "Back to formats",
     "img_alt": "Format {{name}}",
@@ -48,6 +53,9 @@
   "exercise_page": {
     "back_aria": "Back to exercises",
     "demo_aria": "Demo: {{name}}",
+    "doc_title": "{{name}} — Exercise",
+    "doc_title_fallback": "Exercise",
+    "doc_description": "{{name}}: {{short}} Technique, variations, tips and common mistakes.",
     "section_execution": "Execution",
     "section_breathing": "Breathing",
     "section_benefits": "Benefits",

--- a/src/i18n/locales/en/formats_data.json
+++ b/src/i18n/locales/en/formats_data.json
@@ -1,0 +1,234 @@
+{
+  "pyramide": {
+    "name": "Pyramid",
+    "subtitle": "Progressive up-and-down",
+    "shortDescription": "Ascending then descending sets for a gradual increase in load.",
+    "principle": "The Pyramid format structures your workout around a progressive increase in reps (2, 4, 6, 8…) followed by a symmetrical descent. Intensity naturally rises with the rep count, then falls back down — letting your body warm up gradually without any sudden shock.",
+    "protocol": "Each exercise follows a pyramid scheme. For example: 2 reps → 4 reps → 6 reps → 8 reps → 6 reps → 4 reps → 2 reps. Rest between each level is short (15–30s). Work time per exercise is fixed; rep count climbs and descends.",
+    "benefits": [
+      "Warm-up built right in thanks to the ascending phase",
+      "Self-regulation: your body adapts at every level",
+      "Muscular endurance work at the higher rep counts",
+      "Cool-down made easy by the descending phase",
+      "Accessible to all fitness levels"
+    ],
+    "targetAudience": "Ideal for beginners and those getting back into exercise. The gradual ramp-up reduces injury risk and helps you find your pace. Also well-suited to intermediate athletes looking to build muscular endurance.",
+    "tips": [
+      "Focus on movement quality over speed, especially at the higher levels",
+      "Use the lower levels to dial in your breathing",
+      "If a level feels too hard, stay at the previous one rather than rushing through sloppy reps",
+      "The descent is not a cool-down: keep your technique locked in"
+    ],
+    "commonMistakes": [
+      "Going too fast on the early levels and burning out before the peak",
+      "Letting form slip as the rep count climbs",
+      "Skipping levels to finish faster",
+      "Not respecting the rest periods between levels"
+    ],
+    "card_description": "Reps go up at each step (2, 4, 6, 8…) then back down. Intensity rises and falls naturally.",
+    "card_benefit": "Self-regulated: the warmup is built into the ascent."
+  },
+  "renforcement": {
+    "name": "Strength Training",
+    "subtitle": "Classic sets",
+    "shortDescription": "Targeted work in classic sets with structured rest periods.",
+    "principle": "Classic strength training is the most traditional format in bodyweight fitness. Each exercise is performed in successive sets with a set rep count and rest time between sets. This format lets you target a specific muscle group and apply enough volume to drive consistent progress.",
+    "protocol": "Exercises are organized by muscle group (upper body, lower body, core). Each exercise is performed for 3–4 sets of 8–15 reps, with 30–60 seconds of rest between sets. Workouts alternate between push days (push-ups, dips, shoulders) and pull/leg days (squats, lunges, glute bridges).",
+    "benefits": [
+      "Targeted development of strength and muscle",
+      "Measurable progress: you can track rep improvements over time",
+      "Simple, familiar structure that's easy to follow",
+      "Adequate rest to maintain movement quality throughout",
+      "Adaptable to all levels by adjusting reps and sets"
+    ],
+    "targetAudience": "Suitable for all levels. Beginners will appreciate the clear structure and built-in rest. Advanced athletes can increase reps or move to harder variations (decline push-ups, pistol squats, etc.).",
+    "tips": [
+      "Prioritize full range of motion over speed",
+      "Use your rest periods to hydrate and breathe deeply",
+      "If you can't hold your form, reduce your reps rather than cheating",
+      "Alternate upper and lower body on consecutive days to allow recovery"
+    ],
+    "commonMistakes": [
+      "Cutting range of motion short to squeeze out more reps",
+      "Not respecting rest periods (too short or too long)",
+      "Always training the same muscle groups while neglecting others",
+      "Holding your breath during the effort"
+    ],
+    "card_description": "Targeted exercises in sets with rest. Upper body (push & pull) or lower body & core.",
+    "card_benefit": "Targeted toning. Clear, measurable progression."
+  },
+  "superset": {
+    "name": "Superset",
+    "subtitle": "Antagonist pairs",
+    "shortDescription": "Two complementary exercises back-to-back with no rest for balanced, efficient training.",
+    "principle": "A superset pairs two complementary exercises (typically antagonist muscles) with no rest between them. While one muscle works, the other recovers — effectively doubling your work volume in the same amount of time. Classic example: push-ups (chest) immediately followed by rows (back).",
+    "protocol": "Exercises are organized into complementary pairs. Each pair is performed for 3–4 sets. Within a pair, both exercises flow directly into each other with no break. Rest (30–60s) comes between pairs, not between exercises. This rhythm keeps effort high while allowing muscular recovery.",
+    "benefits": [
+      "Time efficiency: twice the work in the same time",
+      "Muscular balance through antagonist pairing",
+      "Elevated heart rate for a cardio effect",
+      "Active recovery: one muscle rests while the other works",
+      "Shorter overall session without sacrificing quality"
+    ],
+    "targetAudience": "For athletes who already have a solid technical foundation and want to optimize their training time. Cardiovascular demand is moderate but higher than classic strength training, making it a great stepping-stone format.",
+    "tips": [
+      "Pick pairs that target opposing muscle groups (push/pull, flexion/extension)",
+      "Transition quickly between exercises to preserve the superset effect",
+      "If fatigue is compromising your form, take a few seconds to reset",
+      "Hydrate during rest periods between pairs"
+    ],
+    "commonMistakes": [
+      "Resting too long between the two exercises in a pair, which kills the superset effect",
+      "Choosing two exercises that target the same muscle group",
+      "Letting form break down on the second exercise due to fatigue",
+      "Failing to adjust rep counts between the exercises in a pair"
+    ],
+    "card_description": "Two complementary exercises back-to-back with no rest (e.g. push-ups then pull). Rest between pairs.",
+    "card_benefit": "Balanced, efficient work in less time."
+  },
+  "emom": {
+    "name": "EMOM",
+    "subtitle": "Every Minute On the Minute",
+    "shortDescription": "Every minute, a task to complete. Whatever time is left is your rest.",
+    "principle": "EMOM (Every Minute On the Minute) sets a target number of reps to complete at the start of each minute. Once done, the remaining time before the next minute is your rest. The faster and more efficient you are, the more you recover. This format teaches effort management: going too fast burns you out, going too slow cuts your rest.",
+    "protocol": "The timer runs in one-minute intervals. On each minute mark, complete the prescribed reps (e.g., 10 squats + 5 push-ups). The remaining time is your rest. On the next mark, you go again. The EMOM block lasts 10–16 minutes, with a warm-up and cool-down on either end.",
+    "benefits": [
+      "Builds both muscular and cardiovascular endurance",
+      "Teaches effort pacing and rhythm management",
+      "Natural self-regulation: your rest automatically adjusts to your speed",
+      "Built-in motivation from the challenge of finishing before the minute ends",
+      "Clear, predictable structure that sharpens mental focus"
+    ],
+    "targetAudience": "Accessible to beginners if reps are well-calibrated (aim for 30–40s of work per minute, leaving 20–30s of rest). Advanced athletes can increase volume or movement difficulty.",
+    "tips": [
+      "Aim for a steady pace rather than going all-out on the first minute",
+      "If you finish with less than 10 seconds of rest, reduce your reps",
+      "Use the rest to breathe deeply and reset mentally",
+      "Keep one eye on the clock so you're ready for the next minute"
+    ],
+    "commonMistakes": [
+      "Starting too fast in the first few minutes and running out of rest entirely",
+      "Rushing the last reps to steal a bit more rest",
+      "Not adjusting volume when rest starts disappearing",
+      "Losing count of reps in the rush"
+    ],
+    "card_description": "At the start of every minute, do a set number of reps. Remaining time = rest.",
+    "card_benefit": "Builds endurance and teaches effort pacing."
+  },
+  "circuit": {
+    "name": "Circuit Training",
+    "subtitle": "Full-body sequence",
+    "shortDescription": "A rotating loop of varied exercises blending strength and cardio.",
+    "principle": "Circuit training chains multiple different exercises together with minimal rest between them. Each exercise targets a different muscle group or physical quality, allowing you to sustain overall effort while each muscle partially recovers. The circuit is repeated for multiple rounds to build total volume.",
+    "protocol": "A typical circuit includes 4–6 varied exercises (upper body, lower body, core, cardio). Each exercise is performed for 30–45 seconds or a set number of reps. Rest between exercises is brief (10–15s transition). Rest between rounds is 60–90 seconds. Sessions typically include 3–5 rounds.",
+    "benefits": [
+      "Full-body workout in a single session",
+      "Effective combination of strength and cardio",
+      "Exercise variety keeps motivation and engagement high",
+      "Adjustable intensity: tweak the number of rounds and rest times",
+      "Burns plenty of calories by keeping heart rate elevated"
+    ],
+    "targetAudience": "A versatile format suited to intermediate fitness levels. Beginners can ease in by extending rest periods. It's the go-to format when you want a complete workout without specializing.",
+    "tips": [
+      "Alternate muscle groups in the circuit order to prevent local fatigue",
+      "Keep a steady pace rather than alternating sprints with long breaks",
+      "Treat the first round as your warm-up: ramp up intensity gradually",
+      "If an exercise is too hard, drop to an easier variation rather than skipping it"
+    ],
+    "commonMistakes": [
+      "Placing two exercises that target the same muscle back-to-back",
+      "Sprinting through early rounds then collapsing on the last ones",
+      "Cutting rest so short that technique breaks down",
+      "Neglecting core or mobility exercises in the circuit"
+    ],
+    "card_description": "A chain of varied exercises with very little rest. The circuit is repeated multiple times.",
+    "card_benefit": "Combines strength and cardio for complete training."
+  },
+  "amrap": {
+    "name": "AMRAP",
+    "subtitle": "As Many Rounds As Possible",
+    "shortDescription": "Max rounds in the time cap. You control your own pace.",
+    "principle": "AMRAP (As Many Rounds As Possible) gives you a short exercise circuit and a time cap to fill. The goal: complete as many full rounds as possible before the clock runs out. Everyone moves at their own pace — there's no 'right' number of rounds, only your personal record to beat next time.",
+    "protocol": "A circuit of 3–5 exercises with a fixed rep count per exercise (e.g., 10 squats, 8 push-ups, 6 burpees). The clock runs continuously for 8–15 minutes. No prescribed rest: you manage your own breaks. At the end, count total rounds completed plus reps from the ongoing round.",
+    "benefits": [
+      "Objective measure of progress: round count is a clear performance indicator",
+      "Total pace freedom: everyone adapts to their own level",
+      "Personal-challenge motivation to beat your score",
+      "Builds the ability to sustain effort over time",
+      "Simple to understand and easy to follow"
+    ],
+    "targetAudience": "An excellent format for all levels. A beginner might complete 3 rounds while an advanced athlete gets 7 — both get a workout perfectly matched to their fitness. The score-based nature is highly motivating for competitive types.",
+    "tips": [
+      "Find a sustainable pace from round one and stick with it",
+      "A consistent pace beats a fast start followed by a crash",
+      "Record your score so you can compare it next time",
+      "Breathe between exercises rather than stopping completely"
+    ],
+    "commonMistakes": [
+      "Sprinting the first round and burning out within 3 minutes",
+      "Sacrificing technique to squeeze out extra reps",
+      "Taking long breaks between exercises instead of simply slowing the overall pace",
+      "Not tracking your score, which makes it impossible to measure progress"
+    ],
+    "card_description": "Repeat a circuit as many times as possible within the time cap. You set the pace.",
+    "card_benefit": "Pace freedom. Ideal to track your progress."
+  },
+  "hiit": {
+    "name": "HIIT",
+    "subtitle": "High-Intensity Interval Training",
+    "shortDescription": "Explosive efforts followed by short recovery. Short, intense, effective.",
+    "principle": "HIIT alternates between maximal-effort work phases and rest or active recovery. The goal is to push your body into its high-intensity zone during the work intervals, then recover just enough to go again. This format leverages the afterburn effect (EPOC): your body keeps burning calories for hours after the session.",
+    "protocol": "Typical intervals: 30 seconds of effort followed by 30 seconds of rest (1:1 ratio). Each round features one exercise performed at maximum intensity. Sessions include 8–12 rounds (8–12 minutes of pure HIIT), bookended by a warm-up and cool-down.",
+    "benefits": [
+      "Maximum efficiency: meaningful results in minimal time",
+      "Afterburn effect: metabolism stays elevated for hours post-workout",
+      "Rapid cardiovascular improvement",
+      "No equipment needed: bodyweight exercises are all it takes",
+      "Short format that fits easily into a packed schedule"
+    ],
+    "targetAudience": "Reserved for athletes who already have a solid baseline fitness level and have mastered the fundamental movement patterns. The high intensity demands a healthy cardiovascular system and strong body awareness to avoid injury.",
+    "tips": [
+      "Give everything during work phases — it's short, make it count",
+      "Use rest phases for active breathing, not phone-scrolling",
+      "Choose exercises you've fully mastered, because fatigue will degrade your form",
+      "Don't do HIIT two days in a row: your body needs time to recover"
+    ],
+    "commonMistakes": [
+      "Not pushing hard enough during work phases (the 'I' in HIIT stands for Intense)",
+      "Chaining HIIT sessions back-to-back without rest days",
+      "Choosing overly complex movements that become dangerous under fatigue",
+      "Skipping the warm-up because the session seems short"
+    ],
+    "card_description": "Alternating hard effort (30s) and rest (30s). Every exercise goes all-out.",
+    "card_benefit": "Maximum results in minimum time."
+  },
+  "tabata": {
+    "name": "Tabata",
+    "subtitle": "20/10 Protocol",
+    "shortDescription": "20 seconds all-out, 10 seconds of rest. The shortest and most intense format.",
+    "principle": "The Tabata protocol, developed by Dr. Izumi Tabata in 1996, is an ultra-short interval training format. The 2:1 work-to-rest ratio (20s effort / 10s rest) is designed to push the body to its absolute maximum. In just 4 minutes per set (8 rounds of 30 seconds), this protocol simultaneously develops both aerobic and anaerobic capacity.",
+    "protocol": "A classic Tabata set: 8 rounds of 20 seconds maximum effort followed by 10 seconds of rest. Total: 4 minutes. On Wan2Fit, Tabata sessions include 1–2 sets with 60 seconds of rest between sets. Effort during the 20 seconds must be truly maximal — if you can speak in full sentences, you're not pushing hard enough.",
+    "benefits": [
+      "The shortest format available: 4 minutes of intense work per set",
+      "Scientifically proven improvements in both aerobic and anaerobic capacity",
+      "Significant afterburn effect despite the short duration",
+      "Builds power, explosiveness, and endurance simultaneously",
+      "A mental challenge: learning to sustain intensity when your body wants to quit"
+    ],
+    "targetAudience": "Reserved for advanced athletes with excellent cardiovascular fitness. This is not a format for beginners. It demands flawless movement mastery, because 20 seconds of maximum effort under extreme fatigue requires impeccable technical control.",
+    "tips": [
+      "Choose simple, explosive movements (burpees, mountain climbers, jump squats)",
+      "The 10-second rest goes by fast: get into position immediately for the next round",
+      "Effort must be truly maximal — by the end of 8 rounds, you should be completely spent",
+      "Limit yourself to 1–2 Tabata sessions per week maximum"
+    ],
+    "commonMistakes": [
+      "Holding back 'just in case' — Tabata demands 100% effort every single round",
+      "Using complex movements that become dangerous under extreme fatigue",
+      "Doing Tabata sessions too frequently (more than twice a week)",
+      "Confusing Tabata with regular HIIT: 20/10 is significantly more intense than 30/30"
+    ],
+    "card_description": "8 rounds of 20 seconds max effort followed by 10 seconds rest. Short but intense.",
+    "card_benefit": "The shortest and most intense format."
+  }
+}

--- a/src/i18n/locales/en/programs.json
+++ b/src/i18n/locales/en/programs.json
@@ -59,6 +59,7 @@
   },
   "content": {
     "back_aria": "Back to programs",
+    "img_alt": "Program: {{headline}}",
     "stat_duration": "Duration",
     "stat_frequency": "Frequency",
     "stat_session_length": "Per session",

--- a/src/i18n/locales/en/programs_data.json
+++ b/src/i18n/locales/en/programs_data.json
@@ -1,0 +1,104 @@
+{
+  "debutant-4-semaines": {
+    "headline": "Build your foundations",
+    "intro": "Getting back into sport or starting out? This 4-week program guides you step by step. Each week adds a little more intensity so you progress without ever feeling overwhelmed.",
+    "audience": "Returning to activity, true beginners, or anyone who wants to (re)start on solid ground.",
+    "duration": "4 weeks",
+    "frequency": "3 sessions per week",
+    "sessionLength": "~25 min",
+    "approach": "The progression is designed so you don't skip steps. We start with simple movements and generous rest, then shorten the breaks and add fuller variations as the weeks go by.",
+    "weeks": [
+      {
+        "title": "Discovery",
+        "description": "Basic movements, 2 sets, generous rest. Learning the fundamental moves: squats, adapted push-ups, planks."
+      },
+      {
+        "title": "Building habits",
+        "description": "Same improved patterns, 2-3 sets, reps increasing. Your body starts to memorize the movements."
+      },
+      {
+        "title": "Progression",
+        "description": "Full variations (feet-elevated plank, standard push-ups), 3 sets. Introducing the EMOM format to learn effort management."
+      },
+      {
+        "title": "Consolidation",
+        "description": "Combined circuits, supersets, increased volume. You've mastered the basics and are ready for what's next."
+      }
+    ],
+    "benefits": [
+      "Learn the fundamental movements safely",
+      "Build a consistent training habit",
+      "Gain confidence and mobility",
+      "Prepare your body for more intense programs"
+    ],
+    "tip": "No need to push hard from day one. Consistency is what matters most. 3 sessions per week is enough to see real results in a month."
+  },
+  "remise-en-forme": {
+    "headline": "Find your rhythm back",
+    "intro": "You used to train but fell off the wagon? This program gets things back on track. Varied formats from the first week, progressive intensity — you'll find your feel quickly.",
+    "audience": "Former athletes getting back in shape, or intermediate-level people who want to structure their training.",
+    "duration": "4 weeks",
+    "frequency": "4 sessions per week",
+    "sessionLength": "~30 min",
+    "approach": "No discovery phase here: we dive straight in with varied formats. Each week alternates upper body, lower body, full-body, and cardio for a complete, balanced workout.",
+    "weeks": [
+      {
+        "title": "Active restart",
+        "description": "Targeted strength work and first circuits. We wake up the muscle groups with structured sessions."
+      },
+      {
+        "title": "Loading up",
+        "description": "Volume and intensity increase. Supersets and EMOM to build muscular endurance."
+      },
+      {
+        "title": "Intensity peak",
+        "description": "Demanding formats: AMRAP, HIIT. Your body is ready to be pushed. Sessions are shorter but more intense."
+      },
+      {
+        "title": "Mastery",
+        "description": "Advanced combinations, complex circuits. You finish the program in top shape, ready for a new challenge."
+      }
+    ],
+    "benefits": [
+      "Quickly regain a good level of fitness",
+      "Work your whole body in a balanced way",
+      "Discover multiple training formats",
+      "Kick-start your metabolism and endurance"
+    ],
+    "tip": "If a session feels easy, that's normal — it means you're in shape for it. The following week will raise the bar."
+  },
+  "cardio-express": {
+    "headline": "Short, intense, effective",
+    "intro": "No time for an hour of sport? This program bets on short, high-intensity sessions. 20 minutes is all it takes to sweat, progress, and get back to your day.",
+    "audience": "Busy schedules, athletes who want results without spending hours training.",
+    "duration": "4 weeks",
+    "frequency": "3 sessions per week",
+    "sessionLength": "~20 min",
+    "approach": "Every session uses formats designed to maximize effort in minimal time: HIIT, Tabata, EMOM. Intensity builds progressively so your cardio and explosiveness improve week after week.",
+    "weeks": [
+      {
+        "title": "Warm-up phase",
+        "description": "HIIT and classic intervals. We calibrate the intensity and establish the rhythm."
+      },
+      {
+        "title": "Acceleration",
+        "description": "Tabata and EMOM come into play. Rest periods shorten, cardio kicks up a notch."
+      },
+      {
+        "title": "High intensity",
+        "description": "Denser sessions, explosive combinations. Your heart is working at full capacity."
+      },
+      {
+        "title": "Full throttle",
+        "description": "The most intense sessions of the program. You measure your progress with timed formats."
+      }
+    ],
+    "benefits": [
+      "Improve your cardio in less time",
+      "Burn maximum calories in 20 minutes",
+      "Develop explosiveness and endurance",
+      "Train even with a packed schedule"
+    ],
+    "tip": "Intensity is the key. 20 minutes at full effort beats 45 minutes at half pace. Give everything during the work phases, and fully recover during the rest."
+  }
+}

--- a/src/i18n/locales/fr/exercises_data.json
+++ b/src/i18n/locales/fr/exercises_data.json
@@ -1,0 +1,1007 @@
+{
+  "pompes-classiques": {
+    "name": "Pompes classiques",
+    "aliases": ["Pompes", "Push-ups", "Scapular push-ups", "Pompes pike"],
+    "muscles": ["Pectoraux", "Triceps", "Deltoïdes antérieurs", "Core (stabilisation)"],
+    "shortDescription": "L'exercice fondamental du haut du corps au poids du corps. Les pompes développent la poussée horizontale en sollicitant pectoraux, triceps et épaules dans un mouvement complet et fonctionnel.",
+    "execution": "Position de départ : mains au sol légèrement plus larges que les épaules, bras tendus, corps aligné de la tête aux talons. Les pieds sont serrés ou légèrement écartés. Descendez en fléchissant les coudes jusqu'à ce que la poitrine frôle le sol (coudes à environ 45° du corps, pas écartés à 90°). Poussez pour revenir à la position initiale en verrouillant les bras. Le corps reste gainé tout au long du mouvement : pas de creux dans le dos, pas de fesses en l'air.",
+    "breathing": "Inspirez pendant la descente, expirez pendant la poussée. Ne bloquez jamais votre respiration, même quand l'effort devient intense.",
+    "benefits": [
+      "Renforce l'ensemble de la chaîne de poussée (pectoraux, triceps, épaules)",
+      "Travaille le gainage du tronc en position de planche dynamique",
+      "Ne nécessite aucun matériel et se pratique partout",
+      "Transfert direct vers les mouvements du quotidien (se relever, pousser une porte)",
+      "Des dizaines de variantes permettent de progresser indéfiniment"
+    ],
+    "variants": [
+      {
+        "name": "Pompes inclinées",
+        "description": "Mains sur un support surélevé (chaise, marche). Réduit la charge et facilite le mouvement — idéal pour débuter ou en fin de série quand la fatigue s'installe."
+      },
+      {
+        "name": "Pompes diamant",
+        "description": "Mains rapprochées sous la poitrine, pouces et index formant un losange. Augmente le travail des triceps et de la partie interne des pectoraux."
+      },
+      {
+        "name": "Pompes déclinées",
+        "description": "Pieds surélevés sur un support. Augmente la charge sur les épaules et la partie haute des pectoraux. Réservé aux pratiquants qui maîtrisent les pompes classiques."
+      },
+      {
+        "name": "Pompes explosives",
+        "description": "Poussée suffisamment puissante pour que les mains décollent du sol. Développe la puissance et la vitesse de contraction musculaire."
+      },
+      {
+        "name": "Pompes archer",
+        "description": "Un bras tendu sur le côté, l'autre bras effectue l'essentiel de la poussée. Développe la force unilatérale et prépare progressivement aux pompes à un bras."
+      },
+      {
+        "name": "Pompes commando",
+        "description": "Départ en planche sur les avant-bras, montée en planche bras tendus un bras après l'autre, puis redescente. Travaille la force de transition et la stabilité du tronc sous effort asymétrique."
+      },
+      {
+        "name": "Pompes Hindu",
+        "description": "Départ en position du chien tête en bas, le corps plonge vers l'avant en rasant le sol puis remonte en cobra. Mouvement dynamique qui combine souplesse, force et mobilité de la colonne."
+      },
+      {
+        "name": "Pompes larges",
+        "description": "Mains placées nettement plus larges que les épaules. Augmente le recrutement des pectoraux et réduit l'implication des triceps — idéal pour cibler la poitrine au poids du corps."
+      },
+      {
+        "name": "Pike push-ups",
+        "description": "Hanches hautes en V inversé, poussée verticale vers le sol. Cible les épaules de manière similaire à un développé militaire — excellente progression vers le handstand push-up."
+      },
+      {
+        "name": "Pompes scapulaires",
+        "description": "En position de planche bras tendus, seules les omoplates bougent (protraction et rétraction) sans fléchir les coudes. Renforce le dentelé antérieur et améliore la stabilité scapulaire."
+      }
+    ],
+    "tips": [
+      "Gardez les coudes à 45° du corps (ni collés, ni écartés à 90°) pour protéger les épaules",
+      "Serrez les abdos et les fessiers comme si vous teniez une planche — le corps ne doit pas « casser »",
+      "Descendez jusqu'en bas : les demi-pompes ne comptent pas et limitent la progression",
+      "Si vous n'arrivez pas à faire une pompe complète, commencez par les pompes inclinées plutôt que sur les genoux"
+    ],
+    "commonMistakes": [
+      "Le bassin qui s'affaisse (dos creux) — signe d'un gainage insuffisant. Contractez les abdos.",
+      "Les fesses qui montent en pic — raccourcit le mouvement et supprime le travail des pectoraux",
+      "Les coudes qui s'écartent à 90° — crée un stress excessif sur l'articulation de l'épaule",
+      "L'amplitude incomplète — ne pas descendre assez bas limite les gains de force et de mobilité",
+      "La tête qui tombe vers le sol — gardez le regard vers le sol, à 30 cm devant vos mains, nuque neutre"
+    ]
+  },
+  "dips-sur-chaise": {
+    "name": "Dips sur chaise",
+    "aliases": ["Dips", "Triceps dips"],
+    "muscles": ["Triceps", "Deltoïdes antérieurs", "Pectoraux (partie basse)"],
+    "shortDescription": "Un exercice de poussée verticale qui cible les triceps en utilisant une chaise ou un support stable. Les dips sur chaise sont l'un des meilleurs mouvements au poids du corps pour sculpter l'arrière des bras et renforcer la poussée.",
+    "execution": "Asseyez-vous au bord d'une chaise ou d'un banc stable, mains agrippées au rebord de chaque côté des hanches, doigts vers l'avant. Avancez les pieds pour décoller les fesses du support, bras tendus. Descendez en fléchissant les coudes vers l'arrière (pas vers l'extérieur) jusqu'à ce que vos bras forment un angle d'environ 90°. Poussez dans vos paumes pour remonter en verrouillant les bras en haut. Gardez le dos proche du support tout au long du mouvement — ne vous éloignez pas de la chaise. Les épaules restent basses et en arrière, loin des oreilles.",
+    "breathing": "Inspirez pendant la descente en contrôlant le mouvement. Expirez en poussant pour remonter. Ne bloquez pas votre respiration en position basse.",
+    "benefits": [
+      "Isole efficacement les triceps avec un mouvement naturel de poussée",
+      "Renforce les deltoïdes antérieurs et la partie basse des pectoraux",
+      "Ne nécessite qu'une chaise, un banc ou une marche — praticable partout",
+      "Développe la force de poussée verticale utile au quotidien",
+      "Intensité facilement modulable en ajustant la position des pieds"
+    ],
+    "variants": [],
+    "tips": [
+      "Utilisez un support parfaitement stable — une chaise qui glisse peut provoquer une chute",
+      "Gardez les coudes serrés et dirigés vers l'arrière, jamais vers l'extérieur",
+      "Pour faciliter le mouvement, rapprochez les pieds du support en fléchissant les genoux",
+      "Pour augmenter la difficulté, tendez les jambes ou surélevez les pieds sur un second support"
+    ],
+    "commonMistakes": [
+      "Les coudes qui s'écartent vers l'extérieur — gardez-les serrés et dirigés vers l'arrière pour protéger les épaules",
+      "Descendre trop bas (au-delà de 90°) — crée un stress excessif sur l'articulation de l'épaule",
+      "Les épaules qui montent vers les oreilles — tirez les omoplates vers le bas et l'arrière",
+      "Le dos qui s'éloigne de la chaise — restez proche du support pour maintenir le travail sur les triceps",
+      "Pousser avec les jambes au lieu des bras — les pieds sont un appui, pas le moteur du mouvement"
+    ]
+  },
+  "rowing-inverse": {
+    "name": "Rowing inverse (table)",
+    "aliases": ["Rowing inverse", "Inverted row"],
+    "muscles": ["Dorsaux", "Rhomboïdes", "Trapèzes", "Biceps", "Deltoïdes postérieurs"],
+    "shortDescription": "Le pendant inversé des pompes pour le haut du dos. Le rowing inverse sous une table ou une barre basse permet de travailler la traction horizontale au poids du corps en ciblant les dorsaux, les rhomboïdes et les biceps. Un exercice fondamental pour l'équilibre postural.",
+    "execution": "Allongez-vous sous une table solide (ou une barre basse) et saisissez le bord de la table avec les mains à largeur d'épaules, paumes vers vous ou en prise neutre. Le corps est aligné de la tête aux talons, bras tendus, talons au sol. En gardant le corps parfaitement gainé, tirez votre poitrine vers la table en serrant les omoplates l'une vers l'autre. Les coudes passent le long du corps (pas écartés). Montez jusqu'à ce que la poitrine touche ou s'approche de la table, marquez un temps d'arrêt en haut en contractant le haut du dos, puis redescendez lentement jusqu'à l'extension complète des bras.",
+    "breathing": "Expirez en tirant la poitrine vers la table, inspirez en redescendant de manière contrôlée. Gardez les abdominaux engagés pour maintenir l'alignement du corps pendant toute la série.",
+    "benefits": [
+      "Renforce l'ensemble de la chaîne de traction : dorsaux, rhomboïdes, trapèzes et biceps",
+      "Corrige les déséquilibres posturaux en ciblant les muscles du haut du dos souvent négligés",
+      "Prépare aux tractions classiques en développant la force de traction horizontale",
+      "Améliore la rétraction scapulaire, essentielle pour la santé des épaules",
+      "Ne nécessite qu'une table solide ou une barre basse — réalisable à la maison"
+    ],
+    "variants": [
+      {
+        "name": "Face pulls au sol",
+        "description": "Allongé sur le ventre, bras tendus devant vous, tirez les coudes vers l'arrière en serrant les omoplates. Isole le travail des rhomboïdes et des deltoïdes postérieurs sans aucun matériel. Excellent pour la posture et l'activation du haut du dos."
+      }
+    ],
+    "tips": [
+      "Choisissez une table bien stable et solide — testez-la avant de vous suspendre dessous",
+      "Serrez les omoplates en haut du mouvement et maintenez la contraction une seconde avant de redescendre",
+      "Plus vos pieds sont avancés (corps horizontal), plus l'exercice est difficile — ajustez en reculant les pieds pour réduire la charge",
+      "Gardez le corps rigide comme une planche : les fessiers et les abdos restent contractés tout au long du mouvement"
+    ],
+    "commonMistakes": [
+      "Le bassin qui s'affaisse — le corps doit rester aligné comme en planche. Contractez les fessiers et les abdominaux.",
+      "Les épaules qui montent vers les oreilles en tirant — abaissez les épaules et focalisez-vous sur le rapprochement des omoplates",
+      "L'amplitude incomplète — descendez bras tendus et montez poitrine contre la table. Les demi-répétitions ne comptent pas.",
+      "Les coudes qui s'écartent à 90° du corps — gardez-les à 45° maximum pour protéger les épaules et cibler les bons muscles",
+      "Utiliser l'élan en balançant les hanches — le mouvement doit être lent et contrôlé, seuls les bras et le dos travaillent"
+    ]
+  },
+  "squats": {
+    "name": "Squats",
+    "aliases": ["Squat", "Flexion de jambes", "Jump squats", "Speed squats"],
+    "muscles": ["Quadriceps", "Fessiers", "Ischio-jambiers", "Core (stabilisation)"],
+    "shortDescription": "Le mouvement roi du bas du corps. Le squat est un patron moteur fondamental qui sollicite l'ensemble de la chaîne inférieure : cuisses, fessiers et tronc. C'est le mouvement que vous faites chaque fois que vous vous asseyez et vous relevez.",
+    "execution": "Debout, pieds écartés à largeur d'épaules ou légèrement plus, pointes de pieds tournées vers l'extérieur (15-30°). Initiez le mouvement en poussant les hanches vers l'arrière comme pour vous asseoir sur une chaise. Descendez en gardant le poids sur les talons et le milieu du pied, genoux alignés avec les pointes de pieds. Descendez au moins jusqu'à ce que les cuisses soient parallèles au sol (ou plus bas si votre mobilité le permet). Poussez dans le sol pour remonter en contractant les fessiers en haut du mouvement.",
+    "breathing": "Inspirez profondément pendant la descente (le ventre se gonfle), expirez puissamment pendant la remontée. Sur les séries lourdes ou intenses, prenez une inspiration avant de descendre et expirez en passant le point le plus difficile de la remontée.",
+    "benefits": [
+      "Renforce l'ensemble du bas du corps : quadriceps, fessiers, ischio-jambiers",
+      "Améliore la mobilité des hanches, genoux et chevilles",
+      "Mouvement fonctionnel essentiel : s'asseoir, se relever, porter des charges",
+      "Sollicite fortement le gainage du tronc pour maintenir le dos droit",
+      "Stimule une réponse hormonale importante grâce à la masse musculaire engagée"
+    ],
+    "variants": [
+      {
+        "name": "Squats sumo",
+        "description": "Pieds très écartés, pointes vers l'extérieur. Cible davantage les adducteurs (intérieur des cuisses) et les fessiers. Plus facile en termes de mobilité de cheville."
+      },
+      {
+        "name": "Squats pulse",
+        "description": "Rester dans la partie basse du squat et effectuer de petits mouvements de rebond. Augmente le temps sous tension et brûle les quadriceps."
+      },
+      {
+        "name": "Squats sautés",
+        "description": "Ajouter un saut explosif à la remontée. Développe la puissance et le cardio. Réservé aux pratiquants sans problèmes articulaires aux genoux."
+      },
+      {
+        "name": "Pistol squat assisté",
+        "description": "Squat sur une jambe en se tenant à un support. Travaille l'équilibre, la force unilatérale et la mobilité. Objectif avancé à construire progressivement."
+      },
+      {
+        "name": "Squats 1.5",
+        "description": "Descente complète, remontée à mi-chemin, redescente, puis remontée complète — ça compte pour une seule répétition. Augmente considérablement le temps sous tension dans la partie basse du mouvement."
+      },
+      {
+        "name": "Pop squats",
+        "description": "Sautez pour écarter les pieds en squat large, puis sautez pour les ramener serrés. Combine travail cardio et renforcement des jambes dans un mouvement dynamique et rythmé."
+      },
+      {
+        "name": "Goblet squat (sans poids)",
+        "description": "Mains jointes devant la poitrine, coudes poussés entre les genoux en bas du mouvement. Aide à maintenir le buste droit et à gagner en profondeur de squat — excellent outil de correction technique."
+      },
+      {
+        "name": "Sissy squat",
+        "description": "Penchez le buste en arrière, poussez les genoux vers l'avant, talons décollés. Isole intensément les quadriceps. Mouvement avancé qui demande un bon équilibre et des genoux en bonne santé."
+      },
+      {
+        "name": "Wall sit",
+        "description": "Dos plaqué contre un mur, cuisses parallèles au sol, maintien en isométrie. Défi d'endurance pure pour les quadriceps — simple en apparence, redoutable après 30 secondes."
+      }
+    ],
+    "tips": [
+      "Poussez les genoux vers l'extérieur pendant la descente — ils ne doivent jamais rentrer vers l'intérieur",
+      "Gardez le poids sur les talons : vous devez pouvoir remuer les orteils à tout moment",
+      "Le dos reste droit et la poitrine ouverte. Imaginez que vous portez un logo sur le torse et que tout le monde doit le voir",
+      "Descendez au moins cuisses parallèles — les quarts de squat ne développent ni la force ni la mobilité"
+    ],
+    "commonMistakes": [
+      "Les genoux qui rentrent vers l'intérieur (valgus) — activez consciemment les fessiers pour pousser les genoux dehors",
+      "Les talons qui décollent du sol — signe d'un manque de mobilité de cheville. Travaillez la mobilité ou placez un petit support sous les talons",
+      "Le buste qui tombe trop vers l'avant — renforcez le haut du dos et le gainage. Essayez les squats goblet pour corriger",
+      "L'amplitude insuffisante — descendre à moitié prive le mouvement de ses principaux bénéfices",
+      "La vitesse excessive — contrôlez la descente (2-3 secondes) avant de remonter de manière dynamique"
+    ]
+  },
+  "fentes": {
+    "name": "Fentes avant",
+    "aliases": ["Fentes", "Lunges", "Fentes alternees", "Jump lunges", "Jumping lunges"],
+    "muscles": ["Quadriceps", "Fessiers", "Ischio-jambiers", "Mollets", "Core (stabilisation)"],
+    "shortDescription": "Le mouvement unilatéral incontournable pour des jambes puissantes et équilibrées. Les fentes sollicitent quadriceps, fessiers et ischio-jambiers tout en travaillant l'équilibre et la stabilité du bassin — un exercice complet qui corrige les déséquilibres entre jambe droite et jambe gauche.",
+    "execution": "Debout, pieds écartés à largeur de hanches, regard droit devant. Faites un grand pas en avant avec une jambe en gardant le buste droit et les abdos contractés. Fléchissez les deux genoux simultanément jusqu'à ce que le genou arrière frôle le sol (les deux genoux forment un angle d'environ 90°). Le genou avant reste aligné avec la pointe du pied, sans dépasser excessivement les orteils. Poussez fermement dans le talon du pied avant pour revenir à la position de départ. Alternez les jambes ou enchaînez toutes les répétitions d'un même côté selon la variante choisie.",
+    "breathing": "Inspirez pendant la descente en contrôlant le mouvement, expirez en poussant pour remonter. Gardez une respiration régulière et profonde — ne bloquez jamais le souffle, surtout en fin de série quand la fatigue s'installe.",
+    "benefits": [
+      "Développe la force unilatérale et corrige les déséquilibres musculaires entre les deux jambes",
+      "Sollicite intensément les fessiers, souvent sous-activés dans les mouvements bilatéraux comme le squat",
+      "Améliore l'équilibre, la proprioception et la stabilité du bassin",
+      "Renforce la mobilité des hanches et la souplesse des fléchisseurs de hanche",
+      "Transfert direct vers la marche, la course, la montée d'escaliers et les changements de direction"
+    ],
+    "variants": [
+      {
+        "name": "Fentes alternées",
+        "description": "Un pas en avant jambe droite, retour, puis un pas en avant jambe gauche. Permet de travailler les deux côtés de manière équilibrée dans la même série. Le retour à la position debout entre chaque répétition ajoute un travail de stabilisation."
+      },
+      {
+        "name": "Fentes arrière",
+        "description": "Le pas se fait vers l'arrière au lieu de vers l'avant. Plus douce pour les genoux car le poids reste naturellement sur le talon de la jambe d'appui. Idéale pour les pratiquants ayant des sensibilités au niveau des rotules."
+      },
+      {
+        "name": "Fentes avec pause",
+        "description": "Maintenez la position basse pendant 2 à 3 secondes avant de remonter. La pause élimine l'élan et augmente le temps sous tension, ce qui intensifie le travail musculaire des quadriceps et des fessiers."
+      },
+      {
+        "name": "Fentes bulgares",
+        "description": "Le pied arrière est surélevé sur une chaise ou un banc. Augmente considérablement la charge sur la jambe avant et l'étirement du fléchisseur de hanche arrière. Variante exigeante en force et en équilibre, réservée aux pratiquants à l'aise avec les fentes classiques."
+      },
+      {
+        "name": "Fentes curtsy",
+        "description": "Le pied arrière se croise derrière la jambe d'appui, comme une révérence. Cible davantage le moyen fessier et les adducteurs, travaillant la stabilité latérale du bassin dans un plan de mouvement rarement sollicité."
+      },
+      {
+        "name": "Fentes latérales",
+        "description": "Le pas se fait sur le côté au lieu de vers l'avant. Sollicite les adducteurs et les abducteurs en plus des quadriceps et fessiers. Excellent pour la mobilité des hanches et la préparation aux sports impliquant des déplacements latéraux."
+      },
+      {
+        "name": "Fentes marchées",
+        "description": "Enchaînez les fentes en avançant à chaque pas, comme une marche. Le mouvement continu ajoute un défi d'équilibre dynamique et augmente la composante cardiovasculaire de l'exercice. Nécessite un espace de quelques mètres."
+      },
+      {
+        "name": "Fentes sautées",
+        "description": "Effectuez un saut pour changer de jambe en position basse. Version plyométrique qui développe l'explosivité et fait monter le cardio rapidement. Réservée aux pratiquants maîtrisant parfaitement les fentes classiques et n'ayant aucune douleur articulaire."
+      }
+    ],
+    "tips": [
+      "Gardez le buste droit et le regard devant vous — la tendance naturelle est de se pencher vers l'avant quand la fatigue arrive",
+      "Le genou avant doit rester aligné avec le deuxième orteil : s'il rentre vers l'intérieur, activez consciemment le fessier",
+      "Faites un pas suffisamment long : un pas trop court met trop de pression sur le genou avant, un pas trop long déséquilibre",
+      "Si l'équilibre est un problème, commencez par les fentes arrière ou posez les mains sur les hanches pour abaisser le centre de gravité"
+    ],
+    "commonMistakes": [
+      "Le genou avant qui dépasse largement les orteils ou qui rentre vers l'intérieur — raccourcissez le pas et poussez le genou vers l'extérieur",
+      "Le buste qui s'incline vers l'avant — gardez la poitrine ouverte et les épaules au-dessus des hanches",
+      "Le pas trop court qui transforme la fente en squat partiel — le tibia avant doit être quasi vertical en position basse",
+      "Le pied arrière à plat au sol — seule la pointe du pied arrière touche le sol, le talon reste décollé",
+      "La descente trop rapide et non contrôlée — contrôlez la phase excentrique sur 2 secondes pour protéger les genoux et maximiser le travail musculaire"
+    ]
+  },
+  "glute-bridge": {
+    "name": "Glute bridge",
+    "aliases": ["Pont fessier", "Hip thrust au sol"],
+    "muscles": ["Fessiers", "Ischio-jambiers", "Core (stabilisation)"],
+    "shortDescription": "Le mouvement de référence pour activer et renforcer les fessiers. Allongé au sol, vous soulevez le bassin en contractant les fessiers — un exercice simple, efficace et accessible à tous les niveaux.",
+    "execution": "Allongez-vous sur le dos, genoux fléchis, pieds à plat au sol écartés à largeur de hanches et positionnés de sorte que vos tibias soient verticaux en position haute. Bras le long du corps, paumes vers le sol. Poussez dans vos talons et contractez les fessiers pour soulever le bassin jusqu'à former une ligne droite des épaules aux genoux. Maintenez la contraction une seconde en haut en serrant les fessiers au maximum. Redescendez lentement sans poser complètement les fesses au sol entre chaque répétition pour maintenir la tension. Le mouvement vient des hanches — ne cambrez pas le bas du dos pour monter plus haut.",
+    "breathing": "Expirez en montant le bassin et en contractant les fessiers. Inspirez en redescendant de manière contrôlée. Cette respiration aide à engager le core et à stabiliser le mouvement.",
+    "benefits": [
+      "Active et renforce les fessiers, souvent sous-utilisés à cause de la position assise prolongée",
+      "Protège le bas du dos en renforçant la chaîne postérieure",
+      "Améliore la stabilité du bassin et la posture en position debout",
+      "Mouvement sans impact, accessible même en cas de douleurs articulaires",
+      "Excellent exercice d'échauffement avant des mouvements plus intenses (squats, fentes)"
+    ],
+    "variants": [
+      {
+        "name": "Glute bridge marché",
+        "description": "En position haute du pont, tendez une jambe devant vous puis reposez-la, et alternez. Cette variante ajoute un travail unilatéral et un défi d'équilibre qui intensifie l'activation des fessiers."
+      },
+      {
+        "name": "Hip thrust au sol",
+        "description": "Haut du dos appuyé sur un canapé ou un banc, pieds au sol, soulevez le bassin. L'amplitude de mouvement est plus grande et la position permet d'ajouter du poids (sac, haltère) sur les hanches pour progresser en charge."
+      },
+      {
+        "name": "Hip thrust unilatéral",
+        "description": "En position de hip thrust, une seule jambe au sol, l'autre tendue ou genou ramené vers la poitrine. Double la charge sur la jambe d'appui et révèle les déséquilibres de force entre les deux côtés."
+      }
+    ],
+    "tips": [
+      "Poussez à travers les talons, pas les orteils — vous devez pouvoir soulever les orteils du sol",
+      "Serrez les fessiers au maximum en haut du mouvement et maintenez une seconde",
+      "Ne cambrez pas le bas du dos pour monter plus haut — arrêtez-vous quand le corps forme une ligne droite",
+      "Placez les pieds de sorte que les tibias soient verticaux en position haute pour maximiser le recrutement des fessiers"
+    ],
+    "commonMistakes": [
+      "Pousser avec les orteils au lieu des talons — transfère le travail vers les quadriceps au détriment des fessiers",
+      "Cambrer le bas du dos en position haute — signe que le bassin monte trop haut. Arrêtez-vous quand le corps est aligné.",
+      "Ne pas contracter les fessiers consciemment — le mouvement devient passif et les ischio-jambiers prennent le relais",
+      "Les genoux qui s'écartent ou se rapprochent — gardez-les stables et alignés avec les pieds tout au long du mouvement",
+      "Monter et descendre trop vite — contrôlez le tempo pour maximiser le temps sous tension et l'activation musculaire"
+    ]
+  },
+  "box-jumps": {
+    "name": "Box jumps (marche)",
+    "aliases": ["Box jumps", "Sauts sur marche"],
+    "muscles": ["Quadriceps", "Fessiers", "Mollets", "Core"],
+    "shortDescription": "Un exercice pliométrique accessible qui consiste à sauter sur une marche ou un support stable. Les box jumps développent la puissance explosive des jambes et la coordination tout en apprenant au corps à produire de la force rapidement.",
+    "execution": "Placez-vous face à une marche ou un support stable, pieds à largeur d'épaules, à environ 30 cm du bord. Fléchissez les genoux en envoyant les hanches vers l'arrière (comme un demi-squat) tout en balançant les bras en arrière. Poussez explosément dans le sol et balancez les bras vers l'avant et le haut pour propulser votre corps. Réceptionnez-vous sur la marche avec les deux pieds à plat, genoux fléchis pour amortir. Redressez-vous complètement en haut, hanches ouvertes. Redescendez en contrôle (un pied après l'autre ou en sautant légèrement en arrière) et enchaînez la répétition suivante.",
+    "breathing": "Prenez une inspiration rapide avant le saut, expirez pendant la phase de poussée et le vol. Respirez librement en haut de la marche avant de redescendre.",
+    "benefits": [
+      "Développe la puissance explosive des membres inférieurs de manière fonctionnelle et progressive",
+      "Améliore la coordination, le timing et la proprioception dynamique",
+      "Renforce les quadriceps, les fessiers et les mollets en mode pliométrique",
+      "Enseigne au corps à absorber les impacts correctement (qualité de réception)",
+      "Progression naturelle : il suffit d'augmenter la hauteur de la marche pour monter en difficulté"
+    ],
+    "variants": [
+      {
+        "name": "Broad jumps",
+        "description": "Saut en longueur debout vers l'avant. Développe la puissance horizontale et la capacité d'extension complète de la chaîne postérieure. Excellent pour le transfert vers les mouvements sportifs."
+      },
+      {
+        "name": "Tuck jumps",
+        "description": "Saut vertical avec les genoux ramenés vers la poitrine en l'air. Augmente le temps de vol et l'explosivité. Demande un bon gainage pour contrôler la position en vol."
+      },
+      {
+        "name": "Squat jumps",
+        "description": "Saut explosif vers le haut depuis une position de squat profond, sans support. Combine le travail de force du squat avec l'explosivité du saut. Très intense pour les quadriceps et les fessiers."
+      }
+    ],
+    "tips": [
+      "Commencez avec une marche basse (15-20 cm) et augmentez progressivement la hauteur",
+      "Réceptionnez-vous avec les deux pieds en même temps, genoux fléchis — jamais en atterrissant sur un seul pied",
+      "Utilisez le balancier des bras pour gagner en hauteur : ils jouent un rôle clé dans la propulsion",
+      "Redescendez toujours en contrôle — pas de saut en arrière incontrôlé qui met les chevilles à risque"
+    ],
+    "commonMistakes": [
+      "Réception sur la pointe des pieds au bord de la marche — posez les pieds à plat et au centre du support pour la stabilité",
+      "Les genoux qui rentrent vers l'intérieur à la réception — poussez les genoux vers l'extérieur en atterrissant, comme pour un squat",
+      "Ne pas ouvrir les hanches en haut — redressez-vous complètement avant de redescendre, sinon le mouvement est incomplet",
+      "Utiliser un support instable ou trop haut — la sécurité prime sur l'ego, choisissez une hauteur que vous maîtrisez",
+      "Enchaîner les répétitions en tombant en arrière — redescendez de manière contrôlée à chaque fois pour préserver les tendons d'Achille"
+    ]
+  },
+  "good-morning": {
+    "name": "Good morning",
+    "aliases": ["Good mornings"],
+    "muscles": ["Ischio-jambiers", "Érecteurs du rachis", "Fessiers"],
+    "shortDescription": "Un exercice de charnière de hanche qui cible la chaîne postérieure en profondeur. Le good morning renforce les ischio-jambiers, les érecteurs du rachis et les fessiers dans un mouvement de flexion contrôlée du buste — essentiel pour la santé du dos et la posture.",
+    "execution": "Debout, pieds à largeur d'épaules, genoux légèrement fléchis (jamais verrouillés). Placez les mains derrière la tête ou croisées sur la poitrine. En gardant le dos parfaitement droit et la poitrine ouverte, penchez le buste vers l'avant en poussant les hanches vers l'arrière, comme si vous vouliez toucher le mur derrière vous avec vos fessiers. Descendez jusqu'à sentir un étirement prononcé dans les ischio-jambiers (le buste arrive environ parallèle au sol selon votre souplesse). Contractez les fessiers et les ischio-jambiers pour remonter le buste en ramenant les hanches vers l'avant. Le mouvement part des hanches, jamais du bas du dos.",
+    "breathing": "Inspirez profondément en descendant le buste vers l'avant, expirez en remontant en contractant les fessiers. Gardez les abdominaux engagés tout au long du mouvement pour protéger la colonne vertébrale.",
+    "benefits": [
+      "Renforce toute la chaîne postérieure : ischio-jambiers, érecteurs du rachis et fessiers",
+      "Améliore la mobilité de hanche et la souplesse des ischio-jambiers en dynamique",
+      "Enseigne le patron moteur de la charnière de hanche (hip hinge), fondamental pour soulever des charges au quotidien",
+      "Prévient les douleurs lombaires en renforçant les muscles stabilisateurs du dos",
+      "Prépare aux mouvements plus avancés comme le soulevé de terre et le kettlebell swing"
+    ],
+    "variants": [
+      {
+        "name": "Romanian deadlift unilatéral",
+        "description": "Même mouvement de charnière de hanche mais sur une seule jambe, la jambe libre partant en arrière. Augmente considérablement le travail d'équilibre et la sollicitation des stabilisateurs de hanche."
+      },
+      {
+        "name": "Single leg deadlift",
+        "description": "Similaire au Romanian deadlift unilatéral avec un défi d'équilibre encore plus marqué. La jambe libre s'aligne avec le buste pour former une ligne horizontale. Excellent pour corriger les déséquilibres musculaires entre les deux côtés."
+      }
+    ],
+    "tips": [
+      "Gardez une légère flexion des genoux en permanence — les jambes tendues mettent trop de stress sur les lombaires",
+      "Le mouvement vient des hanches, pas du dos : imaginez que vos hanches sont une charnière de porte",
+      "Gardez le regard vers le sol à environ un mètre devant vous pour maintenir la nuque alignée avec la colonne",
+      "Descendez uniquement jusqu'où votre dos reste droit — ne sacrifiez jamais la posture pour l'amplitude"
+    ],
+    "commonMistakes": [
+      "Le dos qui s'arrondit pendant la descente — signe que vous descendez trop bas ou que les ischio-jambiers manquent de souplesse. Réduisez l'amplitude.",
+      "Les genoux verrouillés — gardez toujours une micro-flexion pour protéger les lombaires et permettre aux hanches de bouger librement",
+      "Le mouvement qui part du bas du dos au lieu des hanches — poussez les fessiers vers l'arrière en premier, le buste suit naturellement",
+      "La tête qui se relève pour regarder devant — gardez la nuque neutre, le regard suit le mouvement du buste",
+      "Descente trop rapide et incontrôlée — contrôlez la descente sur 2-3 secondes pour maximiser le travail musculaire et protéger le dos"
+    ]
+  },
+  "gainage-planche": {
+    "name": "Gainage planche",
+    "aliases": ["Planche", "Plank", "Gainage", "Bear crawl", "Hollow body hold"],
+    "muscles": ["Transverse de l'abdomen", "Grand droit", "Obliques", "Deltoïdes", "Érecteurs du rachis"],
+    "shortDescription": "L'exercice de base pour un tronc solide et un dos protégé. Le gainage en planche renforce la sangle abdominale en profondeur sans aucun mouvement : il suffit de maintenir la position et de résister à la gravité. Un fondamental accessible à tous.",
+    "execution": "Au sol, placez-vous en appui sur les avant-bras et les pointes de pieds. Les coudes sont placés directement sous les épaules, les avant-bras parallèles ou les mains jointes devant vous. Le corps forme une ligne droite de la tête aux talons : contractez les abdominaux en rentrant le nombril vers la colonne vertébrale, serrez les fessiers et poussez les talons vers l'arrière. Le regard est dirigé vers le sol, entre les mains, nuque dans le prolongement de la colonne. Maintenez la position le temps indiqué en respirant régulièrement, sans jamais laisser le bassin s'affaisser ou monter.",
+    "breathing": "Respirez normalement et régulièrement par le nez et la bouche. La tendance naturelle est de bloquer le souffle — résistez : adoptez une respiration abdominale contrôlée, en gardant la contraction du transverse à chaque expiration.",
+    "benefits": [
+      "Renforce le transverse de l'abdomen, le muscle profond essentiel à la stabilité du tronc",
+      "Protège le bas du dos en améliorant le contrôle de la posture et la rigidité du caisson abdominal",
+      "Sollicite l'ensemble du corps en isométrie : épaules, dos, fessiers et cuisses participent au maintien",
+      "Aucun matériel nécessaire et risque de blessure très faible — accessible dès le premier jour",
+      "Fondation indispensable pour tous les autres exercices : pompes, squats, burpees, et mouvements du quotidien"
+    ],
+    "variants": [
+      {
+        "name": "Gainage latéral",
+        "description": "En appui sur un avant-bras et le bord extérieur du pied, corps de profil. Cible les obliques et le moyen fessier pour renforcer la stabilité latérale du tronc. Alternez les deux côtés pour un travail équilibré."
+      },
+      {
+        "name": "Gainage latéral sur genoux",
+        "description": "Version accessible du gainage latéral : en appui sur l'avant-bras et le genou plutôt que le pied. Réduit le bras de levier pour les débutants tout en travaillant les obliques et la stabilité latérale. Idéal pour construire la force avant de passer à la version complète."
+      },
+      {
+        "name": "Gainage Superman",
+        "description": "En position de planche classique, tendez les bras vers l'avant comme Superman en vol. Augmente considérablement le bras de levier et la difficulté en sollicitant davantage les érecteurs du rachis et les épaules."
+      },
+      {
+        "name": "Planche épaule",
+        "description": "En position de planche haute (bras tendus), touchez l'épaule opposée avec chaque main en alternance. Ajoute un défi anti-rotation : le tronc doit résister à la torsion pendant que vous levez une main."
+      },
+      {
+        "name": "Planche RKC",
+        "description": "Planche sur les avant-bras avec une contraction maximale de tout le corps : rapprochez les coudes des pieds (sans bouger), serrez les poings et contractez chaque muscle à fond. Beaucoup plus intense que la planche classique — 10 secondes en RKC valent 30 secondes en planche standard."
+      },
+      {
+        "name": "Bear hold",
+        "description": "À quatre pattes, mains sous les épaules, genoux sous les hanches, soulevez les genoux de 2-3 cm du sol et maintenez. Travaille le gainage dans une position raccourcie qui sollicite intensément les quadriceps et le transverse. Excellent exercice de transition avant la planche."
+      },
+      {
+        "name": "Hollow hold",
+        "description": "Allongé sur le dos, bras tendus au-dessus de la tête et jambes tendues, soulevez les épaules et les pieds du sol en pressant le bas du dos contre le sol. Position de gymnastique qui renforce puissamment le grand droit et le transverse en position allongée."
+      },
+      {
+        "name": "Planche to downward dog",
+        "description": "En position de planche haute, poussez les hanches vers le haut et l'arrière pour passer en position du chien tête en bas, puis revenez en planche. L'alternance travaille la mobilité des épaules, la souplesse des ischio-jambiers et le gainage dynamique. Excellent mouvement de transition en échauffement."
+      }
+    ],
+    "tips": [
+      "Pensez à pousser le sol loin de vous avec les avant-bras — cet engagement actif des épaules protège l'articulation et augmente le recrutement musculaire",
+      "Contractez les fessiers aussi fort que les abdos : ce sont eux qui empêchent le bassin de basculer vers l'avant",
+      "Préférez plusieurs séries courtes avec une bonne forme (4 x 20 s) à une longue série où la posture se dégrade",
+      "Si vous tremblez, c'est normal et signe que les muscles travaillent — si le dos se creuse, arrêtez et reposez-vous"
+    ],
+    "commonMistakes": [
+      "Le bassin qui s'affaisse vers le sol (dos creux) — le signe le plus courant de fatigue. Contractez les abdos et les fessiers ou arrêtez la série.",
+      "Les fesses qui montent en pic — facilite l'exercice mais supprime le travail du gainage. Le corps doit rester en ligne droite.",
+      "Les coudes placés trop en avant des épaules — crée une contrainte excessive sur les épaules. Les coudes doivent être directement sous les articulations.",
+      "La tête qui se relève pour regarder devant soi — comprime les cervicales. Gardez le regard vers le sol, nuque neutre dans l'axe de la colonne.",
+      "Bloquer la respiration — augmente la pression sanguine et limite la durée du maintien. Respirez calmement et régulièrement."
+    ]
+  },
+  "crunchs": {
+    "name": "Crunchs",
+    "aliases": ["Crunch", "Abdominaux", "Crunchs vélo"],
+    "muscles": ["Grand droit de l'abdomen", "Obliques"],
+    "shortDescription": "Le mouvement de base pour cibler les abdominaux. Le crunch isole le grand droit grâce à une flexion courte et contrôlée du tronc, sans élan ni traction sur la nuque. Simple en apparence, il demande une vraie connexion esprit-muscle pour être efficace.",
+    "execution": "Allongez-vous sur le dos, genoux fléchis, pieds à plat au sol à largeur de hanches. Placez les mains derrière la tête (doigts qui effleurent les oreilles, sans tirer sur la nuque) ou croisées sur la poitrine. Contractez les abdominaux pour décoller les épaules et le haut du dos du sol en enroulant le buste vers le bassin. Montez jusqu'à sentir une contraction maximale des abdos (environ 30 degrés), marquez un temps d'arrêt en haut, puis redescendez lentement sans reposer complètement les épaules au sol. Le bas du dos reste plaqué au sol pendant tout le mouvement.",
+    "breathing": "Expirez en montant (soufflez fort, ventre rentré vers la colonne) et inspirez en redescendant. L'expiration forcée sur la contraction active le transverse et maximise le recrutement des abdominaux.",
+    "benefits": [
+      "Isole efficacement le grand droit de l'abdomen sans matériel",
+      "Renforce la sangle abdominale pour une meilleure posture au quotidien",
+      "Mouvement accessible qui s'adapte à tous les niveaux grâce à ses nombreuses variantes",
+      "Faible stress articulaire comparé aux sit-ups complets",
+      "Améliore la connexion esprit-muscle sur la zone abdominale"
+    ],
+    "variants": [
+      {
+        "name": "Bicycle crunchs",
+        "description": "En position de crunch, amenez le coude droit vers le genou gauche pendant que la jambe droite se tend, puis alternez. Le pédalage rotatif sollicite intensément les obliques en plus du grand droit."
+      },
+      {
+        "name": "Sit-ups",
+        "description": "Remontée complète du buste jusqu'en position assise, le dos décolle entièrement du sol. Mouvement plus complet qui recrute les fléchisseurs de hanche en plus des abdominaux, mais plus exigeant pour le bas du dos."
+      },
+      {
+        "name": "V-ups",
+        "description": "Les jambes et le buste montent simultanément pour former un V, les mains cherchent à toucher les pieds. Variante avancée qui demande force abdominale et souplesse des ischio-jambiers."
+      },
+      {
+        "name": "Russian twists",
+        "description": "Assis en équilibre sur les fessiers, pieds décollés du sol, effectuez des rotations du buste de gauche à droite. Cible les obliques et le transverse avec un travail d'antirotation dynamique."
+      },
+      {
+        "name": "Toe touches",
+        "description": "Allongé sur le dos, jambes tendues à la verticale, montez les mains pour toucher les orteils. Le mouvement court et ciblé isole la partie haute du grand droit avec une contraction intense."
+      }
+    ],
+    "tips": [
+      "Gardez un espace d'un poing entre le menton et la poitrine pour protéger la nuque",
+      "Concentrez-vous sur le rapprochement des côtes vers le bassin, pas sur la hauteur de la montée",
+      "Maintenez le bas du dos collé au sol : s'il se cambre, c'est que les abdos ont lâché",
+      "Ralentissez la descente (2-3 secondes) pour doubler le temps sous tension"
+    ],
+    "commonMistakes": [
+      "Tirer sur la nuque avec les mains — relâchez la pression des doigts, ils ne font que soutenir la tête sans la tirer",
+      "Monter trop haut en décollant les lombaires — le crunch est un mouvement court, pas un sit-up",
+      "Utiliser l'élan pour enchaîner les répétitions — chaque montée doit être initiée par la contraction abdominale, pas par un balancier",
+      "Gonfler le ventre en montant — le ventre doit se creuser vers l'intérieur à l'effort pour engager le transverse",
+      "Reposer complètement les épaules entre chaque répétition — gardez une tension continue en restant légèrement décollé"
+    ]
+  },
+  "superman": {
+    "name": "Superman",
+    "aliases": ["Superman alterne", "Back extension au sol"],
+    "muscles": ["Erecteurs du rachis", "Fessiers", "Trapèzes", "Rhomboïdes", "Deltoïdes postérieurs"],
+    "shortDescription": "L'antidote aux heures passées assis. Le superman renforce toute la chaîne postérieure en un seul mouvement au sol. En soulevant bras et jambes simultanément, vous travaillez les érecteurs du rachis, les fessiers et le haut du dos pour un dos solide et une posture redressée.",
+    "execution": "Allongez-vous face au sol, bras tendus devant vous (position « superman en vol »), jambes tendues et serrées. Le front peut reposer sur le sol ou rester légèrement décollé. Contractez simultanément les fessiers et les muscles du dos pour soulever les bras, la poitrine et les jambes du sol. Montez aussi haut que votre mobilité le permet sans forcer dans les lombaires, en gardant le regard vers le sol (nuque neutre). Tenez la position haute 1 à 2 secondes en serrant les omoplates l'une vers l'autre, puis redescendez lentement. Le mouvement part des fessiers et du dos, pas d'un coup de rein.",
+    "breathing": "Inspirez en position basse pour préparer le mouvement, expirez en montant tout en contractant le dos et les fessiers. Maintenez une respiration fluide si vous tenez la position en isométrie.",
+    "benefits": [
+      "Renforce toute la chaîne postérieure : érecteurs du rachis, fessiers, haut du dos",
+      "Corrige la posture en contrebalançant les effets de la position assise prolongée",
+      "Prévient les douleurs lombaires en développant l'endurance des muscles stabilisateurs du rachis",
+      "Aucun matériel nécessaire, peut se pratiquer sur n'importe quelle surface plane",
+      "Améliore la proprioception et la coordination entre le haut et le bas du corps"
+    ],
+    "variants": [
+      {
+        "name": "Superman alterné",
+        "description": "Soulevez le bras droit et la jambe gauche simultanément, puis alternez. Réduit la difficulté et ajoute un travail de stabilisation anti-rotation du bassin."
+      },
+      {
+        "name": "Back extensions",
+        "description": "Seul le haut du corps se soulève, les jambes restent au sol. Concentre le travail sur les érecteurs du rachis et le haut du dos, idéal pour les débutants ou en pré-fatigue."
+      },
+      {
+        "name": "Reverse hyper sur table",
+        "description": "Allongé sur le ventre au bord d'une table, hanches en appui, soulevez les jambes vers l'horizontal. Cible les fessiers et les lombaires avec une amplitude accrue et sans compression discale."
+      },
+      {
+        "name": "Reverse snow angels",
+        "description": "En position de superman maintenue, effectuez un arc de cercle avec les bras, du devant vers les hanches et retour. Le mouvement continu sous tension brûle les rhomboïdes et les trapèzes."
+      },
+      {
+        "name": "Prone T raises",
+        "description": "Face au sol, bras écartés sur les côtés, soulevez-les pour former un T. Cible spécifiquement les trapèzes moyens et les rhomboïdes, parfait pour corriger les épaules enroulées."
+      },
+      {
+        "name": "Prone Y raises",
+        "description": "Face au sol, bras tendus vers l'avant à 45 degrés, soulevez-les pour former un Y. Recrute les trapèzes inférieurs et les deltoïdes postérieurs, renforçant la stabilité de l'omoplate."
+      }
+    ],
+    "tips": [
+      "Gardez le regard vers le sol pour maintenir la nuque neutre — ne levez pas la tête pour regarder devant",
+      "Serrez les omoplates en haut du mouvement comme si vous vouliez coincer un crayon entre elles",
+      "Initiez le mouvement par les fessiers, pas par une cambrure excessive des lombaires",
+      "Commencez par la variante alternée si le superman complet provoque des tensions dans le bas du dos"
+    ],
+    "commonMistakes": [
+      "Lever la tête pour regarder devant soi — crée une hyperextension cervicale. Gardez le regard au sol, nuque dans le prolongement de la colonne.",
+      "Forcer la montée en cambrant excessivement les lombaires — la hauteur vient de la contraction musculaire, pas d'un coup de rein. Limitez l'amplitude si nécessaire.",
+      "Plier les genoux pour monter les jambes plus haut — gardez les jambes tendues et laissez les fessiers faire le travail",
+      "Relâcher les bras entre les répétitions — maintenez une légère tension dans le haut du dos même en position basse",
+      "Aller trop vite sans contrôler le mouvement — le superman est un exercice de contrôle, pas de vitesse. Marquez un temps d'arrêt en haut."
+    ]
+  },
+  "leg-raises": {
+    "name": "Leg raises",
+    "aliases": ["Relevés de jambes"],
+    "muscles": ["Grand droit (portion basse)", "Fléchisseurs de hanche", "Obliques (stabilisation)"],
+    "shortDescription": "L'exercice de référence pour cibler la partie basse des abdominaux. Le leg raise demande un contrôle réel du bassin pour empêcher le dos de se cambrer, ce qui en fait un mouvement bien plus technique qu'il n'y paraît.",
+    "execution": "Allongez-vous sur le dos, bras le long du corps (paumes vers le sol) ou mains glissées sous les fessiers pour stabiliser le bassin. Jambes tendues et serrées, décollez les pieds du sol de quelques centimètres. En gardant le bas du dos plaqué au sol, montez les jambes tendues à la verticale (90 degrés) en contractant les abdominaux. Redescendez lentement, en contrôlant la descente sur 3 à 4 secondes, jusqu'à ce que les pieds frôlent le sol sans le toucher. Si les jambes tendues sont trop difficiles, pliez légèrement les genoux pour réduire le bras de levier. La clé du mouvement est de ne jamais laisser le bas du dos décoller du sol.",
+    "breathing": "Expirez en montant les jambes (ventre creux, bas du dos plaqué), inspirez en redescendant. L'expiration forcée en montée aide à maintenir la rétroversion du bassin et protège les lombaires.",
+    "benefits": [
+      "Cible la portion basse du grand droit, souvent sous-développée par rapport à la portion haute",
+      "Renforce les fléchisseurs de hanche, essentiels pour la course et la marche",
+      "Développe le contrôle du bassin et la stabilisation lombaire",
+      "Progression naturelle vers des mouvements avancés (toes-to-bar, L-sit)",
+      "Améliore la conscience corporelle et la proprioception de la zone lombo-pelvienne"
+    ],
+    "variants": [
+      {
+        "name": "Flutter kicks",
+        "description": "Jambes tendues à quelques centimètres du sol, effectuez de petits battements alternés rapides. Le maintien continu sous tension avec le bas du dos plaqué au sol brûle les abdominaux et les fléchisseurs de hanche."
+      },
+      {
+        "name": "Scissors",
+        "description": "Jambes tendues décollées du sol, croisez-les en alternance comme des ciseaux. Le mouvement de croisement ajoute une composante d'adduction et un travail des obliques à l'effort de maintien abdominal."
+      }
+    ],
+    "tips": [
+      "Placez les mains sous les fessiers si votre dos se cambre — cela aide à maintenir la rétroversion du bassin",
+      "Contrôlez la descente : c'est la phase excentrique qui construit la force. Si les jambes tombent, c'est trop lourd.",
+      "Ne touchez jamais le sol avec les pieds entre les répétitions pour garder la tension continue",
+      "Pliez légèrement les genoux si les jambes tendues provoquent des tensions dans le bas du dos — la qualité du mouvement prime sur l'amplitude"
+    ],
+    "commonMistakes": [
+      "Le bas du dos qui se cambre à la descente — c'est l'erreur la plus courante et la plus dangereuse. Réduisez l'amplitude ou pliez les genoux tant que vous ne contrôlez pas la position du bassin.",
+      "Utiliser l'élan pour remonter les jambes — chaque montée doit être initiée par la contraction abdominale, pas par un balancement",
+      "Laisser les jambes tomber sous la gravité — la descente doit durer 3-4 secondes minimum. Si vous ne contrôlez pas, réduisez l'amplitude.",
+      "Tirer sur la nuque ou lever la tête — gardez la tête posée au sol, nuque détendue, le travail est dans les abdos pas dans le cou",
+      "Retenir sa respiration par réflexe — l'apnée augmente la pression intra-abdominale de manière incontrôlée et empêche un gainage efficace"
+    ]
+  },
+  "dead-bug": {
+    "name": "Dead bug",
+    "aliases": ["Bird dog"],
+    "muscles": ["Transverse de l'abdomen", "Grand droit", "Obliques", "Fléchisseurs de hanche"],
+    "shortDescription": "Un exercice de gainage anti-extension allongé sur le dos. Le dead bug apprend au corps à stabiliser le tronc pendant que les bras et les jambes bougent — exactement ce que fait le core dans la vie quotidienne et le sport.",
+    "execution": "Allongez-vous sur le dos, bras tendus vers le plafond à la verticale des épaules, genoux fléchis à 90° au-dessus des hanches (tibias parallèles au sol). Avant de bouger, plaquez le bas du dos contre le sol en contractant les abdominaux — ce contact ne doit jamais se perdre. Tendez simultanément le bras droit au-dessus de la tête et la jambe gauche vers le sol, sans que l'un ou l'autre ne touche le sol. Ramenez-les à la position de départ puis répétez du côté opposé. Le mouvement est lent et contrôlé — chaque répétition dure 3 à 4 secondes. Si le bas du dos décolle du sol, réduisez l'amplitude du mouvement.",
+    "breathing": "Expirez lentement en tendant le bras et la jambe opposés — cette expiration aide à maintenir le bas du dos plaqué au sol. Inspirez en revenant à la position de départ.",
+    "benefits": [
+      "Renforce le core en anti-extension, le schéma de stabilisation le plus fonctionnel",
+      "Apprend la dissociation membres-tronc : bouger les bras et jambes sans compenser avec le dos",
+      "Extrêmement doux pour le dos — recommandé en rééducation et en prévention des lombalgies",
+      "Améliore la coordination controlatérale (bras droit / jambe gauche) essentielle en course et marche",
+      "Excellent exercice d'échauffement pour préparer le core avant des mouvements plus intenses"
+    ],
+    "variants": [],
+    "tips": [
+      "Le bas du dos doit rester collé au sol en permanence — c'est LE critère de qualité du mouvement",
+      "Allez lentement : 3-4 secondes par extension, 2 secondes pour revenir. La vitesse est l'ennemi du dead bug.",
+      "Si vous n'arrivez pas à maintenir le dos au sol, réduisez l'amplitude : ne descendez pas le bras et la jambe aussi loin",
+      "Concentrez-vous sur l'expiration pendant l'extension — elle verrouille naturellement la position du tronc"
+    ],
+    "commonMistakes": [
+      "Le bas du dos qui décolle du sol — signe que l'amplitude est trop grande ou que le core n'est pas assez engagé. Réduisez le mouvement.",
+      "Aller trop vite — le dead bug est un exercice de contrôle, pas de vitesse. Chaque répétition doit être délibérée.",
+      "Bouger le bras et la jambe du même côté (homolatéral) au lieu du côté opposé (controlatéral)",
+      "Retenir sa respiration — l'expiration pendant l'extension est essentielle pour maintenir la stabilité du tronc",
+      "Négliger la phase de retour — ramenez le bras et la jambe avec le même contrôle que l'extension"
+    ]
+  },
+  "mountain-climbers": {
+    "name": "Mountain climbers",
+    "aliases": ["Mountain climber", "Spider-Man mountain climbers"],
+    "muscles": ["Core", "Épaules", "Quadriceps", "Fléchisseurs de hanche"],
+    "shortDescription": "Un exercice cardio explosif réalisé en position de planche. Les mountain climbers combinent gainage, travail des jambes et endurance cardiovasculaire dans un mouvement rapide et rythmé qui fait grimper la fréquence cardiaque en quelques secondes.",
+    "execution": "Placez-vous en position de planche haute : mains sous les épaules, bras tendus, corps aligné de la tête aux talons. Ramenez un genou vers la poitrine en contractant les abdominaux, puis renvoyez-le en arrière tout en ramenant simultanément l'autre genou vers la poitrine. Alternez rapidement les jambes dans un mouvement de course horizontale. Les hanches restent basses et stables — elles ne doivent ni monter en pic ni rebondir de haut en bas. Gardez les épaules au-dessus des poignets et le regard dirigé vers le sol, légèrement devant les mains.",
+    "breathing": "Adoptez un rythme respiratoire naturel et régulier, calqué sur le mouvement des jambes : inspirez sur un cycle de deux pas, expirez sur le suivant. Ne bloquez jamais votre respiration même quand le rythme s'accélère.",
+    "benefits": [
+      "Fait monter la fréquence cardiaque très rapidement sans aucun matériel",
+      "Renforce le gainage dynamique en sollicitant le core sous instabilité",
+      "Travaille les fléchisseurs de hanche et les quadriceps en mode explosif",
+      "Améliore la coordination et l'agilité grâce à l'alternance rapide des jambes",
+      "S'intègre facilement dans un circuit ou un HIIT comme pic d'intensité"
+    ],
+    "variants": [],
+    "tips": [
+      "Commencez lentement pour bien maîtriser la position de planche avant d'accélérer",
+      "Gardez les épaules verrouillées au-dessus des poignets — ne reculez pas le buste",
+      "Contractez les abdos en permanence pour empêcher le bassin de rebondir",
+      "Préférez un rythme régulier et soutenu à des accélérations incontrôlées suivies de pauses"
+    ],
+    "commonMistakes": [
+      "Les fesses qui montent en pic — signe que le core lâche. Abaissez les hanches au niveau des épaules.",
+      "Les hanches qui rebondissent de haut en bas — gardez le bassin stable en contractant le ventre",
+      "Les épaules qui reculent derrière les poignets — maintenez les mains directement sous les épaules",
+      "Les pieds qui traînent au sol au lieu de décoller — ramenez les genoux avec énergie, comme une course",
+      "La respiration bloquée — respirez de manière fluide et continue, même à haute intensité"
+    ]
+  },
+  "jumping-jacks": {
+    "name": "Jumping jacks",
+    "aliases": ["Jumping jack"],
+    "muscles": ["Deltoïdes", "Mollets", "Quadriceps", "Adducteurs"],
+    "shortDescription": "L'échauffement par excellence. Les jumping jacks combinent un saut avec un écartement simultané des bras et des jambes dans un mouvement rythmique qui active rapidement le système cardiovasculaire. Simple, efficace et accessible à tous les niveaux.",
+    "execution": "Debout, pieds joints, bras le long du corps. En un seul saut, écartez les pieds à environ une fois et demie la largeur des épaules tout en levant les bras latéralement au-dessus de la tête (les mains se touchent ou se rapprochent en haut). Revenez en position de départ d'un second saut : pieds joints, bras le long du corps. Le mouvement est fluide et continu, les bras et les jambes se synchronisent parfaitement. Réceptionnez-vous sur l'avant du pied avec les genoux légèrement fléchis pour amortir chaque saut.",
+    "breathing": "Inspirez en écartant les bras et les jambes, expirez en revenant en position de départ. Le rythme respiratoire s'adapte naturellement à la cadence du mouvement — gardez une respiration fluide et régulière.",
+    "benefits": [
+      "Échauffement complet du corps en quelques secondes : active le cardio, les épaules et les jambes simultanément",
+      "Améliore la coordination motrice bras-jambes et le sens du rythme",
+      "Zéro matériel, zéro technique complexe : accessible dès la première séance",
+      "Sollicite les adducteurs et les deltoïdes, souvent sous-travaillés dans les routines classiques",
+      "Augmente rapidement la fréquence cardiaque pour préparer le corps à un effort plus intense"
+    ],
+    "variants": [
+      {
+        "name": "Star jumps",
+        "description": "Saut explosif où bras et jambes s'écartent au maximum en l'air pour former une étoile. Plus intense que le jumping jack classique, cette variante développe la puissance et sollicite davantage les fessiers et les épaules."
+      }
+    ],
+    "tips": [
+      "Gardez les genoux légèrement fléchis à la réception pour protéger les articulations",
+      "Les bras montent bien tendus sur les côtés, pas devant vous — le mouvement part des épaules",
+      "Restez sur l'avant du pied, ne retombez jamais talons en premier",
+      "Trouvez un rythme régulier et soutenable plutôt que d'accélérer au maximum dès le départ"
+    ],
+    "commonMistakes": [
+      "Retomber sur les talons — crée un impact excessif sur les genoux et les chevilles. Restez sur l'avant du pied.",
+      "Les bras qui passent devant le corps au lieu de monter latéralement — réduit le travail des deltoïdes et casse le rythme",
+      "Les genoux raides à la réception — fléchissez toujours légèrement les genoux pour absorber le choc",
+      "Amplitude trop faible (les mains ne montent pas au-dessus de la tête) — faites le mouvement complet pour un travail efficace",
+      "Rythme irrégulier ou saccadé — gardez une cadence constante et fluide pour maximiser l'effet cardiovasculaire"
+    ]
+  },
+  "high-knees": {
+    "name": "High knees",
+    "aliases": [
+      "Montées de genoux",
+      "Montees de genoux moderees",
+      "Butt kicks",
+      "Sprint sur place",
+      "Talons-fesses",
+      "Skipping"
+    ],
+    "muscles": ["Fléchisseurs de hanche", "Quadriceps", "Mollets", "Core"],
+    "shortDescription": "Un exercice de cardio dynamique qui imite la course sur place avec les genoux montés haut. Les high knees travaillent intensément les fléchisseurs de hanche et le gainage tout en faisant grimper la fréquence cardiaque en quelques secondes.",
+    "execution": "Debout, pieds à largeur de hanches, bras fléchis à 90° comme en position de sprint. Montez un genou à hauteur de hanche (cuisse parallèle au sol ou plus haut) tout en poussant le bras opposé vers l'avant. Reposez le pied et enchaînez immédiatement avec l'autre jambe. Le mouvement est rapide et dynamique, semblable à une course sur place à haute fréquence. Restez sur la pointe des pieds, le tronc légèrement incliné vers l'avant et les abdominaux bien engagés pour stabiliser le bassin.",
+    "breathing": "Respirez de manière rythmique et courte, comme pendant un sprint : deux temps d'inspiration, deux temps d'expiration. Évitez de bloquer la respiration, même quand l'intensité monte.",
+    "benefits": [
+      "Fait exploser la fréquence cardiaque en quelques secondes — parfait pour les intervalles haute intensité",
+      "Renforce les fléchisseurs de hanche, un groupe musculaire clé pour la course et la mobilité quotidienne",
+      "Travaille la coordination bras-jambes et la proprioception dynamique",
+      "Sollicite fortement le gainage pour stabiliser le bassin à chaque montée de genou",
+      "Améliore la vitesse de pied et la réactivité musculaire des membres inférieurs"
+    ],
+    "variants": [
+      {
+        "name": "Talon-fesses",
+        "description": "Au lieu de monter les genoux, les talons viennent frapper les fessiers en arrière. Cible davantage les ischio-jambiers et les mollets tout en réduisant le stress sur les fléchisseurs de hanche."
+      }
+    ],
+    "tips": [
+      "Montez les genoux au minimum à hauteur de hanche — en dessous, l'exercice perd son intérêt",
+      "Gardez le buste droit ou très légèrement penché vers l'avant, pas en arrière",
+      "Utilisez vos bras activement : ils donnent le rythme et aident à la montée des genoux",
+      "Commencez à un rythme modéré et augmentez progressivement la vitesse sur les premières répétitions"
+    ],
+    "commonMistakes": [
+      "Les genoux qui ne montent pas assez haut — la cuisse doit atteindre la parallèle au sol pour un travail efficace des fléchisseurs de hanche",
+      "Le buste qui part en arrière pour compenser — signe que les fléchisseurs de hanche sont faibles. Réduisez la vitesse et gardez le tronc engagé.",
+      "Retomber sur les talons — restez sur la pointe des pieds pour protéger les articulations et garder du dynamisme",
+      "Les bras immobiles le long du corps — les bras opposés doivent accompagner le mouvement pour la coordination et l'équilibre",
+      "Rythme trop rapide au détriment de l'amplitude — mieux vaut monter haut et un peu moins vite que de piétiner sans amplitude"
+    ]
+  },
+  "skaters": {
+    "name": "Skaters",
+    "aliases": ["Skater", "Patineur", "Speed skaters"],
+    "muscles": ["Fessiers", "Quadriceps", "Adducteurs", "Mollets"],
+    "shortDescription": "Un exercice de cardio latéral inspiré du mouvement du patineur de vitesse. Les skaters développent la puissance des jambes, l'équilibre unipodal et la stabilité de hanche dans un mouvement explosif et fluide.",
+    "execution": "Debout, transférez votre poids sur la jambe droite et poussez latéralement vers la gauche en décollant du sol. Réceptionnez-vous sur le pied gauche, genou légèrement fléchi, en amenant la jambe droite derrière la jambe d'appui (sans poser le pied au sol ou en le posant à peine). Simultanément, le bras droit vient vers l'avant et le bras gauche part en arrière, comme un patineur. Enchaînez immédiatement en poussant vers la droite. Le mouvement est continu, fluide et contrôlé : chaque réception est amortie par une flexion de genou avant de repartir dans l'autre direction.",
+    "breathing": "Expirez à chaque impulsion latérale, inspirez brièvement pendant la phase de vol. Le rythme respiratoire se cale naturellement sur les allers-retours.",
+    "benefits": [
+      "Travaille la puissance latérale des jambes, un plan de mouvement souvent négligé dans les entraînements classiques",
+      "Renforce les fessiers et les adducteurs en mode dynamique et fonctionnel",
+      "Développe l'équilibre unipodal et la stabilité de hanche et de cheville",
+      "Effet cardio élevé avec un faible impact par rapport aux sauts verticaux",
+      "Améliore l'agilité et la capacité de changement de direction rapide"
+    ],
+    "variants": [
+      {
+        "name": "Lateral bounds",
+        "description": "Sauts latéraux plus amples et plus explosifs, avec un temps de vol plus long. Développe davantage la puissance et l'explosivité des membres inférieurs. Nécessite une bonne stabilité de cheville."
+      },
+      {
+        "name": "Pas chassés",
+        "description": "Déplacement latéral en pas glissés sans phase de vol. Réduit l'impact articulaire tout en travaillant les adducteurs et la coordination latérale. Idéal pour l'échauffement ou les débutants."
+      }
+    ],
+    "tips": [
+      "Poussez fort avec la jambe d'appui dans le sol — c'est l'explosivité de cette poussée qui fait la qualité du mouvement",
+      "Fléchissez le genou à la réception pour amortir et préparer la prochaine impulsion",
+      "Gardez le buste légèrement penché vers l'avant, comme un vrai patineur — cela aide l'équilibre",
+      "Commencez avec une amplitude modérée et augmentez progressivement la largeur des sauts"
+    ],
+    "commonMistakes": [
+      "Réception jambe tendue — fléchissez toujours le genou à l'atterrissage pour protéger les articulations et maintenir l'équilibre",
+      "Le buste trop vertical — penchez-vous légèrement vers l'avant pour abaisser votre centre de gravité et améliorer la stabilité",
+      "Amplitude trop faible (petits pas au lieu de vrais sauts latéraux) — poussez réellement dans le sol pour couvrir de la distance",
+      "Les bras qui restent immobiles — utilisez le balancier naturel des bras pour l'équilibre et la puissance",
+      "Le genou de réception qui s'effondre vers l'intérieur (valgus) — concentrez-vous sur l'alignement genou-pied à chaque atterrissage"
+    ]
+  },
+  "burpees": {
+    "name": "Burpees",
+    "aliases": ["Burpee", "Sprawls", "Sprawl", "Push-up burpees", "Tuck jump burpees", "Broad jump burpees"],
+    "muscles": ["Pectoraux", "Quadriceps", "Fessiers", "Épaules", "Triceps", "Core"],
+    "shortDescription": "L'exercice au poids du corps le plus complet et le plus redouté. Le burpee combine une pompe, un squat et un saut dans un mouvement fluide qui fait exploser le cardio et sollicite chaque muscle du corps.",
+    "execution": "Debout, pieds à largeur d'épaules. Descendez en squat et posez les mains au sol devant vous. Lancez les pieds vers l'arrière d'un bond pour arriver en position de pompe. Effectuez une pompe complète (poitrine au sol). Ramenez les pieds vers les mains d'un bond. Sautez verticalement en levant les bras au-dessus de la tête. Réceptionnez-vous souplement et enchaînez immédiatement la répétition suivante.",
+    "breathing": "Inspirez en descendant au sol, expirez en remontant du sol et pendant le saut. Le rythme respiratoire s'adapte naturellement à l'intensité — l'important est de ne jamais bloquer la respiration.",
+    "benefits": [
+      "Travail complet du corps en un seul mouvement : poussée, squat, saut, gainage",
+      "Développe simultanément la force, l'endurance et la puissance",
+      "Effet cardio maximal : fait monter la fréquence cardiaque en quelques répétitions",
+      "Brûle énormément de calories grâce à la sollicitation de grandes chaînes musculaires",
+      "Aucun matériel, très peu d'espace nécessaire"
+    ],
+    "variants": [
+      {
+        "name": "Burpees sans pompe",
+        "description": "On saute en planche et on revient sans effectuer la pompe. Réduit la difficulté tout en gardant l'effet cardio. Bon point de départ pour construire l'endurance."
+      },
+      {
+        "name": "Burpees sans saut",
+        "description": "On remplace le saut final par une simple extension debout. Moins d'impact sur les articulations, idéal en appartement ou pour les pratiquants avec des sensibilités aux genoux."
+      },
+      {
+        "name": "Burpees avec tuck jump",
+        "description": "Le saut final est remplacé par un saut genoux poitrine. Version avancée qui augmente l'explosivité et la demande cardiovasculaire."
+      }
+    ],
+    "tips": [
+      "Trouvez un rythme soutenable. Mieux vaut un rythme régulier que 5 burpees rapides suivis de 30 secondes à reprendre son souffle",
+      "La pompe doit être complète — si vous n'y arrivez plus, passez aux burpees sans pompe plutôt que de tricher",
+      "Réceptionnez-vous souplement sur l'avant du pied, pas les jambes raides",
+      "Gardez les abdos contractés pendant toute la phase au sol pour protéger le bas du dos"
+    ],
+    "commonMistakes": [
+      "Sauter la pompe ou faire une demi-pompe — c'est une partie intégrante du mouvement",
+      "Le dos qui se creuse en position de planche — gainez le tronc avant de lancer les pieds en arrière",
+      "Se réceptionner jambes tendues après le saut — fléchissez les genoux pour absorber l'impact",
+      "Partir trop vite et s'effondrer après 4-5 reps — le burpee est un marathon, pas un sprint",
+      "Oublier de respirer — l'apnée d'effort est le piège numéro un sur cet exercice"
+    ]
+  },
+  "inchworms": {
+    "name": "Inchworms",
+    "aliases": ["Inchworm"],
+    "muscles": ["Épaules", "Core", "Ischio-jambiers (souplesse)", "Pectoraux"],
+    "shortDescription": "Un exercice de mobilité dynamique qui combine marche des mains et étirement des ischio-jambiers. L'inchworm réchauffe tout le corps en passant de la position debout à la planche et retour — parfait en échauffement ou en récupération active.",
+    "execution": "Debout, pieds joints ou légèrement écartés. Penchez-vous en avant et posez les mains au sol devant vos pieds (fléchissez les genoux si nécessaire pour atteindre le sol). Avancez les mains pas à pas jusqu'à arriver en position de planche haute, corps aligné de la tête aux talons. Marquez un temps d'arrêt en planche, épaules au-dessus des poignets. Puis ramenez les pieds vers les mains en marchant à petits pas, jambes aussi tendues que possible pour étirer les ischio-jambiers. Redressez-vous à la position debout et enchaînez la répétition suivante. Chaque transition main-pied doit être fluide et contrôlée.",
+    "breathing": "Inspirez en marchant les mains vers l'avant, expirez en ramenant les pieds vers les mains. Maintenez un rythme respiratoire calme et régulier — cet exercice n'est pas un sprint.",
+    "benefits": [
+      "Échauffe l'ensemble du corps en un seul mouvement fluide : épaules, core, ischio-jambiers",
+      "Améliore la souplesse dynamique des ischio-jambiers et des mollets",
+      "Renforce les épaules et le core en position de planche à chaque répétition",
+      "Prépare les articulations et les muscles à des mouvements plus intenses",
+      "Mouvement lent et contrôlé qui peut servir de récupération active entre des séries intenses"
+    ],
+    "variants": [],
+    "tips": [
+      "Gardez les jambes aussi tendues que possible en ramenant les pieds — c'est là que se fait l'étirement",
+      "Ne vous précipitez pas : l'inchworm est un exercice de mobilité, pas de vitesse",
+      "En position de planche, vérifiez que vos épaules sont bien au-dessus des poignets avant de repartir",
+      "Si vous ne pouvez pas toucher le sol jambes tendues, fléchissez légèrement les genoux — la souplesse viendra avec la pratique"
+    ],
+    "commonMistakes": [
+      "Se précipiter et bâcler les transitions — chaque phase (marche des mains, planche, marche des pieds) mérite d'être contrôlée",
+      "Plier excessivement les genoux en ramenant les pieds — l'objectif est de sentir l'étirement des ischio-jambiers",
+      "Les hanches qui montent ou descendent en planche — maintenez un alignement tête-talons comme pour une planche statique",
+      "Oublier de marquer la position de planche — ne faites pas qu'un aller-retour, stabilisez-vous une seconde en planche",
+      "Les mains qui avancent trop loin devant les épaules — en planche, les poignets doivent être sous les épaules"
+    ]
+  },
+  "etirements": {
+    "name": "Étirements",
+    "aliases": ["Stretching", "Étirement", "Torsion", "Cobra", "Savasana", "Devil press"],
+    "muscles": ["Ischio-jambiers", "Quadriceps", "Pectoraux", "Psoas", "Triceps"],
+    "shortDescription": "Les étirements statiques en fin de séance permettent de ramener les muscles à leur longueur de repos, d'améliorer la souplesse et de favoriser la récupération. Chaque position est maintenue 20 à 30 secondes en respirant calmement.",
+    "execution": "Adoptez chaque position d'étirement lentement, sans à-coups. Maintenez la posture 20 à 30 secondes en respirant profondément. Vous devez ressentir une tension modérée, jamais une douleur. Relâchez doucement et passez à l'étirement suivant. Pour les étirements unilatéraux, travaillez toujours les deux côtés en maintenant le même temps de chaque côté.",
+    "breathing": "Respirez lentement et profondément par le nez. À chaque expiration, relâchez un peu plus la tension musculaire pour gagner en amplitude. Ne bloquez jamais votre respiration.",
+    "benefits": [
+      "Améliore la souplesse musculaire et l'amplitude articulaire",
+      "Favorise la récupération en réduisant les tensions post-effort",
+      "Diminue le risque de blessures en maintenant l'élasticité des tissus",
+      "Réduit les courbatures et les raideurs musculaires du lendemain",
+      "Moment de retour au calme qui aide à la transition vers le repos"
+    ],
+    "variants": [
+      {
+        "name": "Étirement ischio-jambiers",
+        "description": "Jambe tendue posée devant vous sur un support bas ou au sol, penchez le buste en avant en gardant le dos droit jusqu'à sentir l'étirement à l'arrière de la cuisse. Maintenez 20 à 30 secondes de chaque côté."
+      },
+      {
+        "name": "Étirement pectoraux",
+        "description": "Bras tendu contre un mur ou un encadrement de porte à 90°, pivotez lentement le buste vers l'extérieur jusqu'à sentir l'étirement dans la poitrine et l'avant de l'épaule. Maintenez 20 à 30 secondes de chaque côté."
+      },
+      {
+        "name": "Étirement psoas",
+        "description": "En position de fente basse, genou arrière au sol, poussez les hanches vers l'avant jusqu'à sentir l'étirement à l'avant de la hanche arrière. Le buste reste droit. Maintenez 20 à 30 secondes de chaque côté."
+      },
+      {
+        "name": "Étirement quadriceps debout",
+        "description": "Debout sur une jambe, attrapez le pied de l'autre jambe derrière vous et tirez le talon vers la fesse en gardant les genoux serrés. Gardez le bassin neutre. Maintenez 20 à 30 secondes de chaque côté."
+      },
+      {
+        "name": "Étirement triceps",
+        "description": "Bras levé, pliez le coude pour amener la main derrière la tête entre les omoplates. Avec l'autre main, poussez doucement le coude vers le bas. Maintenez 20 à 30 secondes de chaque côté."
+      }
+    ],
+    "tips": [
+      "Étirez-vous toujours sur des muscles chauds — jamais à froid en début de séance",
+      "Recherchez la sensation d'étirement, pas la douleur : si ça fait mal, relâchez",
+      "Ne rebondissez jamais dans un étirement : maintenez la position de manière statique",
+      "Respectez la symétrie : étirez toujours les deux côtés le même temps"
+    ],
+    "commonMistakes": [
+      "S'étirer à froid avant l'effort — les étirements statiques réduisent la performance s'ils sont faits avant l'entraînement",
+      "Forcer l'amplitude au point de ressentir une douleur — un étirement doit être confortable, jamais douloureux",
+      "Faire des à-coups ou rebondir dans la position — augmente le risque de micro-déchirures musculaires",
+      "Tenir moins de 15 secondes — en dessous, l'étirement n'a pas le temps de produire un effet significatif",
+      "Bloquer la respiration — empêche le relâchement musculaire et augmente la tension"
+    ]
+  },
+  "mobilite": {
+    "name": "Mobilité articulaire",
+    "aliases": [
+      "Mobilité",
+      "Mobility",
+      "Chat-vache",
+      "Posture de l'enfant",
+      "Pigeon allongé",
+      "Scorpion stretches",
+      "Squat to stand",
+      "Rotation thoracique"
+    ],
+    "muscles": ["Hanches", "Colonne vertébrale", "Épaules", "Chevilles"],
+    "shortDescription": "Les exercices de mobilité améliorent l'amplitude de mouvement des articulations et la qualité du mouvement. Ils préparent le corps à l'effort en échauffement et favorisent la récupération en fin de séance.",
+    "execution": "Effectuez chaque mouvement de mobilité lentement et de manière contrôlée, en explorant toute l'amplitude disponible sans forcer. Enchaînez les positions de manière fluide en respirant régulièrement. Le travail de mobilité n'est pas un effort intense : c'est un dialogue avec votre corps pour identifier et réduire les restrictions de mouvement.",
+    "breathing": "Respirez calmement et profondément. Utilisez l'expiration pour relâcher les tensions et gagner en amplitude. La respiration guide le rythme du mouvement.",
+    "benefits": [
+      "Améliore l'amplitude articulaire et la qualité de mouvement",
+      "Prévient les blessures en préparant les articulations à l'effort",
+      "Réduit les raideurs liées à la sédentarité et à la position assise",
+      "Favorise la récupération et réduit les douleurs post-entraînement",
+      "Améliore la posture et la conscience corporelle au quotidien"
+    ],
+    "variants": [
+      {
+        "name": "Cat-cow",
+        "description": "À quatre pattes, alternez lentement entre dos rond (chat : tête baissée, nombril rentré, dos vers le plafond) et dos creux (vache : tête levée, ventre vers le sol, poitrine ouverte). Mobilise toute la colonne vertébrale segment par segment."
+      },
+      {
+        "name": "Child's pose",
+        "description": "À genoux, asseyez-vous sur les talons et tendez les bras devant vous, front au sol. Respirez profondément dans le bas du dos. Position de repos et d'étirement qui relâche les lombaires, les épaules et les hanches."
+      },
+      {
+        "name": "Deep squat hold",
+        "description": "Maintenez un squat profond (fesses près du sol), pieds à plat, coudes contre l'intérieur des genoux pour les pousser vers l'extérieur. Améliore la mobilité des hanches, des chevilles et du bas du dos. Maintenez 30 à 60 secondes."
+      },
+      {
+        "name": "Hip 90/90",
+        "description": "Assis au sol, une jambe pliée à 90° devant vous (rotation externe de hanche) et l'autre à 90° sur le côté (rotation interne). Pivotez pour alterner les côtés. Travaille la mobilité en rotation des hanches dans les deux directions."
+      },
+      {
+        "name": "Pigeon stretch",
+        "description": "En position de fente, amenez le tibia avant au sol devant vous (parallèle ou en diagonale) et allongez la jambe arrière. Penchez le buste vers l'avant pour intensifier l'étirement du fessier et du piriforme. Maintenez 30 secondes de chaque côté."
+      },
+      {
+        "name": "Scorpion stretch",
+        "description": "Allongé sur le ventre, bras écartés en croix. Amenez le pied droit vers la main gauche en tournant le bassin, puis alternez. Mobilise la colonne thoracique en rotation et étire les fléchisseurs de hanche."
+      },
+      {
+        "name": "World's greatest stretch",
+        "description": "En position de fente basse, posez la main intérieure au sol, puis effectuez une rotation du buste en levant l'autre bras vers le ciel. Combine fente, rotation thoracique et ouverture de hanche en un seul mouvement complet. Le roi des échauffements."
+      }
+    ],
+    "tips": [
+      "Pratiquez la mobilité quotidiennement, même quelques minutes suffisent pour maintenir les gains",
+      "Respectez les limites de votre corps : la mobilité se construit progressivement, pas en forçant",
+      "Associez la mobilité articulaire à une respiration profonde pour maximiser le relâchement",
+      "Les exercices de mobilité sont parfaits au réveil pour « réveiller » les articulations après la nuit"
+    ],
+    "commonMistakes": [
+      "Aller trop vite — la mobilité demande de la lenteur pour être efficace. Prenez le temps d'explorer chaque position.",
+      "Forcer l'amplitude au-delà de ce que le corps permet — respectez les limitations actuelles et progressez graduellement",
+      "Négliger la respiration — une respiration superficielle empêche le relâchement musculaire nécessaire",
+      "Ne travailler la mobilité qu'en cas de douleur — la prévention est bien plus efficace que la correction",
+      "Confondre mobilité et étirement — la mobilité est un mouvement actif et contrôlé, pas un maintien passif"
+    ]
+  },
+  "echauffement": {
+    "name": "Échauffement dynamique",
+    "aliases": [
+      "Échauffement",
+      "Warm-up",
+      "Arm circles",
+      "Respiration",
+      "Rotations",
+      "Marche",
+      "Course sur place",
+      "Cercles",
+      "Balancement",
+      "A-skips",
+      "Carioca",
+      "Lateral shuffles"
+    ],
+    "muscles": ["Corps entier"],
+    "shortDescription": "Les exercices d'échauffement dynamique préparent le corps à l'effort en augmentant progressivement la température corporelle, la fréquence cardiaque et la lubrification articulaire. Indispensables avant chaque séance pour performer et prévenir les blessures.",
+    "execution": "Commencez par des mouvements lents et de faible amplitude, puis augmentez progressivement la vitesse et l'intensité. L'échauffement dure généralement 5 à 10 minutes. L'objectif est de sentir le corps monter en température et les articulations se « déverrouiller » — vous devez être légèrement essoufflé à la fin.",
+    "breathing": "Respirez naturellement en suivant le rythme des mouvements. La respiration s'accélère progressivement avec l'intensité. Gardez une respiration fluide et régulière.",
+    "benefits": [
+      "Augmente la température corporelle et la vascularisation musculaire",
+      "Prépare les articulations en stimulant la production de liquide synovial",
+      "Réduit significativement le risque de blessures musculaires et articulaires",
+      "Améliore la performance en activant les connexions neuromusculaires",
+      "Crée une transition mentale entre le quotidien et l'entraînement"
+    ],
+    "variants": [
+      {
+        "name": "Rotations articulaires",
+        "description": "Effectuez des cercles lents et contrôlés avec chaque articulation : cou, épaules, coudes, poignets, hanches, genoux et chevilles. Commencez petit et agrandissez progressivement les cercles. 10 rotations dans chaque sens par articulation."
+      },
+      {
+        "name": "Marche rapide sur place",
+        "description": "Marchez vigoureusement sur place en levant les genoux et en balançant les bras de manière coordonnée. Augmente progressivement la fréquence cardiaque sans impact. Parfait pour commencer l'échauffement avant des mouvements plus intenses."
+      },
+      {
+        "name": "Toe taps (marche)",
+        "description": "Face à une marche ou un step bas, tapez alternativement la pointe de chaque pied sur le bord. Le rythme est rapide et régulier, comme un petit pas de course. Travaille la coordination, l'agilité et échauffe les mollets et les fléchisseurs de hanche."
+      },
+      {
+        "name": "Respiration profonde",
+        "description": "Inspirez lentement par le nez pendant 4 secondes en gonflant le ventre, retenez 4 secondes, puis expirez par la bouche pendant 6 secondes. Utilisé en fin de séance pour ramener le système nerveux au calme et accélérer la récupération. 5 à 10 cycles suffisent."
+      }
+    ],
+    "tips": [
+      "Ne sautez jamais l'échauffement — même 3 minutes valent mieux que rien",
+      "Adaptez l'intensité : l'échauffement prépare à l'effort, il ne doit pas vous fatiguer",
+      "Ciblez les zones qui seront le plus sollicitées dans la séance à venir",
+      "En hiver ou par temps froid, allongez la durée de l'échauffement"
+    ],
+    "commonMistakes": [
+      "Sauter directement aux exercices intenses — le corps a besoin de 5 minutes minimum pour se préparer",
+      "Faire des étirements statiques en guise d'échauffement — l'échauffement doit être dynamique et actif",
+      "Aller trop vite et trop fort — l'échauffement est progressif, pas un sprint",
+      "Se contenter de quelques mouvements de bras — tout le corps doit être échauffé, des chevilles aux épaules",
+      "Considérer l'échauffement comme du temps perdu — c'est un investissement pour la performance et la prévention des blessures"
+    ]
+  }
+}

--- a/src/i18n/locales/fr/explore.json
+++ b/src/i18n/locales/fr/explore.json
@@ -20,6 +20,11 @@
     "footer_note": "Les durées indiquées incluent l'échauffement et les étirements.",
     "img_alt": "Format {{name}}"
   },
+  "format_page_meta": {
+    "doc_title": "{{name}} — Format d'entraînement",
+    "doc_title_fallback": "Format",
+    "doc_description": "{{name}} : {{short}} Découvre le principe, le protocole, les bénéfices et les conseils pour ce format d'entraînement sans matériel."
+  },
   "format_page": {
     "back_aria": "Retour aux formats",
     "img_alt": "Format {{name}}",
@@ -48,6 +53,9 @@
   "exercise_page": {
     "back_aria": "Retour aux exercices",
     "demo_aria": "Démonstration : {{name}}",
+    "doc_title": "{{name}} — Exercice",
+    "doc_title_fallback": "Exercice",
+    "doc_description": "{{name}} : {{short}} Exécution, variantes, conseils et erreurs courantes.",
     "section_execution": "Exécution",
     "section_breathing": "Respiration",
     "section_benefits": "Bénéfices",

--- a/src/i18n/locales/fr/formats_data.json
+++ b/src/i18n/locales/fr/formats_data.json
@@ -1,0 +1,234 @@
+{
+  "pyramide": {
+    "name": "Pyramide",
+    "subtitle": "Montée-descente progressive",
+    "shortDescription": "Séries croissantes puis décroissantes pour une montée en charge progressive.",
+    "principle": "Le format Pyramide structure la séance autour d'une montée progressive en répétitions (2, 4, 6, 8…) suivie d'une redescente symétrique. L'intensité augmente naturellement avec le nombre de répétitions, puis diminue, ce qui permet au corps de monter en température graduellement sans choc initial.",
+    "protocol": "Chaque exercice est répété selon un schéma pyramidal. Par exemple : 2 reps → 4 reps → 6 reps → 8 reps → 6 reps → 4 reps → 2 reps. Le repos entre chaque palier est court (15-30s). Le temps de travail par exercice est fixe, le nombre de répétitions monte et descend.",
+    "benefits": [
+      "Échauffement naturellement intégré grâce à la montée progressive",
+      "Auto-régulation : le corps s'adapte à chaque palier",
+      "Travail en endurance musculaire sur les paliers hauts",
+      "Retour au calme facilité par la descente",
+      "Format accessible à tous les niveaux de pratique"
+    ],
+    "targetAudience": "Idéal pour les débutants et ceux qui reprennent le sport. La montée progressive réduit le risque de blessure et permet de trouver son rythme. Convient aussi aux pratiquants intermédiaires qui veulent travailler l'endurance musculaire.",
+    "tips": [
+      "Concentrez-vous sur la qualité du mouvement plutôt que la vitesse, surtout dans les paliers hauts",
+      "Utilisez les paliers bas pour bien placer votre respiration",
+      "Si un palier est trop difficile, restez au palier précédent plutôt que de bâcler les répétitions",
+      "La descente n'est pas un moment de relâchement : maintenez la technique"
+    ],
+    "commonMistakes": [
+      "Aller trop vite sur les premiers paliers et s'épuiser avant le sommet",
+      "Négliger la technique quand le nombre de répétitions augmente",
+      "Sauter des paliers pour aller plus vite",
+      "Ne pas respecter les temps de repos entre les paliers"
+    ],
+    "card_description": "Les répétitions augmentent à chaque palier (2, 4, 6, 8…) puis redescendent. L'intensité monte puis diminue naturellement.",
+    "card_benefit": "Auto-régulé : l'échauffement est intégré dans la montée."
+  },
+  "renforcement": {
+    "name": "Renforcement",
+    "subtitle": "Classique par séries",
+    "shortDescription": "Travail ciblé en séries classiques avec temps de repos structurés.",
+    "principle": "Le renforcement musculaire classique est le format le plus traditionnel de l'entraînement au poids du corps. Chaque exercice est réalisé en séries successives avec un nombre de répétitions défini et un temps de repos entre les séries. Ce format permet de cibler précisément un groupe musculaire et de lui appliquer un volume de travail suffisant pour progresser.",
+    "protocol": "Les exercices sont organisés par groupes musculaires (haut du corps, bas du corps, core). Chaque exercice est réalisé en 3-4 séries de 8-15 répétitions, avec 30-60 secondes de repos entre les séries. Les séances alternent entre des jours « push » (pompes, dips, épaules) et « pull/legs » (squats, fentes, pont fessier).",
+    "benefits": [
+      "Développement ciblé de la force et de la masse musculaire",
+      "Progression mesurable : on peut suivre l'évolution du nombre de reps",
+      "Structure simple et familière, facile à suivre",
+      "Temps de repos suffisants pour maintenir la qualité du mouvement",
+      "Adaptable à tous les niveaux en ajustant reps et séries"
+    ],
+    "targetAudience": "Convient à tous les niveaux. Les débutants apprécieront la structure claire et les temps de repos. Les pratiquants avancés peuvent augmenter le nombre de répétitions ou passer à des variantes plus difficiles (pompes déclinées, pistol squats, etc.).",
+    "tips": [
+      "Privilégiez l'amplitude complète du mouvement à la vitesse",
+      "Utilisez les temps de repos pour vous hydrater et respirer profondément",
+      "Si vous ne pouvez plus maintenir la technique, réduisez les reps plutôt que de tricher",
+      "Alternez haut du corps et bas du corps d'un jour à l'autre pour la récupération"
+    ],
+    "commonMistakes": [
+      "Raccourcir l'amplitude pour faire plus de répétitions",
+      "Ne pas respecter les temps de repos (trop courts ou trop longs)",
+      "Toujours travailler les mêmes groupes musculaires au détriment des autres",
+      "Bloquer sa respiration pendant l'effort"
+    ],
+    "card_description": "Des exercices ciblés en séries avec des temps de repos. Haut du corps (push & pull) ou bas du corps & core.",
+    "card_benefit": "Tonification ciblée. Progression claire et mesurable."
+  },
+  "superset": {
+    "name": "Superset",
+    "subtitle": "Paires antagonistes",
+    "shortDescription": "Deux exercices complémentaires enchaînés sans repos pour un travail équilibré.",
+    "principle": "Le superset consiste à enchaîner deux exercices complémentaires (généralement des muscles antagonistes) sans temps de repos entre eux. Pendant que le premier muscle travaille, l'autre récupère, ce qui permet de doubler le volume de travail dans le même temps. Par exemple : pompes (pectoraux) suivies immédiatement de tirage (dos).",
+    "protocol": "Les exercices sont organisés en paires complémentaires. Chaque paire est réalisée en 3-4 séries. Au sein d'une paire, les deux exercices s'enchaînent sans pause. Le repos (30-60s) intervient entre les paires, pas entre les exercices. Ce rythme maintient un effort constant tout en permettant la récupération musculaire.",
+    "benefits": [
+      "Efficacité temporelle : deux fois plus de travail dans le même temps",
+      "Équilibre musculaire grâce au travail des antagonistes",
+      "Maintien d'une fréquence cardiaque élevée pour un effet cardio",
+      "Récupération active : un muscle récupère pendant que l'autre travaille",
+      "Réduction du temps total de la séance sans perte de qualité"
+    ],
+    "targetAudience": "Pour les pratiquants qui ont déjà une bonne base technique et qui souhaitent optimiser leur temps d'entraînement. La demande cardiovasculaire est modérée mais supérieure au renforcement classique, ce qui en fait un bon format de transition.",
+    "tips": [
+      "Choisissez des paires qui travaillent des groupes musculaires opposés (push/pull, flexion/extension)",
+      "Passez rapidement d'un exercice à l'autre pour maintenir l'effet superset",
+      "Si la fatigue compromet votre technique, prenez quelques secondes de transition",
+      "Hydratez-vous pendant les repos entre les paires"
+    ],
+    "commonMistakes": [
+      "Prendre trop de repos entre les deux exercices d'une paire, ce qui annule l'effet superset",
+      "Choisir deux exercices qui sollicitent le même groupe musculaire",
+      "Négliger la technique sur le deuxième exercice par fatigue",
+      "Ne pas adapter le nombre de répétitions entre les exercices de la paire"
+    ],
+    "card_description": "Deux exercices complémentaires enchaînés sans repos (ex : pompes puis tirage). Repos entre les paires.",
+    "card_benefit": "Travail équilibré et efficace en moins de temps."
+  },
+  "emom": {
+    "name": "EMOM",
+    "subtitle": "Every Minute On the Minute",
+    "shortDescription": "Chaque minute, un effort à compléter. Le temps restant, c'est votre repos.",
+    "principle": "L'EMOM (Every Minute On the Minute) impose un nombre défini de répétitions à réaliser au début de chaque minute. Une fois les répétitions terminées, le temps restant avant la minute suivante est votre repos. Plus vous êtes rapide et efficace, plus vous récupérez. Ce format enseigne la gestion de l'effort : aller trop vite fatigue, aller trop lentement supprime le repos.",
+    "protocol": "Le minuteur tourne par intervalles d'une minute. Au top de chaque minute, réalisez le nombre de répétitions prescrit (ex : 10 squats + 5 pompes). Le temps restant est votre repos. Au top suivant, on repart. La séance dure entre 10 et 16 minutes pour le bloc EMOM, avec échauffement et retour au calme en plus.",
+    "benefits": [
+      "Développe l'endurance musculaire et cardiovasculaire",
+      "Enseigne la gestion de l'effort et du rythme",
+      "Auto-régulation naturelle : le repos s'adapte à votre vitesse",
+      "Motivation par le défi de terminer avant la fin de la minute",
+      "Structure claire et prévisible qui facilite le focus mental"
+    ],
+    "targetAudience": "Accessible aux débutants si le nombre de répétitions est bien calibré (viser 30-40s de travail par minute pour garder 20-30s de repos). Les pratiquants avancés peuvent augmenter le volume ou la difficulté des mouvements.",
+    "tips": [
+      "Visez un rythme régulier plutôt que d'aller à fond la première minute",
+      "Si vous finissez avec moins de 10 secondes de repos, réduisez les reps",
+      "Utilisez le repos pour respirer profondément et vous recentrer",
+      "Gardez un œil sur le chrono pour anticiper le départ de la minute suivante"
+    ],
+    "commonMistakes": [
+      "Partir trop vite les premières minutes et ne plus avoir de repos ensuite",
+      "Bâcler les dernières répétitions pour grappiller du repos",
+      "Ne pas adapter le volume quand on sent que le repos disparaît",
+      "Oublier de compter ses répétitions dans la précipitation"
+    ],
+    "card_description": "À chaque début de minute, réaliser un nombre défini de répétitions. Le temps restant = repos.",
+    "card_benefit": "Développe l'endurance et apprend à gérer son effort."
+  },
+  "circuit": {
+    "name": "Circuit",
+    "subtitle": "Enchaînement full body",
+    "shortDescription": "Rotation d'exercices variés en boucle, mêlant renforcement et cardio.",
+    "principle": "Le circuit training enchaîne plusieurs exercices différents avec un repos minimal entre chacun. Chaque exercice cible un groupe musculaire ou une capacité physique différente, ce qui permet de maintenir l'effort global tout en laissant chaque muscle récupérer partiellement. Le circuit est répété plusieurs fois (rounds) pour augmenter le volume total.",
+    "protocol": "Un circuit typique comprend 4 à 6 exercices variés (haut du corps, bas du corps, core, cardio). Chaque exercice est réalisé pendant 30-45 secondes ou un nombre fixe de répétitions. Le repos entre les exercices est court (10-15s de transition). Le repos entre les rounds est de 60-90 secondes. La séance comprend généralement 3 à 5 rounds.",
+    "benefits": [
+      "Travail complet du corps en une seule séance",
+      "Combinaison efficace de renforcement musculaire et de cardio",
+      "Variété d'exercices qui maintient la motivation et l'engagement",
+      "Adaptable en intensité : on peut jouer sur le nombre de rounds et le temps de repos",
+      "Brûle beaucoup de calories grâce au maintien d'une fréquence cardiaque élevée"
+    ],
+    "targetAudience": "Format polyvalent qui convient aux pratiquants de niveau intermédiaire. Les débutants peuvent l'aborder en allongeant les temps de repos. C'est le format idéal quand on veut un entraînement complet sans se spécialiser.",
+    "tips": [
+      "Alternez les groupes musculaires dans l'ordre du circuit pour éviter la fatigue locale",
+      "Gardez un rythme constant plutôt que d'alterner sprints et pauses longues",
+      "Le premier round est un échauffement : montez progressivement en intensité",
+      "Si un exercice est trop difficile, passez à sa variante simplifiée plutôt que de sauter"
+    ],
+    "commonMistakes": [
+      "Mettre deux exercices sollicitant le même muscle à la suite",
+      "Sprinter sur les premiers rounds et s'effondrer sur les derniers",
+      "Couper les temps de repos au point de compromettre la technique",
+      "Négliger les exercices de core ou de mobilité dans le circuit"
+    ],
+    "card_description": "Enchaînement d'exercices variés avec très peu de repos. On répète le circuit plusieurs fois.",
+    "card_benefit": "Combine renforcement et cardio pour un travail complet."
+  },
+  "amrap": {
+    "name": "AMRAP",
+    "subtitle": "As Many Rounds As Possible",
+    "shortDescription": "Maximum de tours dans le temps imparti. Vous gérez votre propre rythme.",
+    "principle": "L'AMRAP (As Many Rounds As Possible) donne un circuit court d'exercices et un temps total à remplir. L'objectif : réaliser le plus de tours complets possible avant la fin du chrono. Chacun avance à son rythme — il n'y a pas de « bon » nombre de tours, seulement votre record personnel à battre la prochaine fois.",
+    "protocol": "Un circuit de 3-5 exercices avec un nombre de répétitions fixe par exercice (ex : 10 squats, 8 pompes, 6 burpees). Le chrono tourne en continu pendant 8-15 minutes. Pas de repos imposé : vous gérez vos pauses. À la fin, comptez le nombre total de rounds complétés et les répétitions du round en cours.",
+    "benefits": [
+      "Mesure objective de la progression : le nombre de rounds est un indicateur clair",
+      "Liberté totale de rythme : chacun s'adapte à son niveau",
+      "Motivation par le défi personnel de battre son score",
+      "Développe la capacité à gérer l'effort sur la durée",
+      "Format simple à comprendre et à suivre"
+    ],
+    "targetAudience": "Excellent format pour tous les niveaux. Le débutant fera 3 rounds là où l'avancé en fera 7, mais les deux auront un entraînement adapté. Le côté « score » est très motivant pour les compétiteurs dans l'âme.",
+    "tips": [
+      "Trouvez un rythme soutenable dès le premier round et maintenez-le",
+      "Il vaut mieux un rythme constant qu'un départ rapide suivi d'une chute",
+      "Notez votre score pour le comparer la prochaine fois",
+      "Respirez entre les exercices plutôt que de vous arrêter complètement"
+    ],
+    "commonMistakes": [
+      "Partir comme un sprint sur le premier round et cramer en 3 minutes",
+      "Sacrifier la technique pour grappiller des reps",
+      "Prendre de longues pauses entre les exercices au lieu de ralentir le rythme global",
+      "Ne pas noter son score, ce qui empêche de mesurer la progression"
+    ],
+    "card_description": "Enchaîner un circuit le plus de fois possible dans un temps imparti. Tu gères ton rythme.",
+    "card_benefit": "Liberté de rythme. Idéal pour mesurer sa progression."
+  },
+  "hiit": {
+    "name": "HIIT",
+    "subtitle": "High-Intensity Interval Training",
+    "shortDescription": "Efforts explosifs suivis de récupération courte. Court, intense, efficace.",
+    "principle": "Le HIIT alterne des phases d'effort maximal avec des phases de repos ou de récupération active. L'objectif est de pousser le corps dans sa zone d'effort intense pendant les phases de travail, puis de récupérer juste assez pour repartir. Ce format exploite l'effet « afterburn » (EPOC) : le corps continue de brûler des calories plusieurs heures après l'entraînement.",
+    "protocol": "Les intervalles typiques sont de 30 secondes d'effort suivi de 30 secondes de repos (ratio 1:1). Chaque round comprend un exercice réalisé à intensité maximale. La séance comprend 8-12 rounds, soit 8-12 minutes de HIIT pur, encadrées par un échauffement et un retour au calme.",
+    "benefits": [
+      "Efficacité maximale : des résultats significatifs en peu de temps",
+      "Effet afterburn : le métabolisme reste élevé pendant des heures après la séance",
+      "Amélioration rapide de la capacité cardiovasculaire",
+      "Pas de matériel nécessaire : les exercices au poids du corps suffisent",
+      "Format court qui s'intègre facilement dans un emploi du temps chargé"
+    ],
+    "targetAudience": "Réservé aux pratiquants qui ont déjà une bonne condition physique de base et qui maîtrisent la technique des mouvements fondamentaux. L'intensité élevée demande un système cardiovasculaire en bon état et une conscience corporelle développée pour ne pas se blesser.",
+    "tips": [
+      "Donnez vraiment tout pendant les phases de travail — c'est court, profitez-en",
+      "Utilisez les phases de repos pour respirer activement, pas pour consulter votre téléphone",
+      "Choisissez des exercices que vous maîtrisez bien, car la fatigue va dégrader votre technique",
+      "Ne faites pas de HIIT deux jours consécutifs : votre corps a besoin de récupérer"
+    ],
+    "commonMistakes": [
+      "Ne pas donner assez d'intensité pendant les phases de travail (le « I » de HIIT veut dire Intense)",
+      "Enchaîner les séances HIIT sans jours de repos entre elles",
+      "Choisir des mouvements trop complexes qui deviennent dangereux sous fatigue",
+      "Ignorer l'échauffement sous prétexte que la séance est courte"
+    ],
+    "card_description": "Alternance d'effort intense (30s) et de repos (30s). Chaque exercice est réalisé à fond.",
+    "card_benefit": "Maximum de résultats en minimum de temps."
+  },
+  "tabata": {
+    "name": "Tabata",
+    "subtitle": "Protocole 20/10",
+    "shortDescription": "20 secondes à fond, 10 secondes de repos. Le format le plus court et le plus intense.",
+    "principle": "Le protocole Tabata, développé par le Dr Izumi Tabata en 1996, est un format d'entraînement par intervalles ultra-courts. Le ratio travail/repos de 2:1 (20s d'effort / 10s de repos) est conçu pour pousser le corps à son maximum absolu. En seulement 4 minutes par set (8 rounds de 30 secondes), ce protocole développe simultanément les filières aérobie et anaérobie.",
+    "protocol": "Un set Tabata classique : 8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Total : 4 minutes. Sur Wan2Fit, les séances Tabata incluent 1 à 2 sets avec un repos de 60 secondes entre les sets. L'effort pendant les 20 secondes doit être maximal : si vous pouvez parler, vous n'allez pas assez fort.",
+    "benefits": [
+      "Format le plus court : 4 minutes de travail intense par set",
+      "Amélioration prouvée scientifiquement des capacités aérobie et anaérobie",
+      "Effet afterburn significatif malgré la durée courte",
+      "Développe la puissance, l'explosivité et l'endurance simultanément",
+      "Défi mental : apprendre à maintenir l'intensité quand le corps dit stop"
+    ],
+    "targetAudience": "Réservé aux pratiquants avancés avec une excellente condition cardiovasculaire. Ce n'est pas un format pour débuter le sport. Il demande une maîtrise parfaite des mouvements car les 20 secondes d'effort maximal sous fatigue exigent un contrôle technique irréprochable.",
+    "tips": [
+      "Choisissez des mouvements simples et explosifs (burpees, mountain climbers, squats sautés)",
+      "Les 10 secondes de repos passent très vite : positionnez-vous immédiatement pour le round suivant",
+      "L'effort doit être véritablement maximal : à la fin des 8 rounds, vous devez être épuisé",
+      "Limitez-vous à 1-2 séances Tabata par semaine maximum"
+    ],
+    "commonMistakes": [
+      "Garder du rythme en réserve « au cas où » — le Tabata exige 100% d'effort à chaque round",
+      "Utiliser des mouvements complexes qui deviennent dangereux sous fatigue extrême",
+      "Faire des séances Tabata trop fréquemment (plus de 2 fois par semaine)",
+      "Confondre Tabata avec du HIIT classique : 20/10 est beaucoup plus intense que 30/30"
+    ],
+    "card_description": "8 rounds de 20 secondes d'effort maximal suivies de 10 secondes de repos. Court mais intense.",
+    "card_benefit": "Le format le plus court et le plus intense."
+  }
+}

--- a/src/i18n/locales/fr/programs.json
+++ b/src/i18n/locales/fr/programs.json
@@ -59,6 +59,7 @@
   },
   "content": {
     "back_aria": "Retour aux programmes",
+    "img_alt": "Programme {{headline}}",
     "stat_duration": "Durée",
     "stat_frequency": "Fréquence",
     "stat_session_length": "Par séance",

--- a/src/i18n/locales/fr/programs_data.json
+++ b/src/i18n/locales/fr/programs_data.json
@@ -1,0 +1,104 @@
+{
+  "debutant-4-semaines": {
+    "headline": "Construis tes fondations",
+    "intro": "Tu reprends le sport ou tu débutes ? Ce programme de 4 semaines t'accompagne pas à pas. Chaque semaine ajoute un peu d'intensité pour que tu progresses sans jamais te sentir dépassé.",
+    "audience": "Reprise d'activité, vrai débutant, ou toute personne qui veut (re)partir sur de bonnes bases.",
+    "duration": "4 semaines",
+    "frequency": "3 séances par semaine",
+    "sessionLength": "~25 min",
+    "approach": "La progression est pensée pour que tu ne brûles pas les étapes. On commence par des mouvements simples avec beaucoup de repos, puis on raccourcit les pauses et on ajoute des variantes plus complètes au fil des semaines.",
+    "weeks": [
+      {
+        "title": "Découverte",
+        "description": "Mouvements de base, 2 séries, repos généreux. On apprend les gestes fondamentaux : squats, pompes adaptées, gainage."
+      },
+      {
+        "title": "Installation",
+        "description": "Mêmes patterns améliorés, 2-3 séries, reps en hausse. Le corps commence à mémoriser les mouvements."
+      },
+      {
+        "title": "Progression",
+        "description": "Variantes complètes (planche pieds, pompes standard), 3 séries. On introduit le format EMOM pour apprendre à gérer son effort."
+      },
+      {
+        "title": "Consolidation",
+        "description": "Circuits combinés, supersets, volume augmenté. Tu maîtrises les bases et tu es prêt pour la suite."
+      }
+    ],
+    "benefits": [
+      "Apprendre les mouvements fondamentaux en toute sécurité",
+      "Créer une habitude sportive régulière",
+      "Gagner en confiance et en mobilité",
+      "Préparer le corps pour des programmes plus intenses"
+    ],
+    "tip": "Pas besoin de forcer dès le début. Le plus important, c'est la régularité. 3 séances par semaine suffisent pour voir des résultats concrets en un mois."
+  },
+  "remise-en-forme": {
+    "headline": "Retrouve ton rythme",
+    "intro": "Tu as déjà fait du sport mais tu as décroché ? Ce programme remet les choses en place. Formats variés dès la première semaine, intensité progressive — tu retrouves tes sensations rapidement.",
+    "audience": "Ancien sportif en reprise, ou niveau intermédiaire qui veut structurer son entraînement.",
+    "duration": "4 semaines",
+    "frequency": "4 séances par semaine",
+    "sessionLength": "~30 min",
+    "approach": "Pas de phase de découverte ici : on attaque directement avec des formats variés. Chaque semaine alterne haut du corps, bas du corps, full-body et cardio pour un travail complet et équilibré.",
+    "weeks": [
+      {
+        "title": "Reprise active",
+        "description": "Renforcement ciblé et premiers circuits. On réveille les groupes musculaires avec des séances structurées."
+      },
+      {
+        "title": "Montée en charge",
+        "description": "Volume et intensité augmentent. Supersets et EMOM pour travailler l'endurance musculaire."
+      },
+      {
+        "title": "Pic d'intensité",
+        "description": "Formats exigeants : AMRAP, HIIT. Le corps est prêt à être poussé. Les séances sont plus courtes mais plus intenses."
+      },
+      {
+        "title": "Maîtrise",
+        "description": "Combinaisons avancées, circuits complexes. Tu termines le programme en pleine forme, prêt pour un nouveau challenge."
+      }
+    ],
+    "benefits": [
+      "Retrouver rapidement un bon niveau de condition physique",
+      "Travailler tout le corps de manière équilibrée",
+      "Découvrir plusieurs formats d'entraînement",
+      "Relancer le métabolisme et l'endurance"
+    ],
+    "tip": "Si une séance te semble facile, c'est normal — c'est le signe que tu es en forme pour ça. La semaine suivante ajustera le curseur."
+  },
+  "cardio-express": {
+    "headline": "Court, intense, efficace",
+    "intro": "Pas le temps de faire une heure de sport ? Ce programme mise sur des séances courtes à haute intensité. 20 minutes suffisent pour transpirer, progresser et repartir.",
+    "audience": "Emploi du temps chargé, sportif qui veut du résultat sans y passer des heures.",
+    "duration": "4 semaines",
+    "frequency": "3 séances par semaine",
+    "sessionLength": "~20 min",
+    "approach": "Chaque séance utilise des formats conçus pour maximiser l'effort en peu de temps : HIIT, Tabata, EMOM. L'intensité monte progressivement pour que ton cardio et ton explosivité s'améliorent semaine après semaine.",
+    "weeks": [
+      {
+        "title": "Mise en route",
+        "description": "HIIT et intervalles classiques. On calibre l'intensité et on installe le rythme."
+      },
+      {
+        "title": "Accélération",
+        "description": "Tabata et EMOM entrent en jeu. Les repos se raccourcissent, le cardio monte d'un cran."
+      },
+      {
+        "title": "Haute intensité",
+        "description": "Séances plus denses, combinaisons explosives. Le cœur travaille à plein régime."
+      },
+      {
+        "title": "Full throttle",
+        "description": "Les séances les plus intenses du programme. Tu mesures tes progrès avec des formats chronométrés."
+      }
+    ],
+    "benefits": [
+      "Améliorer son cardio en moins de temps",
+      "Brûler un maximum de calories en 20 minutes",
+      "Développer l'explosivité et la résistance",
+      "S'entraîner même avec un planning chargé"
+    ],
+    "tip": "L'intensité est la clé. Mieux vaut 20 minutes à fond que 45 minutes à mi-régime. Donne tout pendant les phases d'effort, récupère à fond pendant les pauses."
+  }
+}

--- a/src/types/custom-session.ts
+++ b/src/types/custom-session.ts
@@ -37,6 +37,7 @@ export interface CustomSessionRecord {
   input_tokens: number | null;
   output_tokens: number | null;
   model: string | null;
+  locale: 'fr' | 'en';
   created_at: string;
 }
 

--- a/src/types/exercise.ts
+++ b/src/types/exercise.ts
@@ -2,13 +2,19 @@ export type ExerciseCategory = 'upper' | 'lower' | 'core' | 'cardio' | 'full-bod
 
 export interface ExerciseData {
   slug: string;
-  name: string;
-  aliases: string[];
   category: ExerciseCategory;
-  muscles: string[];
   difficulty: 1 | 2 | 3;
   image: string;
   video?: string;
+  /** Video URLs for variants, keyed by variant index. Only present when a variant has a video. */
+  variantVideos?: Record<number, string>;
+}
+
+/** Full exercise data as returned to the view layer (static fields + i18n-resolved text). */
+export interface ExerciseView extends ExerciseData {
+  name: string;
+  aliases: string[];
+  muscles: string[];
   shortDescription: string;
   execution: string;
   breathing: string;

--- a/src/types/format.ts
+++ b/src/types/format.ts
@@ -3,16 +3,7 @@ import type { BlockType } from './session.ts';
 export interface FormatData {
   type: BlockType;
   slug: string;
-  name: string;
-  subtitle: string;
   duration: string;
   intensity: number;
   image: string;
-  shortDescription: string;
-  principle: string;
-  protocol: string;
-  benefits: string[];
-  targetAudience: string;
-  tips: string[];
-  commonMistakes: string[];
 }

--- a/src/utils/exerciseLinks.ts
+++ b/src/utils/exerciseLinks.ts
@@ -1,12 +1,20 @@
 import { EXERCISES_DATA } from '../data/exercises.ts';
+import exercisesEn from '../i18n/locales/en/exercises_data.json';
+import exercisesFr from '../i18n/locales/fr/exercises_data.json';
+
+type LocaleExerciseEntry = {
+  name: string;
+  aliases?: string[];
+  variants?: { name: string; description?: string }[];
+};
+
+type LocaleExercisesMap = Record<string, LocaleExerciseEntry>;
+
+const localeMaps: LocaleExercisesMap[] = [exercisesFr as LocaleExercisesMap, exercisesEn as LocaleExercisesMap];
 
 /** Lowercase, strip accents */
 function normalize(name: string): string {
-  return name
-    .trim()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase();
+  return name.trim().normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
 }
 
 /** Lowercase, strip accents, spaces → hyphens */
@@ -21,18 +29,23 @@ interface ExerciseLink {
 
 const linkMap = new Map<string, ExerciseLink>();
 
+// Build lookup from every supported locale so AI-generated sessions match
+// regardless of whether they were produced in FR or EN.
 for (const ex of EXERCISES_DATA) {
   const entry: ExerciseLink = { slug: ex.slug };
 
-  // Main name + aliases
-  linkMap.set(normalize(ex.name), entry);
-  for (const alias of ex.aliases) {
-    linkMap.set(normalize(alias), entry);
-  }
+  for (const map of localeMaps) {
+    const localized = map[ex.slug];
+    if (!localized) continue;
 
-  // Variants → link to parent with anchor
-  for (const v of ex.variants) {
-    linkMap.set(normalize(v.name), { slug: ex.slug, anchor: slugify(v.name) });
+    linkMap.set(normalize(localized.name), entry);
+    for (const alias of localized.aliases ?? []) {
+      linkMap.set(normalize(alias), entry);
+    }
+
+    for (const v of localized.variants ?? []) {
+      linkMap.set(normalize(v.name), { slug: ex.slug, anchor: slugify(v.name) });
+    }
   }
 }
 

--- a/src/utils/exerciseVideo.ts
+++ b/src/utils/exerciseVideo.ts
@@ -1,34 +1,48 @@
 import { EXERCISES_DATA } from '../data/exercises.ts';
+import exercisesEn from '../i18n/locales/en/exercises_data.json';
+import exercisesFr from '../i18n/locales/fr/exercises_data.json';
+
+type LocaleExerciseEntry = {
+  name: string;
+  aliases?: string[];
+  variants?: { name: string; description?: string }[];
+};
+
+type LocaleExercisesMap = Record<string, LocaleExerciseEntry>;
+
+const localeMaps: LocaleExercisesMap[] = [exercisesFr as LocaleExercisesMap, exercisesEn as LocaleExercisesMap];
 
 /** Lowercase, strip accents */
 function normalize(name: string): string {
-  return name
-    .trim()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase();
+  return name.trim().normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
 }
 
 /** Exact lookup: normalized name → video URL */
 const exactMap = new Map<string, string>();
 
-// Build lookup table once at module load
+// Build lookup table once at module load, covering every supported locale so
+// AI-generated sessions resolve to the right video regardless of the language
+// the session was produced in.
 for (const ex of EXERCISES_DATA) {
   const mainVideo = ex.video;
 
-  // Main name + aliases → exercise video
-  if (mainVideo) {
-    exactMap.set(normalize(ex.name), mainVideo);
-    for (const a of ex.aliases) {
-      exactMap.set(normalize(a), mainVideo);
-    }
-  }
+  for (const map of localeMaps) {
+    const localized = map[ex.slug];
+    if (!localized) continue;
 
-  // Variants → only if the variant has its own video
-  for (const v of ex.variants) {
-    if (v.video) {
-      exactMap.set(normalize(v.name), v.video);
+    if (mainVideo) {
+      exactMap.set(normalize(localized.name), mainVideo);
+      for (const a of localized.aliases ?? []) {
+        exactMap.set(normalize(a), mainVideo);
+      }
     }
+
+    (localized.variants ?? []).forEach((v, i) => {
+      const variantVideo = ex.variantVideos?.[i];
+      if (variantVideo) {
+        exactMap.set(normalize(v.name), variantVideo);
+      }
+    });
   }
 }
 

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
-import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
+import { buildSystemPrompt, buildUserPrompt, type Locale } from "./prompt.ts";
 import { sanitizeOnboardingForPersistence } from "./sanitize.ts";
 import { validateProgram } from "./validate.ts";
 
@@ -23,6 +23,7 @@ const VALID_MATERIEL = [
   'step', 'foam_roller', 'anneaux',
 ];
 const VALID_DUREES = [4, 8, 12];
+const VALID_LOCALES: Locale[] = ["fr", "en"];
 
 function jsonResponse(req: Request, data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -53,6 +54,7 @@ interface RequestInput {
   duree_seance_minutes: number;
   materiel: string[];
   duree_semaines: number;
+  locale?: string;
 }
 
 function validateInput(body: RequestInput): string | null {
@@ -108,6 +110,10 @@ function validateInput(body: RequestInput): string | null {
     return "blessure_detail doit etre une chaine";
   if (body.blessure_detail && body.blessure_detail.length > 300)
     return "blessure_detail: 300 caracteres max";
+
+  if (body.locale && !VALID_LOCALES.includes(body.locale as Locale)) {
+    return "locale invalide";
+  }
 
   return null;
 }
@@ -241,7 +247,9 @@ Deno.serve(async (req: Request) => {
   }
 
   // Build prompt
-  const userPrompt = buildUserPrompt(body);
+  const locale: Locale = (body.locale as Locale) ?? "fr";
+  const userPrompt = buildUserPrompt({ ...body, locale });
+  const systemPrompt = buildSystemPrompt(locale);
 
   // Call Anthropic API
   // Sonnet with 12K tokens needs more time than Haiku session generation
@@ -261,7 +269,7 @@ Deno.serve(async (req: Request) => {
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
-        system: SYSTEM_PROMPT,
+        system: systemPrompt,
         messages,
       }),
       signal: AbortSignal.timeout(timeoutMs),
@@ -370,6 +378,7 @@ Deno.serve(async (req: Request) => {
       input_tokens: totalInputTokens,
       output_tokens: totalOutputTokens,
       model: MODEL,
+      locale,
     })
     .select("id")
     .single();

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -16,7 +16,11 @@ interface ProgramInput {
   locale?: Locale;
 }
 
-const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: titre, description, note_coach, progression.logique, progression.cible_semaine_*, consignes_semaine.*, sessions.*.title, sessions.*.description, sessions.*.focus, blocks.*.name, exercises.*.name, exercises.*.instructions. Use idiomatic fitness English. JSON keys stay exactly as specified below (keep fr keys like "titre", "seances_par_semaine", etc. — only translate the VALUES).\n\n`;
+const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: titre, description, note_coach, progression.logique, progression.cible_semaine_*, consignes_semaine.*, sessions.*.title, sessions.*.description, sessions.*.focus, blocks.*.name, exercises.*.name, exercises.*.instructions. Use idiomatic fitness English. JSON keys stay exactly as specified below (keep fr keys like "titre", "seances_par_semaine", etc. — only translate the VALUES).
+
+The example mini-program below uses French exercise names; map them to their natural English equivalents in your output (e.g. "Squats" → "Squats", "Pompes" → "Push-ups", "Rowing inversé" → "Inverted row", "Mountain climbers" → "Mountain climbers", "Planche" → "Plank", "Jumping jacks" → "Jumping jacks", "Échauffement" / "Echauffement" → "Warm-up", "Retour au calme" → "Cool-down", "Bloc renforcement" → "Strength block", "Circuit cardio-core" → "Cardio-core circuit", "Étirement quadriceps" → "Quad stretch", "Étirement pectoraux" → "Chest stretch", "Étirement ischio-jambiers" → "Hamstring stretch", "Respiration profonde" → "Deep breathing").
+
+`;
 
 export function buildSystemPrompt(locale: Locale = 'fr'): string {
   if (locale === 'en') return LANGUAGE_DIRECTIVE_EN + SYSTEM_PROMPT;

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -1,3 +1,5 @@
+export type Locale = 'fr' | 'en';
+
 interface ProgramInput {
   objectifs: string[];
   objectif_detail?: string;
@@ -11,6 +13,14 @@ interface ProgramInput {
   duree_seance_minutes: number;
   materiel: string[];
   duree_semaines: number;
+  locale?: Locale;
+}
+
+const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: titre, description, note_coach, progression.logique, progression.cible_semaine_*, consignes_semaine.*, sessions.*.title, sessions.*.description, sessions.*.focus, blocks.*.name, exercises.*.name, exercises.*.instructions. Use idiomatic fitness English. JSON keys stay exactly as specified below (keep fr keys like "titre", "seances_par_semaine", etc. — only translate the VALUES).\n\n`;
+
+export function buildSystemPrompt(locale: Locale = 'fr'): string {
+  if (locale === 'en') return LANGUAGE_DIRECTIVE_EN + SYSTEM_PROMPT;
+  return SYSTEM_PROMPT;
 }
 
 export const SYSTEM_PROMPT = `Tu es un preparateur physique expert. Tu generes des programmes d'entrainement multi-semaines au format JSON uniquement.

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
-import { SYSTEM_PROMPT, buildUserPrompt } from "./prompt.ts";
+import { buildSystemPrompt, buildUserPrompt, type Locale } from "./prompt.ts";
 import { validateSession } from "./validate.ts";
 
 const MAX_DAILY_GENERATIONS = 10;
@@ -30,6 +30,7 @@ const VALID_EQUIPMENT = [
 const VALID_INTENSITIES = ["douce", "moderee", "intense"];
 const VALID_BODY_FOCUS = ["upper", "lower", "core", "full"];
 const VALID_DURATIONS = [10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90];
+const VALID_LOCALES: Locale[] = ["fr", "en"];
 
 function jsonResponse(req: Request, data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -51,6 +52,7 @@ interface RequestInput {
   bodyFocus?: string[];
   preferences?: string;
   refinementNote?: string;
+  locale?: string;
 }
 
 function validateInput(body: RequestInput): string | null {
@@ -106,6 +108,10 @@ function validateInput(body: RequestInput): string | null {
   }
   if (body.refinementNote && body.refinementNote.length > 300) {
     return "refinementNote: 300 caractères max";
+  }
+
+  if (body.locale && !VALID_LOCALES.includes(body.locale as Locale)) {
+    return "locale invalide";
   }
 
   return null;
@@ -205,7 +211,9 @@ Deno.serve(async (req: Request) => {
   }
 
   // Build prompt
-  const userPrompt = buildUserPrompt(body as Parameters<typeof buildUserPrompt>[0]);
+  const locale: Locale = (body.locale as Locale) ?? "fr";
+  const userPrompt = buildUserPrompt({ ...body, locale } as Parameters<typeof buildUserPrompt>[0]);
+  const systemPrompt = buildSystemPrompt(locale);
 
   // Call Anthropic API
   let aiResponse: Response;
@@ -220,7 +228,7 @@ Deno.serve(async (req: Request) => {
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
-        system: SYSTEM_PROMPT,
+        system: systemPrompt,
         messages: [{ role: "user", content: userPrompt }],
       }),
       signal: AbortSignal.timeout(30_000),
@@ -297,6 +305,7 @@ Deno.serve(async (req: Request) => {
       input_tokens: inputTokens,
       output_tokens: outputTokens,
       model: MODEL,
+      locale,
     })
     .select("id")
     .single();

--- a/supabase/functions/generate-session/prompt.ts
+++ b/supabase/functions/generate-session/prompt.ts
@@ -44,7 +44,11 @@ const PRESET_DESCRIPTIONS: Record<Locale, Record<string, string>> = {
   },
 };
 
-const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: title, description, focus tags, block names, exercise names, instructions, and any other string value. Use idiomatic fitness English. JSON keys stay exactly as specified below.\n\n`;
+const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: title, description, focus tags, block names, exercise names, instructions, and any other string value. Use idiomatic fitness English. JSON keys stay exactly as specified below.
+
+The example session below uses French exercise names; map them to their natural English equivalents in your output (e.g. "Rotation des bras" → "Arm circles", "Montées de genoux" → "High knees", "Squats" → "Squats", "Pompes" → "Push-ups", "Mountain climbers" → "Mountain climbers", "Étirements quadriceps" → "Quad stretches", "Respiration profonde" → "Deep breathing", "Échauffement" → "Warm-up", "Retour au calme" → "Cool-down", "Circuit Full Body" → "Full Body Circuit").
+
+`;
 
 export const SYSTEM_PROMPT = `Tu es un coach fitness expert. Tu génères des séances d'entraînement au format JSON uniquement.
 
@@ -62,7 +66,7 @@ RÈGLES STRICTES :
 - Le premier bloc DOIT être de type "warmup"
 - Le dernier bloc DOIT être de type "cooldown"
 - Respecte la durée demandée (±3 minutes)
-- Tout le contenu en français
+- Tout le contenu dans la langue indiquée par la directive de langue en tête (français par défaut)
 - Instructions concises (1-2 phrases max par exercice)
 - Pas de HTML, pas d'URLs dans les textes
 

--- a/supabase/functions/generate-session/prompt.ts
+++ b/supabase/functions/generate-session/prompt.ts
@@ -1,8 +1,11 @@
+export type Locale = 'fr' | 'en';
+
 interface QuickInput {
   mode: 'quick';
   preset: string;
   duration: number;
   refinementNote?: string;
+  locale?: Locale;
 }
 
 interface DetailedInput {
@@ -13,6 +16,7 @@ interface DetailedInput {
   bodyFocus?: string[];
   preferences?: string;
   refinementNote?: string;
+  locale?: Locale;
 }
 
 interface ExpertInput {
@@ -20,16 +24,27 @@ interface ExpertInput {
   duration: number;
   preferences: string;
   refinementNote?: string;
+  locale?: Locale;
 }
 
 type PromptInput = QuickInput | DetailedInput | ExpertInput;
 
-const PRESET_DESCRIPTIONS: Record<string, string> = {
-  transpirer: 'HIIT et Tabata, haute intensité, cardio explosif',
-  renfo: 'renforcement musculaire structuré, séries et répétitions',
-  express: 'circuit rapide full body, zéro temps mort',
-  mobilite: 'stretching, mobilité et récupération active, intensité douce',
+const PRESET_DESCRIPTIONS: Record<Locale, Record<string, string>> = {
+  fr: {
+    transpirer: 'HIIT et Tabata, haute intensité, cardio explosif',
+    renfo: 'renforcement musculaire structuré, séries et répétitions',
+    express: 'circuit rapide full body, zéro temps mort',
+    mobilite: 'stretching, mobilité et récupération active, intensité douce',
+  },
+  en: {
+    transpirer: 'HIIT and Tabata, high intensity, explosive cardio',
+    renfo: 'structured strength training, sets and reps',
+    express: 'fast full-body circuit, zero downtime',
+    mobilite: 'stretching, mobility and active recovery, low intensity',
+  },
 };
+
+const LANGUAGE_DIRECTIVE_EN = `CRITICAL LANGUAGE OVERRIDE: All user-facing strings in your JSON output MUST be in natural English. This applies to: title, description, focus tags, block names, exercise names, instructions, and any other string value. Use idiomatic fitness English. JSON keys stay exactly as specified below.\n\n`;
 
 export const SYSTEM_PROMPT = `Tu es un coach fitness expert. Tu génères des séances d'entraînement au format JSON uniquement.
 
@@ -115,52 +130,83 @@ EXEMPLE DE SÉANCE VALIDE :
   ]
 }`;
 
+const FOCUS_LABELS: Record<Locale, Record<string, string>> = {
+  fr: {
+    upper: 'Haut du corps',
+    lower: 'Bas du corps',
+    core: 'Core / Abdos',
+    full: 'Full body',
+  },
+  en: {
+    upper: 'Upper body',
+    lower: 'Lower body',
+    core: 'Core / Abs',
+    full: 'Full body',
+  },
+};
+
+export function buildSystemPrompt(locale: Locale = 'fr'): string {
+  if (locale === 'en') return LANGUAGE_DIRECTIVE_EN + SYSTEM_PROMPT;
+  return SYSTEM_PROMPT;
+}
+
 export function buildUserPrompt(input: PromptInput): string {
+  const locale: Locale = input.locale ?? 'fr';
   const parts: string[] = [];
 
+  const L = (fr: string, en: string) => (locale === 'en' ? en : fr);
+
   if (input.mode === 'quick') {
-    const desc = PRESET_DESCRIPTIONS[input.preset] ?? input.preset;
+    const desc = PRESET_DESCRIPTIONS[locale][input.preset] ?? input.preset;
     parts.push(
-      `Crée une séance axée ${desc} d'environ ${input.duration} minutes.`,
+      L(
+        `Crée une séance axée ${desc} d'environ ${input.duration} minutes.`,
+        `Create a session focused on ${desc}, about ${input.duration} minutes.`,
+      ),
     );
   } else if (input.mode === 'expert') {
     parts.push(
-      `Crée une séance d'environ ${input.duration} minutes selon les préférences suivantes :\n<user_input>\n${input.preferences}\n</user_input>`,
+      L(
+        `Crée une séance d'environ ${input.duration} minutes selon les préférences suivantes :\n<user_input>\n${input.preferences}\n</user_input>`,
+        `Create a session of about ${input.duration} minutes following these preferences:\n<user_input>\n${input.preferences}\n</user_input>`,
+      ),
     );
   } else {
-    parts.push(`Crée une séance de ${input.duration} minutes.`);
+    parts.push(L(`Crée une séance de ${input.duration} minutes.`, `Create a ${input.duration}-minute session.`));
 
     if (input.equipment && input.equipment.length > 0) {
       const equipList = input.equipment.join(', ');
-      parts.push(`Équipement disponible : ${equipList}.`);
+      parts.push(L(`Équipement disponible : ${equipList}.`, `Available equipment: ${equipList}.`));
     } else {
-      parts.push('Sans matériel (poids du corps uniquement).');
+      parts.push(L('Sans matériel (poids du corps uniquement).', 'No equipment (bodyweight only).'));
     }
 
     if (input.intensity) {
-      parts.push(`Intensité souhaitée : ${input.intensity}.`);
+      parts.push(L(`Intensité souhaitée : ${input.intensity}.`, `Target intensity: ${input.intensity}.`));
     }
 
     if (input.bodyFocus && input.bodyFocus.length > 0) {
-      const FOCUS_LABELS: Record<string, string> = {
-        upper: 'Haut du corps',
-        lower: 'Bas du corps',
-        core: 'Core / Abdos',
-        full: 'Full body',
-      };
-      const focusList = input.bodyFocus
-        .map((f) => FOCUS_LABELS[f] ?? f)
-        .join(', ');
-      parts.push(`Zones ciblées : ${focusList}.`);
+      const focusList = input.bodyFocus.map((f) => FOCUS_LABELS[locale][f] ?? f).join(', ');
+      parts.push(L(`Zones ciblées : ${focusList}.`, `Target zones: ${focusList}.`));
     }
 
     if (input.preferences) {
-      parts.push(`Préférences :\n<user_input>\n${input.preferences}\n</user_input>`);
+      parts.push(
+        L(
+          `Préférences :\n<user_input>\n${input.preferences}\n</user_input>`,
+          `Preferences:\n<user_input>\n${input.preferences}\n</user_input>`,
+        ),
+      );
     }
   }
 
   if (input.refinementNote) {
-    parts.push(`\nNote de modification :\n<user_input>\n${input.refinementNote}\n</user_input>`);
+    parts.push(
+      L(
+        `\nNote de modification :\n<user_input>\n${input.refinementNote}\n</user_input>`,
+        `\nRefinement note:\n<user_input>\n${input.refinementNote}\n</user_input>`,
+      ),
+    );
   }
 
   return parts.join('\n');

--- a/supabase/migrations/018_i18n_locale_column.sql
+++ b/supabase/migrations/018_i18n_locale_column.sql
@@ -9,16 +9,30 @@
 ALTER TABLE public.custom_sessions
   ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT 'fr';
 
-ALTER TABLE public.custom_sessions
-  ADD CONSTRAINT custom_sessions_locale_check
-  CHECK (locale IN ('fr', 'en'));
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'custom_sessions_locale_check'
+  ) THEN
+    ALTER TABLE public.custom_sessions
+      ADD CONSTRAINT custom_sessions_locale_check
+      CHECK (locale IN ('fr', 'en'));
+  END IF;
+END $$;
 
 ALTER TABLE public.programs
   ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT 'fr';
 
-ALTER TABLE public.programs
-  ADD CONSTRAINT programs_locale_check
-  CHECK (locale IN ('fr', 'en'));
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'programs_locale_check'
+  ) THEN
+    ALTER TABLE public.programs
+      ADD CONSTRAINT programs_locale_check
+      CHECK (locale IN ('fr', 'en'));
+  END IF;
+END $$;
 
 COMMENT ON COLUMN public.custom_sessions.locale IS
   'Language the session_data was generated in. Pre-i18n rows are ''fr''.';

--- a/supabase/migrations/018_i18n_locale_column.sql
+++ b/supabase/migrations/018_i18n_locale_column.sql
@@ -1,0 +1,27 @@
+-- Add `locale` column to custom_sessions and programs so AI-generated content
+-- knows which language it was produced in. Existing rows are backfilled to 'fr'
+-- (the app's historical default) and stay frozen in that language — no server
+-- retranslation pass is performed.
+--
+-- The column is referenced at render time by the client but is purely
+-- informational; queries / RLS / RPC behaviour are unchanged.
+
+ALTER TABLE public.custom_sessions
+  ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT 'fr';
+
+ALTER TABLE public.custom_sessions
+  ADD CONSTRAINT custom_sessions_locale_check
+  CHECK (locale IN ('fr', 'en'));
+
+ALTER TABLE public.programs
+  ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT 'fr';
+
+ALTER TABLE public.programs
+  ADD CONSTRAINT programs_locale_check
+  CHECK (locale IN ('fr', 'en'));
+
+COMMENT ON COLUMN public.custom_sessions.locale IS
+  'Language the session_data was generated in. Pre-i18n rows are ''fr''.';
+
+COMMENT ON COLUMN public.programs.locale IS
+  'Language the program content was generated in. Fixed programs and pre-i18n rows are ''fr''.';


### PR DESCRIPTION
## Summary
PR 3/4 du chantier i18n. Externalise tout le contenu éditorial vers i18n et fait générer l'IA dans la langue courante de l'utilisateur.

## Contenu éditorial
- \`src/data/formats.ts\` / \`types/format.ts\` : 9 champs textuels retirés, métadonnées only
- \`src/data/exercises.ts\` / \`types/exercise.ts\` : même traitement, \`variantVideos\` côté TS
- \`src/data/programContent.ts\` : \`PROGRAM_CONTENT_META\` (slug + week numbers + format tags)
- 3 nouveaux namespaces : \`formats_data\`, \`exercises_data\`, \`programs_data\`
- **16 namespaces, 1947 clés FR/EN isomorphes**

## Consumers migrés
- Formats / FormatPage / Discover / Exercises / ExercisePage / ProgramContentPage
- \`utils/exerciseLinks\` + \`utils/exerciseVideo\` : lookup maps construites depuis les 2 locales pour matcher les noms d'exos quelle que soit la langue de la séance IA
- \`FORMAT_DESCRIPTIONS\` / \`FORMAT_SHORT_DESCS\` hardcodés retirés (\`card_description\` / \`card_benefit\` injectés dans formats_data)

## Edge functions IA
- \`generate-session\` : accepte \`locale\` dans le body, \`buildSystemPrompt(locale)\` prépend une directive EN avec le mapping FR→EN des noms d'exos cités dans l'exemple, \`PRESET_DESCRIPTIONS\` et \`FOCUS_LABELS\` localisés
- \`generate-program\` : idem (Sonnet gère le user prompt FR avec directive EN sur le system prompt)
- Validation \`locale in ('fr', 'en')\` côté edge
- Colonne \`locale\` persistée

## Migration Supabase
\`018_i18n_locale_column.sql\` : ALTER TABLE + CHECK \`('fr', 'en')\` sur \`custom_sessions\` et \`programs\`. **Idempotente** (DO block + \`pg_constraint\` guard pour replay safe). Lignes pré-i18n backfillées à \`'fr'\`.

## Hooks client
\`useGenerateSession\` / \`useGenerateProgram\` lisent \`i18n.language\` et l'envoient dans le payload.

## Test plan
- [x] \`npm run lint\` — 9 warnings (baseline), 0 erreur
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 317/317
- [x] Isomorphisme FR/EN : 16 namespaces, ~1947 clés alignées
- [x] Chrome EN : /decouvrir, /formats/pyramide, /exercices, /parametres → aucun orphelin UI ou contenu (seuls résidus = titres de séances IA antérieures, figés en \`fr\` par design)
- [x] Review quality-engineer : CRITICAL et WARNING actionnable adressés (commit \`3dce418\`)

## Suite
- **PR 4** — QA finale globale + isomorphisme en CI, puis merge \`develop → main\`
- \`develop\` ne part pas en prod tant que la PR 4 n'est pas validée

🤖 Generated with [Claude Code](https://claude.com/claude-code)