### PR TITLE
fix(program): atomic create via PL/pgSQL RPC, eliminate orphan risk

### DIFF
--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -382,10 +382,18 @@ Deno.serve(async (req: Request) => {
   for (const entry of calendrier) {
     for (const week of entry.semaines) {
       for (const sessionId of entry.sequence) {
+        const sessionData = sessions[sessionId];
+        if (!sessionData) {
+          // Malformed AI output: calendrier references a session id that
+          // isn't in the sessions map. Fail fast with a clear error rather
+          // than letting the RPC raise an opaque NOT NULL violation.
+          console.error("Missing session data for id:", sessionId);
+          return errorResponse(req, "Erreur de génération (sessions invalides)", 500);
+        }
         sessionRows.push({
           week_number: week,
           session_order: globalOrder,
-          session_data: sessions[sessionId],
+          session_data: sessionData,
         });
         globalOrder++;
       }

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -371,43 +371,8 @@ Deno.serve(async (req: Request) => {
     avance: 'advanced',
   };
 
-  // INSERT program
-  const { data: insertedProgram, error: insertError } = await supabaseAdmin
-    .from("programs")
-    .insert({
-      slug,
-      title: pgm.titre,
-      description: pgm.description,
-      goals: body.objectifs,
-      duration_weeks: body.duree_semaines,
-      frequency_per_week: body.seances_par_semaine,
-      fitness_level: niveauMap[pgm.niveau as string] ?? 'intermediate',
-      is_fixed: false,
-      user_id: user.id,
-      note_coach: pgm.note_coach,
-      progression: pgm.progression,
-      consignes_semaine: pgm.consignes_semaine,
-      // Strip age/sexe before persistence — RGPD art. 5(1)(c) minimization.
-      // Both are still sent to Anthropic at generation time (declared in the
-      // Privacy Policy) but never re-read by the app afterwards.
-      onboarding_data: sanitizeOnboardingForPersistence(body),
-      generation_metadata: pgm,
-      input_tokens: totalInputTokens,
-      output_tokens: totalOutputTokens,
-      model: MODEL,
-      locale,
-    })
-    .select("id")
-    .single();
-
-  if (insertError || !insertedProgram) {
-    console.error("Program insert error:", insertError);
-    return errorResponse(req, "Erreur de sauvegarde du programme", 500);
-  }
-
-  // Build program_sessions rows
+  // Build program_sessions rows (program_id is filled by the RPC, not us)
   const sessionRows: {
-    program_id: string;
     week_number: number;
     session_order: number;
     session_data: Record<string, unknown>;
@@ -418,7 +383,6 @@ Deno.serve(async (req: Request) => {
     for (const week of entry.semaines) {
       for (const sessionId of entry.sequence) {
         sessionRows.push({
-          program_id: insertedProgram.id,
           week_number: week,
           session_order: globalOrder,
           session_data: sessions[sessionId],
@@ -428,20 +392,41 @@ Deno.serve(async (req: Request) => {
     }
   }
 
-  // INSERT program_sessions
-  const { error: sessionsError } = await supabaseAdmin
-    .from("program_sessions")
-    .insert(sessionRows);
+  // Atomic INSERT programs + program_sessions via RPC (migration 021).
+  // Wrapping both writes in a single transaction prevents the orphaned-
+  // program-row class of failures the previous "manual rollback" was trying
+  // to handle: if the sessions insert raises, the program insert is rolled
+  // back by Postgres rather than by a best-effort DELETE in JS.
+  const { data: programId, error: rpcError } = await supabaseAdmin.rpc("create_program_with_sessions", {
+    p_user_id: user.id,
+    p_program: {
+      slug,
+      title: pgm.titre,
+      description: pgm.description,
+      goals: body.objectifs,
+      duration_weeks: body.duree_semaines,
+      frequency_per_week: body.seances_par_semaine,
+      fitness_level: niveauMap[pgm.niveau as string] ?? "intermediate",
+      note_coach: pgm.note_coach,
+      progression: pgm.progression,
+      consignes_semaine: pgm.consignes_semaine,
+      // Strip age/sexe before persistence — RGPD art. 5(1)(c) minimization.
+      // Both are still sent to Anthropic at generation time (declared in
+      // the Privacy Policy) but never re-read by the app afterwards.
+      onboarding_data: sanitizeOnboardingForPersistence(body),
+      generation_metadata: pgm,
+      input_tokens: totalInputTokens,
+      output_tokens: totalOutputTokens,
+      model: MODEL,
+      locale,
+    },
+    p_sessions: sessionRows,
+  });
 
-  if (sessionsError) {
-    console.error("Program sessions insert error:", sessionsError);
-    // Rollback: delete the program, verify success
-    const { error: rollbackError } = await supabaseAdmin.from("programs").delete().eq("id", insertedProgram.id).eq("user_id", user.id);
-    if (rollbackError) {
-      console.error("Rollback failed — orphaned program:", insertedProgram.id, rollbackError);
-    }
-    return errorResponse(req, "Erreur de sauvegarde des seances", 502);
+  if (rpcError || !programId) {
+    console.error("Program RPC error:", rpcError);
+    return errorResponse(req, "Erreur de sauvegarde du programme", 500);
   }
 
-  return jsonResponse(req, { programId: insertedProgram.id, slug });
+  return jsonResponse(req, { programId, slug });
 });

--- a/supabase/migrations/021_create_program_with_sessions_rpc.sql
+++ b/supabase/migrations/021_create_program_with_sessions_rpc.sql
@@ -12,11 +12,10 @@ CREATE OR REPLACE FUNCTION public.create_program_with_sessions(
 ) RETURNS uuid
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public
+SET search_path = ''
 AS $$
 DECLARE
   v_program_id uuid;
-  v_session jsonb;
 BEGIN
   INSERT INTO public.programs (
     slug,
@@ -60,21 +59,18 @@ BEGIN
   )
   RETURNING id INTO v_program_id;
 
-  FOR v_session IN SELECT * FROM jsonb_array_elements(p_sessions)
-  LOOP
-    INSERT INTO public.program_sessions (
-      program_id,
-      week_number,
-      session_order,
-      session_data
-    )
-    VALUES (
-      v_program_id,
-      (v_session->>'week_number')::int,
-      (v_session->>'session_order')::int,
-      v_session->'session_data'
-    );
-  END LOOP;
+  INSERT INTO public.program_sessions (
+    program_id,
+    week_number,
+    session_order,
+    session_data
+  )
+  SELECT
+    v_program_id,
+    (s->>'week_number')::int,
+    (s->>'session_order')::int,
+    s->'session_data'
+  FROM jsonb_array_elements(p_sessions) AS s;
 
   RETURN v_program_id;
 END;

--- a/supabase/migrations/021_create_program_with_sessions_rpc.sql
+++ b/supabase/migrations/021_create_program_with_sessions_rpc.sql
@@ -1,0 +1,89 @@
+-- Atomic creation of a custom program + its sessions in a single transaction.
+-- The previous edge-function flow (INSERT programs → INSERT program_sessions
+-- → manual DELETE on failure) leaves an orphaned program row if the rollback
+-- DELETE itself fails (network blip, RLS edge case, etc.). This RPC wraps
+-- both inserts in a single PL/pgSQL transaction: if the sessions insert
+-- raises, the program insert is rolled back automatically.
+
+CREATE OR REPLACE FUNCTION public.create_program_with_sessions(
+  p_user_id uuid,
+  p_program jsonb,
+  p_sessions jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_program_id uuid;
+  v_session jsonb;
+BEGIN
+  INSERT INTO public.programs (
+    slug,
+    title,
+    description,
+    goals,
+    duration_weeks,
+    frequency_per_week,
+    fitness_level,
+    is_fixed,
+    user_id,
+    note_coach,
+    progression,
+    consignes_semaine,
+    onboarding_data,
+    generation_metadata,
+    input_tokens,
+    output_tokens,
+    model,
+    locale
+  )
+  VALUES (
+    p_program->>'slug',
+    p_program->>'title',
+    p_program->>'description',
+    ARRAY(SELECT jsonb_array_elements_text(p_program->'goals')),
+    (p_program->>'duration_weeks')::int,
+    (p_program->>'frequency_per_week')::int,
+    p_program->>'fitness_level',
+    false,
+    p_user_id,
+    p_program->>'note_coach',
+    p_program->'progression',
+    p_program->'consignes_semaine',
+    p_program->'onboarding_data',
+    p_program->'generation_metadata',
+    (p_program->>'input_tokens')::int,
+    (p_program->>'output_tokens')::int,
+    p_program->>'model',
+    p_program->>'locale'
+  )
+  RETURNING id INTO v_program_id;
+
+  FOR v_session IN SELECT * FROM jsonb_array_elements(p_sessions)
+  LOOP
+    INSERT INTO public.program_sessions (
+      program_id,
+      week_number,
+      session_order,
+      session_data
+    )
+    VALUES (
+      v_program_id,
+      (v_session->>'week_number')::int,
+      (v_session->>'session_order')::int,
+      v_session->'session_data'
+    );
+  END LOOP;
+
+  RETURN v_program_id;
+END;
+$$;
+
+-- The edge function calls this via the service role, which bypasses RLS.
+-- No grant to authenticated/anon: regular clients should never call this.
+REVOKE ALL ON FUNCTION public.create_program_with_sessions(uuid, jsonb, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_program_with_sessions(uuid, jsonb, jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.create_program_with_sessions IS
+  'Atomic INSERT into programs + program_sessions. If the sessions insert fails, the program insert is rolled back automatically by the surrounding transaction.';


### PR DESCRIPTION
## Summary

- New RPC `create_program_with_sessions(p_user_id, p_program jsonb, p_sessions jsonb)` wraps both inserts in a single Postgres transaction.
- `SECURITY DEFINER` + `SET search_path = ''` + `REVOKE PUBLIC` + `GRANT service_role` — same hardening pattern as `get_active_program`.
- Edge function refactored to call the RPC instead of inserting sequentially with manual rollback.
- Pre-flight guard added: malformed AI output (calendrier referencing a missing session id) now fails with a clear 500 instead of an opaque NOT NULL violation.

## Why

If the second insert (`program_sessions`) failed, the previous code did a manual `DELETE` on `programs`. If that DELETE itself failed (network blip, RLS edge case), the program row stayed orphaned. The RPC eliminates the class entirely.

## Migration status

- Applied on dev via Supabase MCP at audit time. Re-applied with the corrected `search_path = ''`.
- Will land on prod with the 018/019/020/021 batch when staging the merge to main.

## Test plan

- [x] Build + 317 tests pass
- [x] Reviewed by quality-engineer (REQUEST_CHANGES on first cycle: search_path inconsistency, FOR loop vs INSERT SELECT, missing sessions guard — all addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)