### PR TITLE
feat(i18n): QA finale + parity guard CI (PR 4/4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: i18n FR/EN parity
+        run: npm run check:i18n
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dead-code": "knip",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "check:i18n": "node scripts/check-i18n.mjs"
   },
   "dependencies": {
     "@sentry/react": "^10.45.0",

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Verify FR/EN locale parity.
+ *
+ * For every namespace JSON in `src/i18n/locales/fr/<ns>.json` we expect
+ * an exact match in `src/i18n/locales/en/<ns>.json` and vice-versa.
+ * Object keys must be identical and arrays must have the same length so
+ * `t('list', { returnObjects: true })` returns the same shape regardless
+ * of locale.
+ *
+ * Exits non-zero on any mismatch — wired into CI so a missing translation
+ * never reaches develop.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'src/i18n/locales';
+
+function listNamespaces(locale) {
+  return readdirSync(join(BASE, locale))
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort();
+}
+
+function loadJson(locale, namespace) {
+  return JSON.parse(readFileSync(join(BASE, locale, `${namespace}.json`), 'utf8'));
+}
+
+/**
+ * Walk an object and emit a flat key path for every leaf and array element.
+ * Object: foo.bar.baz
+ * Array of primitives: foo.bar[0], foo.bar[1]
+ * Array of objects: foo.bar[0].name, foo.bar[1].name
+ */
+function flatten(value, prefix = '') {
+  const out = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => {
+      const path = `${prefix}[${i}]`;
+      if (item !== null && typeof item === 'object') out.push(...flatten(item, path));
+      else out.push(path);
+    });
+    return out;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      const path = prefix ? `${prefix}.${k}` : k;
+      if (v !== null && typeof v === 'object') out.push(...flatten(v, path));
+      else out.push(path);
+    }
+    return out;
+  }
+  return [prefix];
+}
+
+function diff(setA, setB) {
+  return [...setA].filter((k) => !setB.has(k));
+}
+
+const frNamespaces = listNamespaces('fr');
+const enNamespaces = listNamespaces('en');
+
+let problems = 0;
+let totalKeys = 0;
+
+if (JSON.stringify(frNamespaces) !== JSON.stringify(enNamespaces)) {
+  console.error('[FAIL] namespace lists differ');
+  console.error('  fr:', frNamespaces);
+  console.error('  en:', enNamespaces);
+  problems++;
+}
+
+for (const namespace of frNamespaces) {
+  if (!enNamespaces.includes(namespace)) continue;
+  const frKeys = new Set(flatten(loadJson('fr', namespace)));
+  const enKeys = new Set(flatten(loadJson('en', namespace)));
+
+  const missingInEn = diff(frKeys, enKeys);
+  const extraInEn = diff(enKeys, frKeys);
+
+  if (missingInEn.length || extraInEn.length) {
+    console.error(`[FAIL] ${namespace}: missing in EN=${missingInEn.length}, extra in EN=${extraInEn.length}`);
+    if (missingInEn.length) console.error('  missing:', missingInEn.slice(0, 8).join(', '));
+    if (extraInEn.length) console.error('  extra:', extraInEn.slice(0, 8).join(', '));
+    problems++;
+  } else {
+    totalKeys += frKeys.size;
+  }
+}
+
+if (problems) {
+  console.error(`\nFR/EN parity broken in ${problems} namespace(s).`);
+  process.exit(1);
+}
+
+console.log(`OK — ${frNamespaces.length} namespaces, ${totalKeys} keys aligned.`);

--- a/src/components/BlockTransition.tsx
+++ b/src/components/BlockTransition.tsx
@@ -1,6 +1,5 @@
 import { CheckCircle, Cross, OctagonX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { BLOCK_LABELS } from '../engine/constants.ts';
 import type { AtomicStep } from '../types/player.ts';
 import { TimerDisplay } from './TimerDisplay.tsx';
 
@@ -38,6 +37,7 @@ function HealthDisclaimerInline() {
 
 export function BlockTransition({ step, remaining, progress }: Props) {
   const { t } = useTranslation('player');
+  const { t: tc } = useTranslation('common');
   const isFirstBlock = step.blockIndex === 0;
 
   return (
@@ -52,7 +52,7 @@ export function BlockTransition({ step, remaining, progress }: Props) {
         className="text-sm font-semibold uppercase tracking-wider px-4 py-1.5 rounded-full"
         style={{ backgroundColor: `${step.blockColor}30`, color: step.blockColor }}
       >
-        {BLOCK_LABELS[step.blockType]}
+        {tc(`block_name.${step.blockType}`)}
       </div>
 
       {/* Block name */}

--- a/src/components/CustomSessionPreviewPage.tsx
+++ b/src/components/CustomSessionPreviewPage.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
-import { BLOCK_COLORS, BLOCK_LABELS } from '../engine/constants.ts';
+import { BLOCK_COLORS } from '../engine/constants.ts';
 import { confirmCustomSession, useCustomSession } from '../hooks/useCustomSessions.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useGenerateSession } from '../hooks/useGenerateSession.ts';
@@ -28,8 +28,9 @@ const BLOCK_ICONS: Record<string, LucideIcon> = {
 
 function BlockDetail({ block, index }: { block: Block; index: number }) {
   const { t } = useTranslation('sessions');
+  const { t: tc } = useTranslation('common');
   const color = BLOCK_COLORS[block.type];
-  const label = BLOCK_LABELS[block.type];
+  const label = tc(`block_name.${block.type}`);
 
   const IconComponent = BLOCK_ICONS[block.type] ?? ClipboardList;
 
@@ -46,7 +47,9 @@ function BlockDetail({ block, index }: { block: Block; index: number }) {
             {block.rounds}R &middot; {block.work}s/{block.rest}s
           </span>
         )}
-        {block.type === 'circuit' && <span className="text-xs text-faint ml-auto">{block.rounds} tours</span>}
+        {block.type === 'circuit' && (
+          <span className="text-xs text-faint ml-auto">{t('preview.rounds_count', { n: block.rounds })}</span>
+        )}
         {block.type === 'tabata' && (
           <span className="text-xs text-faint ml-auto">
             {block.rounds ?? 8}R &middot; {block.work ?? 20}s/{block.rest ?? 10}s

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -2,7 +2,6 @@ import { HeartPulse } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate, useParams } from 'react-router';
-import { BLOCK_LABELS } from '../engine/constants.ts';
 import { compileSession } from '../engine/interpreter.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { isHealthAccepted } from '../hooks/useHealthCheck.ts';
@@ -61,6 +60,7 @@ function getBlockProgress(step: AtomicStep): string {
 }
 
 function BlockBreadcrumb({ session, step }: { session: Session; step: AtomicStep }) {
+  const { t } = useTranslation('common');
   const progress = getBlockProgress(step);
 
   return (
@@ -78,7 +78,7 @@ function BlockBreadcrumb({ session, step }: { session: Session; step: AtomicStep
                 color: isActive ? step.blockColor : isPast ? 'rgba(255,255,255,0.4)' : 'rgba(255,255,255,0.2)',
               }}
             >
-              {BLOCK_LABELS[block.type]}
+              {t(`block_name.${block.type}`)}
               {isActive && progress && ` - ${progress}`}
             </span>
           </span>

--- a/src/components/SessionAccordion.tsx
+++ b/src/components/SessionAccordion.tsx
@@ -50,6 +50,7 @@ export function SessionAccordion({ session, defaultOpen = false }: { session: Se
 
 function SessionDetail({ session }: { session: Session }) {
   const { t } = useTranslation('sessions');
+  const { t: tc } = useTranslation('common');
   const timeline = computeTimeline(session.blocks);
   const totalDuration = timeline.reduce((sum, t) => sum + t.duration, 0);
 
@@ -58,15 +59,15 @@ function SessionDetail({ session }: { session: Session }) {
       {session.blocks.map((block, i) => {
         const seg = timeline[i];
         const color = BLOCK_COLORS[seg.type];
-        const exercises = getBlockExercises(block);
+        const exercises = getBlockExercises(block, tc);
         return (
           <div key={i}>
             <div className="flex items-center gap-2 mb-1.5">
               <div className="w-1.5 h-5 rounded-full shrink-0" style={{ backgroundColor: color }} />
               <span className="text-xs font-bold uppercase tracking-wider" style={{ color }}>
-                {seg.label} · {i + 1}/{session.blocks.length}
+                {tc(`block_name.${seg.type}`)} · {i + 1}/{session.blocks.length}
               </span>
-              <span className="text-xs text-muted ml-auto">{getBlockMeta(block)}</span>
+              <span className="text-xs text-muted ml-auto">{getBlockMeta(block, t)}</span>
             </div>
             <div className="pl-4 space-y-0.5">
               {exercises.map((ex, j) => (
@@ -124,82 +125,91 @@ interface ExerciseInfo {
   detail: string;
 }
 
-function getBlockExercises(block: Block): ExerciseInfo[] {
+type Translator = (key: string, options?: Record<string, unknown>) => string;
+
+function getBlockExercises(block: Block, tc: Translator): ExerciseInfo[] {
   switch (block.type) {
     case 'warmup':
     case 'cooldown':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: ex.bilateral ? `${ex.duration}s × 2 côtés` : `${ex.duration}s`,
+        detail: ex.bilateral
+          ? tc('exercise_detail.bilateral_seconds', { seconds: ex.duration })
+          : tc('exercise_detail.duration_seconds', { seconds: ex.duration }),
       }));
     case 'classic':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `${ex.sets} × ${ex.reps === 'max' ? 'max' : ex.reps} reps`,
+        detail:
+          ex.reps === 'max'
+            ? tc('exercise_detail.max_reps', { sets: ex.sets })
+            : tc('exercise_detail.sets_reps', { sets: ex.sets, reps: ex.reps }),
       }));
     case 'circuit':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: ex.mode === 'timed' ? `${ex.duration}s` : `${ex.reps} reps`,
+        detail:
+          ex.mode === 'timed'
+            ? tc('exercise_detail.duration_seconds', { seconds: ex.duration })
+            : tc('exercise_detail.reps_count', { reps: ex.reps }),
       }));
     case 'hiit':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `${block.work}s effort`,
+        detail: tc('exercise_detail.work_seconds', { seconds: block.work }),
       }));
     case 'tabata':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `${block.work ?? 20}s / ${block.rest ?? 10}s`,
+        detail: tc('exercise_detail.work_rest_seconds', { work: block.work ?? 20, rest: block.rest ?? 10 }),
       }));
     case 'emom':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `× ${ex.reps}`,
+        detail: tc('exercise_detail.reps_inline', { reps: ex.reps }),
       }));
     case 'amrap':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `× ${ex.reps}`,
+        detail: tc('exercise_detail.reps_inline', { reps: ex.reps }),
       }));
     case 'superset':
       return block.pairs.flatMap((pair, pi) =>
         pair.exercises.map((ex) => ({
           name: ex.name,
-          detail: `× ${ex.reps} · paire ${pi + 1}`,
+          detail: tc('exercise_detail.superset_pair', { reps: ex.reps, n: pi + 1 }),
         })),
       );
     case 'pyramid':
       return block.exercises.map((ex) => ({
         name: ex.name,
-        detail: `${block.pattern.join(' - ')} reps`,
+        detail: tc('exercise_detail.pyramid_pattern', { pattern: block.pattern.join(' - ') }),
       }));
   }
 }
 
-function getBlockMeta(block: Block): string {
+function getBlockMeta(block: Block, ts: Translator): string {
   switch (block.type) {
     case 'warmup':
     case 'cooldown':
-      return `${block.exercises.length} exercices`;
     case 'classic':
-      return `${block.exercises.length} exercices`;
+      return ts('block_meta.exercises', { n: block.exercises.length });
     case 'circuit':
-      return `${block.rounds} rounds × ${block.exercises.length} exos`;
+      return ts('block_meta.rounds_x_exos', { rounds: block.rounds, exos: block.exercises.length });
     case 'hiit':
-      return `${block.rounds} rounds · ${block.work}s/${block.rest}s`;
+      return ts('block_meta.hiit', { rounds: block.rounds, work: block.work, rest: block.rest });
     case 'tabata': {
       const sets = block.sets ?? 1;
       const rounds = block.rounds ?? 8;
-      return sets > 1 ? `${sets} sets × ${rounds} rounds` : `${rounds} rounds`;
+      return sets > 1 ? ts('block_meta.tabata_with_sets', { sets, rounds }) : ts('block_meta.rounds_only', { rounds });
     }
     case 'emom':
-      return `${block.minutes} minutes`;
+      return ts('block_meta.minutes', { n: block.minutes });
     case 'amrap':
-      return `${Math.floor(block.duration / 60)} minutes`;
+      return ts('block_meta.minutes', { n: Math.floor(block.duration / 60) });
     case 'superset':
-      return `${block.sets} séries · ${block.pairs.length} paires`;
+      return ts('block_meta.superset', { sets: block.sets, pairs: block.pairs.length });
     case 'pyramid':
-      return `${block.pattern.length} paliers`;
+      return ts('block_meta.pyramid', { n: block.pattern.length });
   }
 }

--- a/src/engine/constants.ts
+++ b/src/engine/constants.ts
@@ -13,19 +13,6 @@ export const BLOCK_COLORS: Record<BlockType, string> = {
   pyramid: '#9333EA',
 };
 
-export const BLOCK_LABELS: Record<BlockType, string> = {
-  warmup: 'Échauffement',
-  cooldown: 'Retour au calme',
-  classic: 'Renforcement',
-  circuit: 'Circuit',
-  hiit: 'HIIT',
-  tabata: 'Tabata',
-  emom: 'EMOM',
-  amrap: 'AMRAP',
-  superset: 'Superset',
-  pyramid: 'Pyramide',
-};
-
 export const TABATA_DEFAULTS = {
   sets: 1,
   rounds: 8,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -4,6 +4,30 @@
     "modere": "Moderate",
     "intense": "Intense"
   },
+  "block_name": {
+    "warmup": "Warm-up",
+    "cooldown": "Cool-down",
+    "classic": "Strength",
+    "circuit": "Circuit",
+    "hiit": "HIIT",
+    "tabata": "Tabata",
+    "emom": "EMOM",
+    "amrap": "AMRAP",
+    "superset": "Superset",
+    "pyramid": "Pyramid"
+  },
+  "exercise_detail": {
+    "bilateral_seconds": "{{seconds}}s × 2 sides",
+    "max_reps": "{{sets}} × max reps",
+    "sets_reps": "{{sets}} × {{reps}} reps",
+    "reps_count": "{{reps}} reps",
+    "duration_seconds": "{{seconds}}s",
+    "work_seconds": "{{seconds}}s work",
+    "work_rest_seconds": "{{work}}s / {{rest}}s",
+    "reps_inline": "× {{reps}}",
+    "superset_pair": "× {{reps}} · pair {{n}}",
+    "pyramid_pattern": "{{pattern}} reps"
+  },
   "language_switcher": {
     "aria_label": "Switch language",
     "option_fr": "French",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -42,7 +42,8 @@
     "regenerate": "Retry",
     "regenerating": "Regenerating...",
     "bilateral": "(bilateral)",
-    "pair": "Pair {{n}}"
+    "pair": "Pair {{n}}",
+    "rounds_count": "{{n}} rounds"
   },
   "seances": {
     "page_title": "My sessions",
@@ -74,6 +75,16 @@
     "toggle_label": "Session content",
     "section_aria": "Session content",
     "summary": "{{blocks}} blocks · ~{{duration}} min estimated"
+  },
+  "block_meta": {
+    "exercises": "{{n}} exercises",
+    "rounds_x_exos": "{{rounds}} rounds × {{exos}} exos",
+    "hiit": "{{rounds}} rounds · {{work}}s/{{rest}}s",
+    "tabata_with_sets": "{{sets}} sets × {{rounds}} rounds",
+    "rounds_only": "{{rounds}} rounds",
+    "minutes": "{{n}} minutes",
+    "superset": "{{sets}} sets · {{pairs}} pairs",
+    "pyramid": "{{n}} levels"
   },
   "presets": {
     "transpirer_label": "Goal: work up a sweat",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -4,6 +4,30 @@
     "modere": "Modéré",
     "intense": "Intense"
   },
+  "block_name": {
+    "warmup": "Échauffement",
+    "cooldown": "Retour au calme",
+    "classic": "Renforcement",
+    "circuit": "Circuit",
+    "hiit": "HIIT",
+    "tabata": "Tabata",
+    "emom": "EMOM",
+    "amrap": "AMRAP",
+    "superset": "Superset",
+    "pyramid": "Pyramide"
+  },
+  "exercise_detail": {
+    "bilateral_seconds": "{{seconds}}s × 2 côtés",
+    "max_reps": "{{sets}} × max reps",
+    "sets_reps": "{{sets}} × {{reps}} reps",
+    "reps_count": "{{reps}} reps",
+    "duration_seconds": "{{seconds}}s",
+    "work_seconds": "{{seconds}}s effort",
+    "work_rest_seconds": "{{work}}s / {{rest}}s",
+    "reps_inline": "× {{reps}}",
+    "superset_pair": "× {{reps}} · paire {{n}}",
+    "pyramid_pattern": "{{pattern}} reps"
+  },
   "language_switcher": {
     "aria_label": "Changer de langue",
     "option_fr": "Français",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -42,7 +42,8 @@
     "regenerate": "Recommencer",
     "regenerating": "Régénération...",
     "bilateral": "(bilatéral)",
-    "pair": "Paire {{n}}"
+    "pair": "Paire {{n}}",
+    "rounds_count": "{{n}} tours"
   },
   "seances": {
     "page_title": "Mes séances",
@@ -74,6 +75,16 @@
     "toggle_label": "Contenu de la séance",
     "section_aria": "Contenu de la séance",
     "summary": "{{blocks}} blocs · ~{{duration}} min estimées"
+  },
+  "block_meta": {
+    "exercises": "{{n}} exercices",
+    "rounds_x_exos": "{{rounds}} rounds × {{exos}} exos",
+    "hiit": "{{rounds}} rounds · {{work}}s/{{rest}}s",
+    "tabata_with_sets": "{{sets}} sets × {{rounds}} rounds",
+    "rounds_only": "{{rounds}} rounds",
+    "minutes": "{{n}} minutes",
+    "superset": "{{sets}} séries · {{pairs}} paires",
+    "pyramid": "{{n}} paliers"
   },
   "presets": {
     "transpirer_label": "Objectif : transpirer",

--- a/src/utils/sessionTimeline.ts
+++ b/src/utils/sessionTimeline.ts
@@ -1,8 +1,7 @@
-import { BLOCK_LABELS } from '../engine/constants.ts';
 import type { Block } from '../types/session.ts';
 
 interface TimelineSegment {
-  label: string;
+  /** Block type — use t(`common:block_name.${type}`) at the call site to localize. */
   type: Block['type'];
   isAccent: boolean;
   duration: number;
@@ -10,7 +9,6 @@ interface TimelineSegment {
 
 export function computeTimeline(blocks: Block[]): TimelineSegment[] {
   return blocks.map((block) => {
-    const label = BLOCK_LABELS[block.type];
     const isAccent = block.type !== 'warmup' && block.type !== 'cooldown';
     let duration = 0;
 
@@ -45,6 +43,6 @@ export function computeTimeline(blocks: Block[]): TimelineSegment[] {
         break;
     }
 
-    return { label, type: block.type, isAccent, duration };
+    return { type: block.type, isAccent, duration };
   });
 }


### PR DESCRIPTION
## Summary
PR 4/4 (dernière) du chantier i18n. Ajoute un guard CI d'isomorphisme FR/EN et comble les derniers orphelins UI détectés en QA.

## CI guard
- \`scripts/check-i18n.mjs\` : flatten les namespaces FR et EN, échoue sur toute clé manquante, en trop, ou tableau de longueur différente
- Step \`i18n FR/EN parity\` ajouté dans \`.github/workflows/ci.yml\` entre lint et build

## QA gaps comblés
- \`engine/constants.BLOCK_LABELS\` (hardcodé FR) → retiré, label maintenant dans \`common.block_name\`
- Nouvelles clés \`common.exercise_detail.*\` pour les détails inline (bilateral, work/rest, sets/reps, superset, pyramid)
- Nouvelles clés \`sessions.block_meta.*\` pour les descripteurs côté droit (rounds × exos, hiit work/rest, tabata sets, etc.)
- Migration de \`Player.BlockBreadcrumb\`, \`BlockTransition\`, \`CustomSessionPreviewPage\`, \`SessionAccordion\` (\`getBlockExercises\` + \`getBlockMeta\` reçoivent un translator en paramètre)
- \`sessionTimeline\` ne pré-calcule plus le label, expose \`type\`

## Hors scope (PR 5)
- 110 fichiers \`public/sessions/*.json\` — séances quotidiennes statiques en FR. Migration vers Supabase + génération bilingue planifiée pour la PR 5.
- Sessions IA déjà persistées : restent figées dans leur locale d'origine (déjà documenté en PR 3).

## Test plan
- [x] \`npm run lint\` — 9 warnings (baseline), 0 erreur
- [x] \`npm run check:i18n\` — 16 namespaces, 1977 clés alignées
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 317/317
- [x] Validation Chrome /seances en EN avec accordion ouvert : zéro orphelin UI, seuls résidus = data sessions (scope PR 5)
- [x] Review quality-engineer → APPROVE

## Bilan du chantier i18n (PR 1 → 4)
| PR | Ce qui a été fait |
|---|---|
| PR 1 | Infra react-i18next + toggle FR/EN dans le header |
| PR 2 | Extraction des strings UI dans 13 namespaces (~1100 clés) |
| PR 3 | Externalisation contenu data (formats, exercises, programs) + edge functions IA bilingues + migration Supabase \`locale\` column |
| PR 4 (celle-ci) | Guard CI + dernières clés transverses |

**Total : 16 namespaces, 1977 clés FR↔EN isomorphes garanties par CI.**

Après merge, on peut faire la review globale (PR 5 brainstorm pour les daily sessions) puis basculer \`develop → main\` pour libérer l'i18n en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)