### PR TITLE
fix(checkout): invalidate profile + subscription on Stripe success

### DIFF
--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -1,5 +1,6 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Camera, Crown, Monitor, Moon, Sparkles, Sun } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
@@ -20,6 +21,7 @@ export function SettingsPage() {
   const { isPremium, subscription, manageSubscription } = useSubscription();
   const [searchParams] = useSearchParams();
   const checkoutSuccess = searchParams.get('checkout') === 'success';
+  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
@@ -29,6 +31,23 @@ export function SettingsPage() {
     title: t('page_title'),
     description: t('page_description'),
   });
+
+  // After Stripe redirects back with ?checkout=success the webhook may not
+  // have updated profiles.subscription_tier yet — there's a short window
+  // where the user sees "free" while the upgrade is still propagating.
+  // Force a profile + subscription refetch on landing, plus a retry after
+  // 3 s to cover typical webhook latency without polling forever.
+  const userId = user?.id;
+  useEffect(() => {
+    if (!checkoutSuccess || !userId) return;
+    queryClient.invalidateQueries({ queryKey: ['profile', userId] });
+    queryClient.invalidateQueries({ queryKey: ['subscription', userId] });
+    const retryId = setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ['profile', userId] });
+      queryClient.invalidateQueries({ queryKey: ['subscription', userId] });
+    }, 3000);
+    return () => clearTimeout(retryId);
+  }, [checkoutSuccess, userId, queryClient]);
 
   const THEME_OPTIONS = [
     { value: 'light' as const, label: t('appearance.theme_light'), Icon: Sun },

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -35,18 +35,24 @@ export function SettingsPage() {
   // After Stripe redirects back with ?checkout=success the webhook may not
   // have updated profiles.subscription_tier yet — there's a short window
   // where the user sees "free" while the upgrade is still propagating.
-  // Force a profile + subscription refetch on landing, plus a retry after
-  // 3 s to cover typical webhook latency without polling forever.
+  // Force a profile + subscription refetch on landing, plus two retries
+  // staggered at 3s/8s to cover edge function cold-start + Stripe API
+  // latency in prod. refetchType: 'all' forces the subscription query to
+  // run even if it's disabled (isPremium still false until profile flips).
   const userId = user?.id;
   useEffect(() => {
     if (!checkoutSuccess || !userId) return;
-    queryClient.invalidateQueries({ queryKey: ['profile', userId] });
-    queryClient.invalidateQueries({ queryKey: ['subscription', userId] });
-    const retryId = setTimeout(() => {
+    const refresh = () => {
       queryClient.invalidateQueries({ queryKey: ['profile', userId] });
-      queryClient.invalidateQueries({ queryKey: ['subscription', userId] });
-    }, 3000);
-    return () => clearTimeout(retryId);
+      queryClient.invalidateQueries({ queryKey: ['subscription', userId], refetchType: 'all' });
+    };
+    refresh();
+    const t1 = setTimeout(refresh, 3000);
+    const t2 = setTimeout(refresh, 8000);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
   }, [checkoutSuccess, userId, queryClient]);
 
   const THEME_OPTIONS = [


### PR DESCRIPTION
## Summary

- Detect `?checkout=success` on SettingsPage and force `['profile', userId]` + `['subscription', userId]` invalidation on landing
- Stagger two retries at 3s and 8s to cover Stripe webhook latency in prod (edge function cold-start + Stripe API)
- `refetchType: 'all'` on subscription so it runs even while disabled (isPremium false until profile flips)

## Why

Audit pre-merge develop → main: after Stripe redirects back, the user can see "free" tier for up to 5 minutes (the AuthContext visibility-handler window) because `profiles.subscription_tier` is updated by the webhook async and no client invalidation was wired. The new behaviour gives a near-instant tier flip in the typical case (1-3s webhook) and stays correct under cold-start (8s cover).

## Test plan

- [x] Build + tests pass
- [x] Reviewed by quality-engineer agent across 2 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)