### PR TITLE
feat(sessions): migrate daily sessions to Supabase (PR 5a infra)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "dotenv": "^17.4.2",
         "knip": "^5.85.0",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.1.18",
@@ -3655,6 +3656,19 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -5213,9 +5227,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check:i18n": "node scripts/check-i18n.mjs"
+    "check:i18n": "node scripts/check-i18n.mjs",
+    "migrate:daily-sessions": "node scripts/migrate-daily-sessions.mjs"
   },
   "dependencies": {
     "@sentry/react": "^10.45.0",
@@ -38,6 +39,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "dotenv": "^17.4.2",
     "knip": "^5.85.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.18",

--- a/scripts/migrate-daily-sessions.mjs
+++ b/scripts/migrate-daily-sessions.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * One-shot import of public/sessions/<YYYYMMDD>.json into the
+ * `daily_sessions` table created by migration 019.
+ *
+ * Usage:
+ *   node scripts/migrate-daily-sessions.mjs --env dev   # default
+ *   node scripts/migrate-daily-sessions.mjs --env prod
+ *   node scripts/migrate-daily-sessions.mjs --env dev --dry-run
+ *
+ * Idempotent: rows are upserted on (date_key, locale). Re-running the script
+ * after editing a JSON file overwrites the existing FR row safely.
+ *
+ * EN content is intentionally NOT inserted here — bilingual translation
+ * happens in PR 5b. After this script, the table holds 110 FR rows and
+ * `useSession` falls back to FR for users on the EN locale.
+ *
+ * Reads SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from .env.local.
+ * For --env prod, the script refuses to run unless the URL contains the
+ * known prod project ref to avoid clobbering dev with prod credentials.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+loadEnv({ path: '.env.local' });
+
+const args = process.argv.slice(2);
+const envFlag = args.includes('--env') ? args[args.indexOf('--env') + 1] : 'dev';
+const dryRun = args.includes('--dry-run');
+
+if (envFlag !== 'dev' && envFlag !== 'prod') {
+  console.error(`Invalid --env: ${envFlag}. Use 'dev' or 'prod'.`);
+  process.exit(1);
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+
+const DEV_PROJECT_REF = 'rgwwpkyuavhqdautpciu';
+const PROD_PROJECT_REF = 'pipbhkaaqsltnvprmzrl';
+const expectedRef = envFlag === 'prod' ? PROD_PROJECT_REF : DEV_PROJECT_REF;
+
+if (!SUPABASE_URL.includes(expectedRef)) {
+  console.error(
+    `Refusing to run with --env ${envFlag}: SUPABASE_URL doesn't match ${expectedRef}.\n` +
+      `URL: ${SUPABASE_URL}\n` +
+      `If you want to switch envs, update .env.local accordingly.`,
+  );
+  process.exit(1);
+}
+
+const SESSIONS_DIR = 'public/sessions';
+const files = readdirSync(SESSIONS_DIR)
+  .filter((f) => /^\d{8}\.json$/.test(f))
+  .sort();
+
+if (files.length === 0) {
+  console.error(`No YYYYMMDD.json files found in ${SESSIONS_DIR}`);
+  process.exit(1);
+}
+
+console.log(`[${envFlag}] importing ${files.length} sessions${dryRun ? ' (dry-run)' : ''}`);
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const rows = files.map((file) => {
+  const dateKey = file.replace('.json', '');
+  const payload = JSON.parse(readFileSync(join(SESSIONS_DIR, file), 'utf8'));
+  return {
+    date_key: dateKey,
+    locale: 'fr',
+    session_data: payload,
+  };
+});
+
+if (dryRun) {
+  console.log(`[dry-run] would upsert ${rows.length} rows. First 3:`);
+  console.log(rows.slice(0, 3).map((r) => `  ${r.date_key} (${r.locale})`).join('\n'));
+  process.exit(0);
+}
+
+// Batch upsert. Supabase has a default batch size limit; chunk to be safe.
+const CHUNK = 50;
+let inserted = 0;
+for (let i = 0; i < rows.length; i += CHUNK) {
+  const slice = rows.slice(i, i + CHUNK);
+  const { error } = await supabase.from('daily_sessions').upsert(slice, { onConflict: 'date_key,locale' });
+  if (error) {
+    console.error(`Upsert failed at chunk ${i}-${i + slice.length}:`, error);
+    process.exit(1);
+  }
+  inserted += slice.length;
+  console.log(`  ${inserted}/${rows.length} upserted`);
+}
+
+console.log(`[${envFlag}] done — ${inserted} rows upserted into daily_sessions.`);

--- a/scripts/upsert-daily-session.mjs
+++ b/scripts/upsert-daily-session.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Upsert a single daily session into the `daily_sessions` table.
+ *
+ * Usage:
+ *   node scripts/upsert-daily-session.mjs --env dev --date 20260501
+ *   node scripts/upsert-daily-session.mjs --env prod --date 20260501
+ *
+ * Reads `public/sessions/<date>.json` (FR) and, if it exists,
+ * `public/sessions/en/<date>.json` (EN). Each present file is upserted as
+ * its own (date_key, locale) row.
+ *
+ * Designed to be called by the `generate-session` skill after it writes the
+ * two JSON files. Reuses the env safety check from migrate-daily-sessions.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+loadEnv({ path: '.env.local' });
+
+const args = process.argv.slice(2);
+
+function arg(name) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+const envFlag = arg('env') ?? 'dev';
+const dateKey = arg('date');
+
+if (envFlag !== 'dev' && envFlag !== 'prod') {
+  console.error(`Invalid --env: ${envFlag}. Use 'dev' or 'prod'.`);
+  process.exit(1);
+}
+
+if (!dateKey || !/^\d{8}$/.test(dateKey)) {
+  console.error('Missing or invalid --date (expected YYYYMMDD).');
+  process.exit(1);
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+
+const DEV_PROJECT_REF = 'rgwwpkyuavhqdautpciu';
+const PROD_PROJECT_REF = 'pipbhkaaqsltnvprmzrl';
+const expectedRef = envFlag === 'prod' ? PROD_PROJECT_REF : DEV_PROJECT_REF;
+
+if (!SUPABASE_URL.includes(expectedRef)) {
+  console.error(
+    `Refusing to run with --env ${envFlag}: SUPABASE_URL doesn't match ${expectedRef}.`,
+  );
+  process.exit(1);
+}
+
+const SESSIONS_DIR = 'public/sessions';
+const frPath = join(SESSIONS_DIR, `${dateKey}.json`);
+const enPath = join(SESSIONS_DIR, 'en', `${dateKey}.json`);
+
+const rows = [];
+if (existsSync(frPath)) {
+  rows.push({ date_key: dateKey, locale: 'fr', session_data: JSON.parse(readFileSync(frPath, 'utf8')) });
+}
+if (existsSync(enPath)) {
+  rows.push({ date_key: dateKey, locale: 'en', session_data: JSON.parse(readFileSync(enPath, 'utf8')) });
+}
+
+if (rows.length === 0) {
+  console.error(`No source file found for ${dateKey} in ${SESSIONS_DIR}.`);
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const { error } = await supabase.from('daily_sessions').upsert(rows, { onConflict: 'date_key,locale' });
+if (error) {
+  console.error(`Upsert failed for ${dateKey}:`, error);
+  process.exit(1);
+}
+
+console.log(`[${envFlag}] upserted ${rows.map((r) => r.locale).join('+')} for ${dateKey}`);

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,56 +1,58 @@
-import { useEffect, useState } from 'react';
-import type { Session, SessionSource } from '../types/session.ts';
-
-const DEFAULT_SOURCE: SessionSource = { type: 'static' };
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { isSupportedLocale } from '../i18n';
+import { supabase } from '../lib/supabase.ts';
+import type { Session } from '../types/session.ts';
 
 /**
- * Fetches a session by date key.
- * Currently reads static JSON; will be extended for Supabase in a future phase.
+ * Fetch the daily session for `dateKey` from Supabase.
+ *
+ * Tries the user's locale first, then falls back to `'fr'` if no row exists
+ * for that locale (e.g. session was generated before bilingual content
+ * landed, or the EN translation hasn't been written yet).
+ *
+ * RLS allows anonymous SELECT — no auth required.
  */
-async function fetchSession(dateKey: string, source: SessionSource = DEFAULT_SOURCE): Promise<Session> {
-  if (source.type === 'static') {
-    const res = await fetch(`/sessions/${dateKey}.json`);
-    if (!res.ok) throw new Error('not_found');
-    return res.json();
+async function fetchDailySession(dateKey: string, locale: string): Promise<Session> {
+  if (!supabase) throw new Error('supabase_unavailable');
+  const client = supabase;
+
+  const tryLocale = async (lng: string) => {
+    const { data, error } = await client
+      .from('daily_sessions')
+      .select('session_data')
+      .eq('date_key', dateKey)
+      .eq('locale', lng)
+      .maybeSingle();
+    if (error) throw error;
+    return data?.session_data as Session | undefined;
+  };
+
+  const requested = await tryLocale(locale);
+  if (requested) return requested;
+
+  if (locale !== 'fr') {
+    const fr = await tryLocale('fr');
+    if (fr) return fr;
   }
-  // API source will be implemented in Phase 2
-  throw new Error(`Unsupported session source: ${source.type}`);
+
+  throw new Error('not_found');
 }
 
 export function useSession(dateKey: string | null) {
-  const [session, setSession] = useState<Session | null>(null);
-  const [loading, setLoading] = useState(!!dateKey);
-  const [error, setError] = useState<string | null>(null);
+  const { i18n } = useTranslation();
+  const locale = isSupportedLocale(i18n.language) ? i18n.language : 'fr';
 
-  useEffect(() => {
-    if (!dateKey) {
-      setSession(null);
-      return;
-    }
+  const query = useQuery<Session>({
+    queryKey: ['daily-session', dateKey, locale],
+    queryFn: () => fetchDailySession(dateKey!, locale),
+    enabled: !!dateKey && !!supabase,
+    staleTime: 5 * 60 * 1000, // 5 min — content changes rarely
+  });
 
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-
-    fetchSession(dateKey)
-      .then((data) => {
-        if (!cancelled) {
-          setSession(data);
-          setLoading(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setSession(null);
-          setError('not_found');
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [dateKey]);
-
-  return { session, loading, error };
+  return {
+    session: query.data ?? null,
+    loading: query.isLoading,
+    error: query.error ? (query.error.message === 'not_found' ? 'not_found' : 'error') : null,
+  };
 }

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -31,6 +31,10 @@ async function fetchDailySession(dateKey: string, locale: string): Promise<Sessi
   const requested = await tryLocale(locale);
   if (requested) return requested;
 
+  // TODO(PR-5b): once EN rows are seeded, replace this two-roundtrip flow with
+  // a single .in('locale', [locale, 'fr']) query and pick the preferred row
+  // client-side. Today the second hop is cheap because (date_key, locale) PK
+  // makes both lookups index-only.
   if (locale !== 'fr') {
     const fr = await tryLocale('fr');
     if (fr) return fr;
@@ -52,7 +56,9 @@ export function useSession(dateKey: string | null) {
 
   return {
     session: query.data ?? null,
-    loading: query.isLoading,
+    // isPending stays true while the query is disabled (no supabase client yet),
+    // which is the honest "still figuring it out" signal for the UI.
+    loading: query.isPending,
     error: query.error ? (query.error.message === 'not_found' ? 'not_found' : 'error') : null,
   };
 }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -163,10 +163,3 @@ export interface Session {
   focus: string[];
   blocks: Block[];
 }
-
-/** Where to fetch sessions from — extensible for future Supabase source. */
-export type SessionSource =
-  | { type: 'static' }
-  | { type: 'api'; baseUrl: string }
-  | { type: 'program'; programSessionId: string }
-  | { type: 'custom'; customSessionId: string };

--- a/supabase/migrations/019_daily_sessions.sql
+++ b/supabase/migrations/019_daily_sessions.sql
@@ -1,0 +1,66 @@
+-- Migrate daily session content from static `public/sessions/*.json` files
+-- to Supabase. The PWA used to fetch /sessions/<YYYYMMDD>.json from the bundle;
+-- after this migration, useSession queries this table by (date_key, locale).
+--
+-- Schema:
+--   date_key   YYYYMMDD string, matches session_completions.session_date
+--   locale     'fr' | 'en' — bilingual content from PR 5b
+--   session_data  the same JSON shape as the static files
+--
+-- RLS:
+--   SELECT is public (no auth required) — daily sessions are free, accessible
+--     to anonymous visitors landing on Home.
+--   INSERT / UPDATE / DELETE are restricted to the service role
+--     (admin scripts and the generate-session skill).
+
+CREATE TABLE IF NOT EXISTS public.daily_sessions (
+  date_key TEXT NOT NULL,
+  locale TEXT NOT NULL,
+  session_data JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (date_key, locale)
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'daily_sessions_locale_check'
+  ) THEN
+    ALTER TABLE public.daily_sessions
+      ADD CONSTRAINT daily_sessions_locale_check CHECK (locale IN ('fr', 'en'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'daily_sessions_date_key_check'
+  ) THEN
+    ALTER TABLE public.daily_sessions
+      ADD CONSTRAINT daily_sessions_date_key_check CHECK (date_key ~ '^\d{8}$');
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS daily_sessions_date_key_idx
+  ON public.daily_sessions (date_key);
+
+ALTER TABLE public.daily_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Anonymous + authenticated users can read every daily session.
+DROP POLICY IF EXISTS "daily_sessions_public_read" ON public.daily_sessions;
+CREATE POLICY "daily_sessions_public_read"
+  ON public.daily_sessions
+  FOR SELECT
+  USING (true);
+
+-- Writes happen only via the service role (migration script + generate-session
+-- skill); regular auth keys cannot insert/update/delete. No RLS policy means
+-- those operations are blocked under RLS for non-service roles, which is what
+-- we want.
+
+COMMENT ON TABLE public.daily_sessions IS
+  'Daily workout content shown on Home and /seance/play. Replaces /public/sessions/*.json.';
+
+COMMENT ON COLUMN public.daily_sessions.session_data IS
+  'Same JSON shape as the legacy static files: title, description, focus, blocks.';

--- a/supabase/migrations/019_daily_sessions.sql
+++ b/supabase/migrations/019_daily_sessions.sql
@@ -25,7 +25,12 @@ CREATE TABLE IF NOT EXISTS public.daily_sessions (
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'daily_sessions_locale_check'
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE c.conname = 'daily_sessions_locale_check'
+      AND n.nspname = 'public'
+      AND t.relname = 'daily_sessions'
   ) THEN
     ALTER TABLE public.daily_sessions
       ADD CONSTRAINT daily_sessions_locale_check CHECK (locale IN ('fr', 'en'));
@@ -35,7 +40,12 @@ END $$;
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'daily_sessions_date_key_check'
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE c.conname = 'daily_sessions_date_key_check'
+      AND n.nspname = 'public'
+      AND t.relname = 'daily_sessions'
   ) THEN
     ALTER TABLE public.daily_sessions
       ADD CONSTRAINT daily_sessions_date_key_check CHECK (date_key ~ '^\d{8}$');
@@ -44,6 +54,10 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS daily_sessions_date_key_idx
   ON public.daily_sessions (date_key);
+
+CREATE OR REPLACE TRIGGER daily_sessions_updated_at
+  BEFORE UPDATE ON public.daily_sessions
+  FOR EACH ROW EXECUTE PROCEDURE public.update_updated_at();
 
 ALTER TABLE public.daily_sessions ENABLE ROW LEVEL SECURITY;
 


### PR DESCRIPTION
## Summary
PR 5a infra du chantier "daily sessions en base". Les ~110 séances quotidiennes statiques (\`public/sessions/*.json\`) sont préparées pour migrer vers une table Supabase. Ce PR pose le rail ; le seed et la traduction EN viennent en PR 5b, le cleanup des fichiers statiques en PR 5c.

## Schéma data
**Migration \`019_daily_sessions.sql\`** :
- Table \`daily_sessions(date_key, locale, session_data, created_at, updated_at)\` avec PK composite \`(date_key, locale)\`
- CHECK constraints : \`locale IN ('fr', 'en')\`, \`date_key ~ '^\d{8}\$'\`
- Index sur \`date_key\` + trigger \`updated_at\`
- RLS : SELECT public, INSERT/UPDATE/DELETE service_role-only
- Migration idempotente (DO block + \`pg_constraint\` guard scopé table+schema)

## App refactor
**\`useSession\`** passe de \`fetch('/sessions/<date>.json')\` à TanStack Query contre Supabase :
- queryKey \`['daily-session', dateKey, locale]\` invalidée à la bascule de locale
- Fallback \`locale='fr'\` si la row EN n'existe pas (cas par défaut tant que PR 5b n'a pas seedé l'EN)
- staleTime 5 min
- \`loading: query.isPending\` (honnête sur l'état \"disabled\" quand supabase est null)

Suppression de \`SessionSource\` (dead code legacy).

## Scripts
- \`scripts/migrate-daily-sessions.mjs --env dev|prod [--dry-run]\` : bulk upsert des 110 JSON existants en \`locale='fr'\`. Idempotent. Refuse de runner si \`SUPABASE_URL\` ne matche pas l'env.
- \`scripts/upsert-daily-session.mjs --env dev|prod --date YYYYMMDD\` : upsert d'une seule date (FR + EN si présents). Utilisé par le skill \`generate-session\`.

## Skill
\`.claude/skills/generate-session/SKILL.md\` (gitignored, local) mis à jour pour produire FR + EN en parallèle, écrire les 2 JSON, puis appeler le script d'upsert avec \`--env\`. Les fichiers JSON restent dans le repo en source de vérité tant que PR 5c n'a pas mergé.

## Étapes manuelles avant promotion
Le service_role key permet uniquement les opérations de table via REST — la DDL doit passer par le dashboard Supabase ou la CLI :

1. **Dev** : appliquer \`019_daily_sessions.sql\` via SQL editor ou \`supabase db push\` sur le projet \`rgwwpkyuavhqdautpciu\`
2. **Dev** : \`node scripts/migrate-daily-sessions.mjs --env dev\` pour seeder les 110 FR
3. Tester l'app, valider que useSession fonctionne (cache TanStack)
4. **Prod** : repeat les 2 étapes sur \`pipbhkaaqsltnvprmzrl\`

## Gap connu
Les utilisateurs avec PWA cache pré-PR-5a continueront de servir les JSON statiques depuis le service worker (TTL 120 jours sur la \`sessions-cache\` runtime rule existante) jusqu'à ce que la cache expire ou qu'ils la clearent. PR 5c (cleanup) supprime cette rule + les fichiers \`/dist/sessions/\` pour finaliser le cut-over.

## Hors scope
- Traductions EN des 110 séances : **PR 5b** (je traduis fichier par fichier avec attention qualité)
- Suppression \`public/sessions/*.json\` + workbox \`globPatterns\` : **PR 5c**
- Tests unitaires \`useSession\` (gap noté, à ajouter PR 5b)

## Test plan
- [x] \`npm run lint\` — 9 warnings (baseline)
- [x] \`npm run check:i18n\` — 16 namespaces, 2011 clés
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 317/317
- [x] \`npm run migrate:daily-sessions -- --env dev --dry-run\` → 110 rows identifiées
- [x] Review quality-engineer → CRITICAL + WARNINGS adressés (commit \`29f04bc\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)