### PR TITLE
sec(i18n): re-enable escapeValue and migrate to <Trans>

### DIFF
--- a/src/components/Formats.tsx
+++ b/src/components/Formats.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { FORMATS_DATA } from '../data/formats.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
@@ -28,11 +28,9 @@ export function Formats() {
       </header>
 
       <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
-        <p
-          className="text-sm text-subtle leading-relaxed"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tag
-          dangerouslySetInnerHTML={{ __html: t('formats.intro') }}
-        />
+        <p className="text-sm text-subtle leading-relaxed">
+          <Trans i18nKey="formats.intro" ns="explore" components={{ strong: <strong /> }} />
+        </p>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {FORMATS_DATA.map((format) => (

--- a/src/components/HealthDisclaimer.tsx
+++ b/src/components/HealthDisclaimer.tsx
@@ -1,6 +1,6 @@
 import { HeartPulse } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 interface Props {
   onAccept: () => void;
@@ -75,10 +75,9 @@ export function HealthDisclaimer({ onAccept, onCancel }: Props) {
         </div>
 
         <div className="px-6 overflow-y-auto flex-1 space-y-3 text-sm text-gray-600 leading-relaxed">
-          <p
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: controlled i18n string with known safe <strong> tag
-            dangerouslySetInnerHTML={{ __html: t('health_disclaimer.body_editorial') }}
-          />
+          <p>
+            <Trans i18nKey="health_disclaimer.body_editorial" ns="player" components={{ strong: <strong /> }} />
+          </p>
           <p>{t('health_disclaimer.body_responsibility')}</p>
           <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 space-y-2">
             <p className="font-semibold text-amber-800">{t('health_disclaimer.warning_box_title')}</p>

--- a/src/components/NutritionSetupPage.tsx
+++ b/src/components/NutritionSetupPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import { type FormEvent, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useNutritionProfile } from '../hooks/useNutritionProfile.ts';
@@ -77,11 +77,9 @@ export function NutritionSetupPage() {
 
         <header>
           <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">{t('setup.heading')}</h1>
-          <p
-            className="text-sm text-body mt-2 leading-relaxed"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tag
-            dangerouslySetInnerHTML={{ __html: t('setup.intro') }}
-          />
+          <p className="text-sm text-body mt-2 leading-relaxed">
+            <Trans i18nKey="setup.intro" ns="nutrition" components={{ strong: <strong /> }} />
+          </p>
         </header>
 
         <section className="rounded-2xl bg-surface-card border border-card-border p-6 space-y-4">

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useOpenFoodFacts } from '../../hooks/useOpenFoodFacts.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
 import type { MealType } from '../../types/nutrition.ts';
@@ -129,15 +129,16 @@ export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) 
             />
           </div>
 
-          <p
-            className="text-sm text-body"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tag
-            dangerouslySetInnerHTML={{
-              __html: t('barcode_pane.portion_text', {
+          <p className="text-sm text-body">
+            <Trans
+              i18nKey="barcode_pane.portion_text"
+              ns="nutrition"
+              values={{
                 kcal: Math.round(scaleKcal(product.calories_100g, Number.parseFloat(portionGrams) || 0)),
-              }),
-            }}
-          />
+              }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
 
           {formError && <p className="text-xs text-red-400">{formError}</p>}
 

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,6 +1,6 @@
 import { X } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { MEAL_TYPES } from '../../config/nutrition.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../../types/nutrition.ts';
@@ -372,11 +372,14 @@ function SearchPane({ selectedFood, onSelect, portionGrams, onPortionChange, sca
           />
         </div>
         {scaledCalories != null && (
-          <p
-            className="text-sm text-body"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tag
-            dangerouslySetInnerHTML={{ __html: t('meal_form.portion_text', { kcal: Math.round(scaledCalories) }) }}
-          />
+          <p className="text-sm text-body">
+            <Trans
+              i18nKey="meal_form.portion_text"
+              ns="nutrition"
+              values={{ kcal: Math.round(scaledCalories) }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
         )}
       </div>
     );

--- a/src/components/nutrition/TdeeCalculatorForm.tsx
+++ b/src/components/nutrition/TdeeCalculatorForm.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { ACTIVITY_LEVELS, NUTRITION_GOALS, TDEE_BOUNDS } from '../../config/nutrition.ts';
 import type { ActivityLevel, BiologicalSex, NutritionGoal, TdeeResult } from '../../types/nutrition.ts';
 import { computeTdee, validateTdeeInputs } from '../../utils/tdee.ts';
@@ -74,11 +74,9 @@ export function TdeeCalculatorForm({ onAccept, onCancel }: TdeeCalculatorFormPro
     <div className="space-y-6">
       <div className="rounded-xl bg-surface-card border border-divider p-4 space-y-2">
         <h3 className="font-display text-base font-bold text-heading">{t('tdee.heading')}</h3>
-        <p
-          className="text-sm text-body leading-relaxed"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tag
-          dangerouslySetInnerHTML={{ __html: t('tdee.intro') }}
-        />
+        <p className="text-sm text-body leading-relaxed">
+          <Trans i18nKey="tdee.intro" ns="nutrition" components={{ strong: <strong /> }} />
+        </p>
         <p className="text-xs text-muted italic">{t('tdee.formula_note')}</p>
       </div>
 
@@ -200,13 +198,21 @@ export function TdeeCalculatorForm({ onAccept, onCancel }: TdeeCalculatorFormPro
       {preview && (
         <div className="rounded-xl bg-surface-card border border-brand/30 p-4 space-y-3">
           <h4 className="font-display text-base font-bold text-heading">{t('tdee.preview_heading')}</h4>
-          <p
-            className="text-sm text-body"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: translated HTML with bold tags
-            dangerouslySetInnerHTML={{
-              __html: `${t('tdee.bmr', { kcal: preview.bmr })}<br />${t('tdee.tdee_label', { kcal: preview.tdee })}`,
-            }}
-          />
+          <p className="text-sm text-body">
+            <Trans
+              i18nKey="tdee.bmr"
+              ns="nutrition"
+              values={{ kcal: preview.bmr }}
+              components={{ strong: <strong /> }}
+            />
+            <br />
+            <Trans
+              i18nKey="tdee.tdee_label"
+              ns="nutrition"
+              values={{ kcal: preview.tdee }}
+              components={{ strong: <strong /> }}
+            />
+          </p>
           <div className="rounded-lg bg-brand/10 border border-brand/30 p-3">
             <p className="text-xs text-muted uppercase tracking-wider mb-1">{t('tdee.target_label')}</p>
             <p className="font-display text-3xl font-black text-brand">{preview.targetCalories} kcal</p>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -42,7 +42,11 @@ i18n
     supportedLngs: SUPPORTED_LOCALES,
     ns: namespaces,
     defaultNS: 'common',
-    interpolation: { escapeValue: false },
+    // Escape interpolated values by default (XSS safety). Strings that need
+    // intentional HTML (e.g. <strong>...</strong>) must be rendered with
+    // react-i18next's <Trans> component and an explicit `components` map —
+    // never with dangerouslySetInnerHTML.
+    interpolation: { escapeValue: true },
     detection: {
       order: ['localStorage', 'navigator'],
       lookupLocalStorage: LOCALE_STORAGE_KEY,

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -68,7 +68,6 @@
     "cancel": "Cancel",
     "add": "Add",
     "adding": "Adding…",
-    "source_credit": "Data provided via <a>Open Food Facts</a> (ODbL licence).",
     "source_credit_prefix": "Data provided via",
     "source_credit_suffix": "(ODbL licence)."
   },

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -68,7 +68,6 @@
     "cancel": "Annuler",
     "add": "Ajouter",
     "adding": "Ajout…",
-    "source_credit": "Données fournies via <a>Open Food Facts</a> (licence ODbL).",
     "source_credit_prefix": "Données fournies via",
     "source_credit_suffix": "(licence ODbL)."
   },


### PR DESCRIPTION
## Summary

- `interpolation.escapeValue: false` → `true` in `src/i18n/index.ts`
- 7 `dangerouslySetInnerHTML` removed across 6 components, replaced with `<Trans i18nKey ns components={{ strong: <strong /> }} />`
- 7 `biome-ignore lint/security/noDangerouslySetInnerHtml` suppressions dropped
- Orphaned `barcode_pane.source_credit` key cleaned in FR + EN (replaced earlier by split prefix/suffix variant)

## Why

Audit pre-merge develop → main: `escapeValue: false` global combined with `dangerouslySetInnerHTML` was a latent XSS surface. Current values were `Math.round(number)` so safe in practice, but one careless future interpolation of a user-controlled value would have leaked. Moving to `<Trans>` + `escapeValue: true` closes the surface at the framework level.

## Test plan

- [x] Build + 317 tests pass
- [x] `npm run check:i18n` passes (2011 keys aligned)
- [x] Reviewed by quality-engineer (APPROVE with NIT addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)