### PR TITLE
sec(ai): atomic rate limit on generate-session and generate-program

### DIFF
--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -226,19 +226,33 @@ Deno.serve(async (req: Request) => {
     );
   }
 
-  // Rate limit: 3 generations / 24h
-  const { count: dailyCount, error: dailyError } = await supabaseAdmin
-    .from("programs")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id)
-    .eq("is_fixed", false)
-    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+  // Atomic rate limit: insert a tracking row first, then count. If we end up
+  // over the quota we delete the just-inserted row and reject. Closes the
+  // race window of "count-then-insert" where parallel calls could slip past.
+  const { data: rateRow, error: rateInsertError } = await supabaseAdmin
+    .from("ai_generation_calls")
+    .insert({ user_id: user.id, kind: "program" })
+    .select("id")
+    .single();
 
-  if (dailyError) {
+  if (rateInsertError || !rateRow) {
     return errorResponse(req, "Erreur serveur", 500);
   }
 
-  if ((dailyCount ?? 0) >= MAX_DAILY_GENERATIONS) {
+  const { count: dailyCount, error: dailyError } = await supabaseAdmin
+    .from("ai_generation_calls")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("kind", "program")
+    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  if (dailyError) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", rateRow.id);
+    return errorResponse(req, "Erreur serveur", 500);
+  }
+
+  if ((dailyCount ?? 0) > MAX_DAILY_GENERATIONS) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", rateRow.id);
     return errorResponse(
       req,
       `Limite atteinte : ${MAX_DAILY_GENERATIONS} programmes par 24h. Reessaye plus tard.`,

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -255,10 +255,13 @@ Deno.serve(async (req: Request) => {
     await supabaseAdmin.from("ai_generation_calls").delete().eq("id", rateRow.id);
     return errorResponse(
       req,
-      `Limite atteinte : ${MAX_DAILY_GENERATIONS} programmes par 24h. Reessaye plus tard.`,
+      `Limite atteinte : ${MAX_DAILY_GENERATIONS} programmes par 24h. Réessaye plus tard.`,
       429,
     );
   }
+  // Note: rateRow is intentionally NOT deleted on downstream failures (AI
+  // call, validation, DB insert). A failed attempt still counts against the
+  // 24h quota to prevent free retry storms — same policy as estimate-nutrition.
 
   // Build prompt
   const locale: Locale = (body.locale as Locale) ?? "fr";

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -224,6 +224,9 @@ Deno.serve(async (req: Request) => {
       429,
     );
   }
+  // Note: rateRow is intentionally NOT deleted on downstream failures (AI
+  // call, validation, DB insert). A failed attempt still counts against the
+  // 24h quota to prevent free retry storms — same policy as estimate-nutrition.
 
   // Build prompt
   const locale: Locale = (body.locale as Locale) ?? "fr";

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -191,18 +191,33 @@ Deno.serve(async (req: Request) => {
     return errorResponse(req, inputError);
   }
 
-  // Rate limit: max generations per 24h
-  const { count, error: countError } = await supabaseAdmin
-    .from("custom_sessions")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id)
-    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+  // Atomic rate limit: insert a tracking row first, then count. If we end up
+  // over the quota we delete the just-inserted row and reject. Closes the
+  // race window of "count-then-insert" where parallel calls could slip past.
+  const { data: rateRow, error: rateInsertError } = await supabaseAdmin
+    .from("ai_generation_calls")
+    .insert({ user_id: user.id, kind: "session" })
+    .select("id")
+    .single();
 
-  if (countError) {
+  if (rateInsertError || !rateRow) {
     return errorResponse(req, "Erreur serveur", 500);
   }
 
-  if ((count ?? 0) >= MAX_DAILY_GENERATIONS) {
+  const { count, error: countError } = await supabaseAdmin
+    .from("ai_generation_calls")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("kind", "session")
+    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  if (countError) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", rateRow.id);
+    return errorResponse(req, "Erreur serveur", 500);
+  }
+
+  if ((count ?? 0) > MAX_DAILY_GENERATIONS) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", rateRow.id);
     return errorResponse(
       req,
       `Limite atteinte : ${MAX_DAILY_GENERATIONS} séances par 24h. Réessayez plus tard.`,

--- a/supabase/migrations/020_ai_generation_calls.sql
+++ b/supabase/migrations/020_ai_generation_calls.sql
@@ -1,0 +1,39 @@
+-- Atomic rate-limit tracking for generate-session and generate-program edge
+-- functions. The previous SELECT COUNT → INSERT pattern leaves a race window
+-- when several requests arrive in parallel: each can observe a pre-increment
+-- count and slip past the limit. With this table the edge function inserts
+-- first, counts including its own row, and deletes if it ends up over quota
+-- — same pattern as estimate-nutrition / ai_text_calls.
+
+CREATE TABLE IF NOT EXISTS public.ai_generation_calls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE c.conname = 'ai_generation_calls_kind_check'
+      AND n.nspname = 'public'
+      AND t.relname = 'ai_generation_calls'
+  ) THEN
+    ALTER TABLE public.ai_generation_calls
+      ADD CONSTRAINT ai_generation_calls_kind_check CHECK (kind IN ('session', 'program'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ai_generation_calls_user_kind_created_idx
+  ON public.ai_generation_calls (user_id, kind, created_at DESC);
+
+ALTER TABLE public.ai_generation_calls ENABLE ROW LEVEL SECURITY;
+
+-- No user-facing policies; only the service role (used by edge functions)
+-- inserts/reads/deletes. RLS without policies blocks anon + authenticated.
+
+COMMENT ON TABLE public.ai_generation_calls IS
+  'Tracks AI generation calls (custom session, custom program) for atomic rate limiting in edge functions.';


### PR DESCRIPTION
## Summary

- New `ai_generation_calls(id, user_id, kind, created_at)` table with RLS service-role-only.
- Migration 020 idempotent (CREATE TABLE/INDEX IF NOT EXISTS, DO $$ guard on the kind check).
- generate-session and generate-program switch from SELECT COUNT → INSERT to the insert-first/count/delete-if-over pattern already used in estimate-nutrition.
- Comment added in both functions explaining the deliberate non-cleanup of the tracker row on downstream AI/validation/DB failures (anti retry-storm policy, mirrors estimate-nutrition).

## Why

Audit pre-merge develop → main: parallel requests could each observe the same pre-increment count and slip past the 24h limit. Risk: financial (extra Anthropic calls billed) for users on burst-test or with concurrent tabs.

## Migration status

- Applied on dev via Supabase MCP at audit time.
- Will be picked up by the same prod migration batch as 018/019 when the merge to main is staged.

## Test plan

- [x] Build + 317 tests pass
- [x] Reviewed by quality-engineer (REQUEST_CHANGES on first cycle: accent typo + missing comment, both addressed)

## Deferred to follow-up (PR-A5-bis)

- `generate-program/index.ts:211` active-program cap (MAX_ACTIVE_PROGRAMS=3) is still non-atomic. Programs table has NOT NULL fields incompatible with the placeholder-row pattern; needs an advisory lock or DB trigger.
- `estimate-nutrition/index.ts:236` overflow mode (OVERFLOW_DAILY_LIMIT=1) is partially mitigated by upsert onConflict but still allows 2 Anthropic calls in a race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)