### PR TITLE
sec(sentry): mask inputs and scrub PII from transaction URLs

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,14 +6,37 @@ import './index.css';
 import './i18n';
 import App from './App.tsx';
 
+// Strip identifiers (UUIDs, YYYYMMDD date keys) from URL paths so user/session
+// IDs don't end up in Sentry transaction names, breadcrumbs, or request URLs.
+function scrubPathIds(value: string): string {
+  return value
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, ':uuid')
+    .replace(/\/\d{8}(?=\/|$|\?)/g, '/:date');
+}
+
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: import.meta.env.MODE,
   enabled: import.meta.env.PROD,
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration({
+      // RGPD art. 9: nutrition logs, injury declarations, and email inputs
+      // qualify as health/personal data. Mask all form inputs and keep the
+      // network detail allowlist empty so request/response bodies aren't
+      // captured in error replays.
+      maskAllInputs: true,
+      networkDetailAllowUrls: [],
+    }),
+  ],
   tracesSampleRate: 0.2,
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
+  beforeSendTransaction(event) {
+    if (event.transaction) event.transaction = scrubPathIds(event.transaction);
+    if (event.request?.url) event.request.url = scrubPathIds(event.request.url);
+    return event;
+  },
 });
 
 createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,12 +6,14 @@ import './index.css';
 import './i18n';
 import App from './App.tsx';
 
-// Strip identifiers (UUIDs, YYYYMMDD date keys) from URL paths so user/session
-// IDs don't end up in Sentry transaction names, breadcrumbs, or request URLs.
+// Strip identifiers (UUIDs, ISO date keys YYYYMMDD with year 19xx-20xx) from
+// URL paths so user/session IDs don't end up in Sentry transaction names,
+// fetch breadcrumbs, or span descriptions. Year prefix guards against matching
+// arbitrary 8-digit numeric IDs in unrelated paths.
 function scrubPathIds(value: string): string {
   return value
     .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, ':uuid')
-    .replace(/\/\d{8}(?=\/|$|\?)/g, '/:date');
+    .replace(/\/(?:19|20)\d{6}(?=\/|$|\?|#)/g, '/:date');
 }
 
 Sentry.init({
@@ -21,20 +23,38 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration({
-      // RGPD art. 9: nutrition logs, injury declarations, and email inputs
-      // qualify as health/personal data. Mask all form inputs and keep the
-      // network detail allowlist empty so request/response bodies aren't
+      // RGPD art. 9: nutrition logs, injury declarations, calorie targets,
+      // AI coach notes and email inputs all qualify as health/personal data.
+      // Mask both form inputs AND rendered text nodes, block media, and keep
+      // the network detail allowlist empty so request/response bodies aren't
       // captured in error replays.
       maskAllInputs: true,
+      maskAllText: true,
+      blockAllMedia: true,
       networkDetailAllowUrls: [],
     }),
   ],
   tracesSampleRate: 0.2,
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
+  beforeBreadcrumb(breadcrumb) {
+    // Default fetch/xhr breadcrumbs include full URLs with Supabase UUID
+    // query params. Scrub before they reach the wire.
+    if (breadcrumb.category === 'fetch' || breadcrumb.category === 'xhr') {
+      if (typeof breadcrumb.data?.url === 'string') {
+        breadcrumb.data.url = scrubPathIds(breadcrumb.data.url);
+      }
+    }
+    return breadcrumb;
+  },
   beforeSendTransaction(event) {
     if (event.transaction) event.transaction = scrubPathIds(event.transaction);
-    if (event.request?.url) event.request.url = scrubPathIds(event.request.url);
+    // Each browser-tracing span carries the full fetch URL in `description`.
+    if (event.spans) {
+      for (const span of event.spans) {
+        if (span.description) span.description = scrubPathIds(span.description);
+      }
+    }
     return event;
   },
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -47,6 +47,13 @@ Sentry.init({
     }
     return breadcrumb;
   },
+  beforeSend(event) {
+    // Error events carry window.location.href in event.request.url via the
+    // HttpContext integration; routes like /seance/custom/<uuid> would leak
+    // the session id otherwise.
+    if (event.request?.url) event.request.url = scrubPathIds(event.request.url);
+    return event;
+  },
   beforeSendTransaction(event) {
     if (event.transaction) event.transaction = scrubPathIds(event.transaction);
     // Each browser-tracing span carries the full fetch URL in `description`.


### PR DESCRIPTION
## Summary

- Activate `maskAllInputs` + `maskAllText` + `blockAllMedia` on Sentry Replay so health data (nutrition logs, injury declarations, calorie targets, AI coach notes, email inputs) is masked in error replays — RGPD art. 9.
- Empty `networkDetailAllowUrls` so request/response bodies aren't captured.
- Scrub UUIDs and `YYYYMMDD` (years 19xx-20xx) from transaction names, fetch/xhr breadcrumb URLs, span descriptions, and error event request URLs so user/session IDs don't reach Sentry.

## Why

Audit pre-merge develop → main flagged that the previous `Sentry.replayIntegration()` config captured DOM text and form inputs in cleartext on error sessions, while default fetch/xhr breadcrumbs and spans leaked Supabase UUID query params.

## Test plan

- [x] Build passes (tsc -b + vite build)
- [x] All 317 tests pass
- [x] Reviewed by quality-engineer agent across 2 cycles, all CRITICAL + WARNING findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)