### PR TITLE
sec(auth): require strong passwords client-side, align config.toml

### DIFF
--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, Navigate } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { isPasswordStrong } from '../../utils/password.ts';
 import { BackLink } from './BackLink.tsx';
 import { FormInput } from './FormInput.tsx';
 
@@ -27,8 +28,8 @@ export function SignupPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (password.length < 8) {
-      setError(t('errors.password_too_short'));
+    if (!isPasswordStrong(password)) {
+      setError(t('errors.password_too_weak'));
       return;
     }
     setSubmitting(true);

--- a/src/components/auth/UpdatePasswordPage.tsx
+++ b/src/components/auth/UpdatePasswordPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { isPasswordStrong } from '../../utils/password.ts';
 import { LoadingSpinner } from '../LoadingSpinner.tsx';
 import { FormInput } from './FormInput.tsx';
 
@@ -23,8 +24,8 @@ export function UpdatePasswordPage() {
     e.preventDefault();
     setError(null);
 
-    if (password.length < 8) {
-      setError(t('errors.password_too_short'));
+    if (!isPasswordStrong(password)) {
+      setError(t('errors.password_too_weak'));
       return;
     }
     if (password !== confirm) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,7 +30,11 @@ const SUPABASE_ERROR_KEYS: Record<string, string> = {
   'Invalid login credentials': 'invalid_credentials',
   'Email not confirmed': 'email_not_confirmed',
   'User already registered': 'user_already_registered',
-  'Password should be at least 6 characters': 'password_too_short',
+  // Generic prefix that matches GoTrue's "Password should be at least N
+  // characters" regardless of N. The client-side isPasswordStrong() catches
+  // weak passwords first; this needle only fires if Supabase Cloud config
+  // ever drifts below the local 8-char rule.
+  'Password should be at least': 'password_too_short',
   'For security purposes, you can only request this after': 'rate_limited_short',
   'Unable to validate email address: invalid format': 'invalid_email_format',
   'New password should be different from the old password': 'new_password_same',

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -86,6 +86,7 @@
     "auth_unavailable": "Auth not available",
     "missing_code": "Verification code missing",
     "password_too_short": "Password must be at least 8 characters.",
+    "password_too_weak": "Password must contain at least 8 characters with one uppercase letter, one lowercase letter, and one digit.",
     "passwords_mismatch": "Passwords do not match."
   },
   "supabase_errors": {

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -94,7 +94,7 @@
     "invalid_credentials": "Incorrect email or password.",
     "email_not_confirmed": "Please confirm your email address before signing in.",
     "user_already_registered": "An account already exists with this email.",
-    "password_too_short": "Password must be at least 6 characters.",
+    "password_too_short": "Password must be at least 8 characters.",
     "rate_limited_short": "Please wait before trying again.",
     "invalid_email_format": "Invalid email address.",
     "new_password_same": "Your new password must be different from the old one.",

--- a/src/i18n/locales/fr/auth.json
+++ b/src/i18n/locales/fr/auth.json
@@ -94,7 +94,7 @@
     "invalid_credentials": "Email ou mot de passe incorrect.",
     "email_not_confirmed": "Confirme ton adresse email avant de te connecter.",
     "user_already_registered": "Un compte existe déjà avec cet email.",
-    "password_too_short": "Le mot de passe doit contenir au moins 6 caractères.",
+    "password_too_short": "Le mot de passe doit contenir au moins 8 caractères.",
     "rate_limited_short": "Patiente avant de réessayer.",
     "invalid_email_format": "Adresse email invalide.",
     "new_password_same": "Le nouveau mot de passe doit être différent de l'ancien.",

--- a/src/i18n/locales/fr/auth.json
+++ b/src/i18n/locales/fr/auth.json
@@ -86,6 +86,7 @@
     "auth_unavailable": "Auth non disponible",
     "missing_code": "Code de vérification manquant",
     "password_too_short": "Le mot de passe doit contenir au moins 8 caractères.",
+    "password_too_weak": "Le mot de passe doit contenir au moins 8 caractères, dont 1 majuscule, 1 minuscule et 1 chiffre.",
     "passwords_mismatch": "Les mots de passe ne correspondent pas."
   },
   "supabase_errors": {

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -2,6 +2,11 @@
 // Mirrors the Supabase Cloud config (minimum_password_length=8 +
 // password_requirements="lower_upper_letters_digits") so the client rejects
 // weak passwords with a clear message before the auth call round-trip.
+//
+// Note: [a-z] / [A-Z] are ASCII-only on purpose — this matches GoTrue's own
+// classifier, so a password composed entirely of accented letters (e.g.
+// "Étoile1") is rejected client- AND server-side. There's no client/server
+// divergence; users hit a single, consistent rule.
 const MIN_LENGTH = 8;
 const PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
 

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,10 @@
+// Password policy: 8 chars min, at least one lowercase, uppercase, and digit.
+// Mirrors the Supabase Cloud config (minimum_password_length=8 +
+// password_requirements="lower_upper_letters_digits") so the client rejects
+// weak passwords with a clear message before the auth call round-trip.
+const MIN_LENGTH = 8;
+const PASSWORD_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
+
+export function isPasswordStrong(password: string): boolean {
+  return password.length >= MIN_LENGTH && PASSWORD_PATTERN.test(password);
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -172,10 +172,10 @@ enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
-minimum_password_length = 6
+minimum_password_length = 8
 # Passwords that do not meet the following requirements will be rejected as weak. Supported values
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
-password_requirements = ""
+password_requirements = "lower_upper_letters_digits"
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.


### PR DESCRIPTION
## Summary

- New `src/utils/password.ts` with `isPasswordStrong()` (8+ chars + 1 lowercase + 1 uppercase + 1 digit, ASCII).
- SignupPage and UpdatePasswordPage migrated to use it.
- New `errors.password_too_weak` i18n key (FR + EN, parity OK).
- `supabase/config.toml` aligned (`minimum_password_length=8`, `password_requirements="lower_upper_letters_digits"`).
- `AuthContext` Supabase error mapping made resilient to GoTrue version drift (prefix match instead of exact length).
- `supabase_errors.password_too_short` text updated from "6" to "8" (FR + EN).

## Why

Audit pre-merge develop → main: client validation only checked `length < 8` with no complexity, and Supabase Cloud default is 6 chars. A user could pick `12345678`. The fix tightens client validation to match the intended policy and aligns the local supabase config.

## Manual follow-up (must be done before / at prod merge)

- Update Supabase Cloud Dashboard for **dev** AND **prod** projects:  
  `Auth → Policies → Password Requirements`:
  - Minimum password length = 8
  - Requirements = "Lowercase, uppercase letters, and digits"

Without that, the server still accepts short passwords (the client just rejects them first).

## Test plan

- [x] Build + 317 tests pass
- [x] `npm run check:i18n` passes (16 namespaces, 2012 keys aligned)
- [x] Reviewed by quality-engineer (APPROVE with NIT addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)