### PR TITLE
fix(player): wrap save completion insert in supabaseQuery

### DIFF
--- a/src/hooks/useSaveCompletion.ts
+++ b/src/hooks/useSaveCompletion.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 
 interface SaveParams {
   sessionDate?: string;
@@ -25,49 +26,63 @@ export function useSaveCompletion() {
       if (!supabase || inflightRef.current || saved) return;
       inflightRef.current = true;
       setError(false);
+      const client = supabase;
 
       try {
         const {
           data: { user },
-        } = await supabase.auth.getUser();
+        } = await client.auth.getUser();
         if (!user) return;
 
-        const { error: insertError } = await supabase.from('session_completions').insert({
-          user_id: user.id,
-          session_date: params.sessionDate ?? null,
-          program_session_id: params.programSessionId ?? null,
-          custom_session_id: params.customSessionId ?? null,
-          duration_seconds: params.durationSeconds,
-          amrap_rounds: params.amrapRounds > 0 ? params.amrapRounds : null,
-          metadata: {
-            ...(params.sessionTitle && { session_title: params.sessionTitle }),
-            ...(params.sessionDescription && { session_description: params.sessionDescription }),
-            ...(params.sessionFocus?.length && { session_focus: params.sessionFocus }),
-            ...(params.blockTypes?.length && { block_types: params.blockTypes }),
-          },
-        });
+        // Wrap the insert in supabaseQuery so an expired JWT mid-session
+        // (e.g. user finishes a 60-min programme on a stale tab) triggers
+        // a refresh + retry instead of silently dropping the completion.
+        const { error: insertError, sessionExpired } = await supabaseQuery(() =>
+          client.from('session_completions').insert({
+            user_id: user.id,
+            session_date: params.sessionDate ?? null,
+            program_session_id: params.programSessionId ?? null,
+            custom_session_id: params.customSessionId ?? null,
+            duration_seconds: params.durationSeconds,
+            amrap_rounds: params.amrapRounds > 0 ? params.amrapRounds : null,
+            metadata: {
+              ...(params.sessionTitle && { session_title: params.sessionTitle }),
+              ...(params.sessionDescription && { session_description: params.sessionDescription }),
+              ...(params.sessionFocus?.length && { session_focus: params.sessionFocus }),
+              ...(params.blockTypes?.length && { block_types: params.blockTypes }),
+            },
+          }),
+        );
+
+        if (sessionExpired) {
+          notifySessionExpired();
+          setError(true);
+          return;
+        }
 
         if (insertError) {
           console.error('Save completion error:', insertError);
           setError(true);
-        } else {
-          setSaved(true);
-          // Every query whose cache is affected by a new completion row must
-          // be invalidated here — TanStack has no way to infer which lists a
-          // mutation touches. Keep this list in sync with the migrated read
-          // hooks:
-          //  - useActiveProgram: progress + nextSession
-          //  - useHistory: prepends the new row
-          //  - useProgram(slug): completedSessionIds for the matching program.
-          //    We invalidate the whole `['program']` prefix rather than a
-          //    specific slug because the save call does not know which slug
-          //    the ProgramPlayer was playing (no slug on the payload). The
-          //    cost is small (rarely more than 1-2 cached programs at a time).
-          queryClient.invalidateQueries({ queryKey: ['activeProgram', user.id] });
-          queryClient.invalidateQueries({ queryKey: ['history', user.id] });
-          queryClient.invalidateQueries({ queryKey: ['program'] });
+          return;
         }
-      } catch {
+
+        setSaved(true);
+        // Every query whose cache is affected by a new completion row must
+        // be invalidated here — TanStack has no way to infer which lists a
+        // mutation touches. Keep this list in sync with the migrated read
+        // hooks:
+        //  - useActiveProgram: progress + nextSession
+        //  - useHistory: prepends the new row
+        //  - useProgram(slug): completedSessionIds for the matching program.
+        //    We invalidate the whole `['program']` prefix rather than a
+        //    specific slug because the save call does not know which slug
+        //    the ProgramPlayer was playing (no slug on the payload). The
+        //    cost is small (rarely more than 1-2 cached programs at a time).
+        queryClient.invalidateQueries({ queryKey: ['activeProgram', user.id] });
+        queryClient.invalidateQueries({ queryKey: ['history', user.id] });
+        queryClient.invalidateQueries({ queryKey: ['program'] });
+      } catch (e) {
+        console.error('Save completion unexpected error:', e);
         setError(true);
       } finally {
         inflightRef.current = false;

--- a/src/hooks/useSaveCompletion.ts
+++ b/src/hooks/useSaveCompletion.ts
@@ -26,19 +26,18 @@ export function useSaveCompletion() {
       if (!supabase || inflightRef.current || saved) return;
       inflightRef.current = true;
       setError(false);
-      const client = supabase;
 
       try {
         const {
           data: { user },
-        } = await client.auth.getUser();
+        } = await supabase.auth.getUser();
         if (!user) return;
 
         // Wrap the insert in supabaseQuery so an expired JWT mid-session
         // (e.g. user finishes a 60-min programme on a stale tab) triggers
         // a refresh + retry instead of silently dropping the completion.
         const { error: insertError, sessionExpired } = await supabaseQuery(() =>
-          client.from('session_completions').insert({
+          supabase!.from('session_completions').insert({
             user_id: user.id,
             session_date: params.sessionDate ?? null,
             program_session_id: params.programSessionId ?? null,


### PR DESCRIPTION
## Summary

- Wrap the `session_completions` insert in `supabaseQuery()` so an expired JWT mid-session triggers a refresh + retry instead of silently dropping the completion.
- Propagate `sessionExpired` via `notifySessionExpired()` when the refresh itself fails, so AuthContext can surface the state to the UI.
- Surface the previously-silent `catch {}` with a `console.error` and use early returns to flatten the success branch.

## Why

Audit pre-merge develop → main flagged that `useSaveCompletion` bypassed the project's `supabaseQuery` resilience helper. Long programme sessions (60+ min) where the JWT expires mid-workout would produce a generic `setError(true)` and the completion was lost without any retry.

## Test plan

- [x] Build passes (tsc -b + vite build)
- [x] All 317 tests pass
- [x] Reviewed by quality-engineer agent — REQUEST_CHANGES on first cycle (unused alias), addressed in second commit

## Follow-ups (separate PRs)

- 3 other mutations bypass `supabaseQuery` and remain to be migrated: `useUserPrograms.deleteProgram`, `SettingsPage` avatar update, `useCustomSessions.confirm`.
- `supabaseQuery<T>` typing footgun for inserts without `.select()` (data is always null but T is inferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)