### PR TITLE
fix(i18n): externalize hook error strings to common namespace

### DIFF
--- a/src/hooks/useCustomSessions.ts
+++ b/src/hooks/useCustomSessions.ts
@@ -1,8 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { CustomSessionRecord } from '../types/custom-session.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 export function useCustomSessions(userId: string | undefined) {
   const queryClient = useQueryClient();
@@ -26,10 +29,10 @@ export function useCustomSessions(userId: string | undefined) {
 
       if (sessionExpired) {
         notifySessionExpired();
-        return { sessions: [], error: 'Session expirée. Rafraîchis la page.' };
+        return { sessions: [], error: tHookError('session_expired_refresh') };
       }
       if (fetchError) {
-        return { sessions: [], error: 'Impossible de charger l\u2019historique.' };
+        return { sessions: [], error: tHookError('history_load_failed') };
       }
       return { sessions: (data as CustomSessionRecord[]) ?? [], error: null };
     },

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -1,8 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 import type {
   DailyNutritionSummary,
   DailyNutritionTotals,
@@ -75,7 +78,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         return { logs: [], error: null };
       }
       if (err) {
-        return { logs: [], error: err.message ?? 'Erreur de chargement des repas' };
+        return { logs: [], error: err.message ?? tHookError('meals_load_failed') };
       }
       return { logs: (data ?? []) as MealLog[], error: null };
     },

--- a/src/hooks/useEstimateNutrition.ts
+++ b/src/hooks/useEstimateNutrition.ts
@@ -1,7 +1,10 @@
 import { useCallback, useRef, useState } from 'react';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import type { NutritionInsight, TextEstimate } from '../types/nutrition.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 export interface TextEstimateResponse {
   estimate: TextEstimate;
@@ -38,7 +41,7 @@ export function useEstimateNutrition(): UseEstimateNutritionResult {
   const inflightRef = useRef(false);
 
   const call = useCallback(async <T>(body: Record<string, unknown>): Promise<CallOutcome<T>> => {
-    if (!supabase) return { data: null, error: 'Service indisponible.' };
+    if (!supabase) return { data: null, error: tHookError('service_unavailable') };
     if (inflightRef.current) return { data: null, error: null };
     inflightRef.current = true;
     setLoading(true);
@@ -50,14 +53,14 @@ export function useEstimateNutrition(): UseEstimateNutritionResult {
       if (fnError) {
         const msg = await extractEdgeFunctionError(
           fnError as unknown as Record<string, unknown>,
-          'Estimation indisponible.',
+          tHookError('service_unavailable'),
         );
         setError(msg);
         return { data: null, error: msg };
       }
       return { data: (data ?? null) as T | null, error: null };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Erreur inconnue';
+      const msg = err instanceof Error ? err.message : tHookError('unexpected');
       setError(msg);
       return { data: null, error: msg };
     } finally {

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { FoodReference } from '../types/nutrition.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 const DEBOUNCE_MS = 200;
 const RESULTS_LIMIT = 12;
@@ -59,7 +62,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
           return;
         }
         if (err) {
-          setError(err.message ?? 'Erreur de recherche');
+          setError(err.message ?? tHookError('search_failed'));
           setLoading(false);
           return;
         }
@@ -68,7 +71,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
         setLoading(false);
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Erreur inconnue');
+          setError(err instanceof Error ? err.message : tHookError('unexpected'));
           setLoading(false);
         }
       }

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -65,7 +65,7 @@ export function useGenerateProgram() {
         inflightRef.current = false;
       }
     },
-    [queryClient, userId, i18n],
+    [queryClient, userId, i18n.language],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -21,7 +21,7 @@ export function useGenerateProgram() {
     async (input: ProgramOnboardingInput): Promise<GenerateProgramResponse | null> => {
       if (inflightRef.current) return null;
       if (!supabase) {
-        setError('Service indisponible');
+        setError(i18n.t('hook_errors.service_unavailable', { ns: 'common' }));
         return null;
       }
 
@@ -38,7 +38,7 @@ export function useGenerateProgram() {
         if (fnError) {
           const message = await extractEdgeFunctionError(
             fnError as unknown as Record<string, unknown>,
-            'Une erreur est survenue. Réessaye.',
+            i18n.t('hook_errors.generic_retry', { ns: 'common' }),
           );
           setError(message);
           return null;
@@ -58,14 +58,14 @@ export function useGenerateProgram() {
 
         return data as GenerateProgramResponse;
       } catch (e) {
-        setError(e instanceof Error ? e.message : 'Erreur inattendue');
+        setError(e instanceof Error ? e.message : i18n.t('hook_errors.unexpected', { ns: 'common' }));
         return null;
       } finally {
         setLoading(false);
         inflightRef.current = false;
       }
     },
-    [queryClient, userId, i18n.language],
+    [queryClient, userId, i18n],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -21,7 +21,7 @@ export function useGenerateSession() {
     async (input: CustomSessionInput): Promise<GenerateSessionResponse | null> => {
       if (inflightRef.current) return null;
       if (!supabase) {
-        setError('Service indisponible');
+        setError(i18n.t('hook_errors.service_unavailable', { ns: 'common' }));
         return null;
       }
 
@@ -38,7 +38,7 @@ export function useGenerateSession() {
         if (fnError) {
           const message = await extractEdgeFunctionError(
             fnError as unknown as Record<string, unknown>,
-            'Une erreur est survenue. Réessayez.',
+            i18n.t('hook_errors.generic_retry', { ns: 'common' }),
           );
           setError(message);
           return null;
@@ -58,14 +58,14 @@ export function useGenerateSession() {
 
         return data as GenerateSessionResponse;
       } catch (e) {
-        setError(e instanceof Error ? e.message : 'Erreur inattendue');
+        setError(e instanceof Error ? e.message : i18n.t('hook_errors.unexpected', { ns: 'common' }));
         return null;
       } finally {
         setLoading(false);
         inflightRef.current = false;
       }
     },
-    [queryClient, userId, i18n.language],
+    [queryClient, userId, i18n],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -65,7 +65,7 @@ export function useGenerateSession() {
         inflightRef.current = false;
       }
     },
-    [queryClient, userId, i18n],
+    [queryClient, userId, i18n.language],
   );
 
   return { generate, loading, error };

--- a/src/hooks/useNutritionProfile.ts
+++ b/src/hooks/useNutritionProfile.ts
@@ -1,9 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { NutritionProfile, NutritionProfileUpsert } from '../types/nutrition.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 export interface UseNutritionProfileResult {
   profile: NutritionProfile | null;
@@ -34,7 +37,7 @@ export function useNutritionProfile(): UseNutritionProfileResult {
         return { profile: null, error: null };
       }
       if (err) {
-        return { profile: null, error: err.message ?? 'Erreur de chargement du profil' };
+        return { profile: null, error: err.message ?? tHookError('profile_load_failed') };
       }
       return { profile: (data as NutritionProfile | null) ?? null, error: null };
     },

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Subscription } from '../types/subscription.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
+
+// Hook errors (FR/EN) live under common:hook_errors and are resolved at call
+// time so the user's current locale wins. Hooks can't use useTranslation
+// reactively because some callers (mutations) run outside React render.
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 export function useSubscription() {
   const { profile, user } = useAuth();
@@ -37,7 +43,7 @@ export function useSubscription() {
 
   const checkout = useCallback(
     async (priceId: string): Promise<string | null> => {
-      if (!supabase || !user) return 'Non connecté';
+      if (!supabase || !user) return tHookError('not_signed_in');
 
       const { data, error } = await supabase.functions.invoke('create-checkout-session', {
         body: { priceId },
@@ -46,7 +52,7 @@ export function useSubscription() {
       if (error) {
         const message = await extractEdgeFunctionError(
           error as unknown as Record<string, unknown>,
-          'Erreur lors de la création de la session de paiement',
+          tHookError('checkout_session_failed'),
         );
         return message;
       }
@@ -55,18 +61,18 @@ export function useSubscription() {
         window.location.href = data.url;
         return null;
       }
-      return data?.error || 'Erreur lors de la création de la session de paiement';
+      return data?.error || tHookError('checkout_session_failed');
     },
     [user],
   );
 
   const manageSubscription = useCallback(async (): Promise<string | null> => {
-    if (!supabase || !user) return 'Non connecté';
+    if (!supabase || !user) return tHookError('not_signed_in');
 
     const { data, error } = await supabase.functions.invoke('create-portal-session');
 
     if (error) {
-      const msg = error.message || "Erreur lors de l'ouverture du portail";
+      const msg = error.message || tHookError('portal_open_failed');
       return msg;
     }
 
@@ -74,7 +80,7 @@ export function useSubscription() {
       window.location.href = data.url;
       return null;
     }
-    return data?.error || "Erreur lors de l'ouverture du portail";
+    return data?.error || tHookError('portal_open_failed');
   }, [user]);
 
   return {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -48,5 +48,15 @@
   },
   "loading": {
     "aria": "Loading"
+  },
+  "hook_errors": {
+    "service_unavailable": "Service unavailable",
+    "not_signed_in": "Not signed in",
+    "checkout_session_failed": "Failed to create the checkout session",
+    "portal_open_failed": "Failed to open the customer portal",
+    "history_load_failed": "Failed to load history.",
+    "session_expired_refresh": "Session expired. Please refresh the page.",
+    "generic_retry": "An error occurred. Please try again.",
+    "unexpected": "Unexpected error"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -56,6 +56,9 @@
     "portal_open_failed": "Failed to open the customer portal",
     "history_load_failed": "Failed to load history.",
     "session_expired_refresh": "Session expired. Please refresh the page.",
+    "search_failed": "Search error",
+    "profile_load_failed": "Failed to load profile",
+    "meals_load_failed": "Failed to load meals",
     "generic_retry": "An error occurred. Please try again.",
     "unexpected": "Unexpected error"
   }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -56,6 +56,9 @@
     "portal_open_failed": "Erreur lors de l'ouverture du portail",
     "history_load_failed": "Impossible de charger l'historique.",
     "session_expired_refresh": "Session expirée. Rafraîchis la page.",
+    "search_failed": "Erreur de recherche",
+    "profile_load_failed": "Erreur de chargement du profil",
+    "meals_load_failed": "Erreur de chargement des repas",
     "generic_retry": "Une erreur est survenue. Réessayez.",
     "unexpected": "Erreur inattendue"
   }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -48,5 +48,15 @@
   },
   "loading": {
     "aria": "Chargement"
+  },
+  "hook_errors": {
+    "service_unavailable": "Service indisponible",
+    "not_signed_in": "Non connecté",
+    "checkout_session_failed": "Erreur lors de la création de la session de paiement",
+    "portal_open_failed": "Erreur lors de l'ouverture du portail",
+    "history_load_failed": "Impossible de charger l'historique.",
+    "session_expired_refresh": "Session expirée. Rafraîchis la page.",
+    "generic_retry": "Une erreur est survenue. Réessayez.",
+    "unexpected": "Erreur inattendue"
   }
 }


### PR DESCRIPTION
## Summary

- New `common.hook_errors` namespace (FR + EN, parity 2022 keys aligned).
- 8 hooks migrated: useSubscription, useGenerateSession, useGenerateProgram, useEstimateNutrition, useCustomSessions, useFoodSearch, useNutritionProfile, useDailyNutrition.
- Hooks call `i18n.t(...)` at call time so the user's current locale wins; some hooks run outside React render (mutations triggered from event handlers) so `useTranslation` would not be reactive.
- For the 2 hooks that already used `useTranslation` (generate session/program), keep `i18n.language` in `useCallback` deps (not `i18n` object) to avoid unnecessary re-memoization.

## Why

Audit pre-merge develop → main: hardcoded French strings in error returns surfaced verbatim to EN users (e.g. "Service indisponible", "Non connecté", "Erreur lors de la création de la session de paiement"). 5 hooks initially flagged; review surfaced 3 more in food search / nutrition profile / daily nutrition.

## Test plan

- [x] Build + 317 tests pass
- [x] `npm run check:i18n` passes (16 namespaces, 2022 keys)
- [x] Reviewed by quality-engineer (REQUEST_CHANGES on first cycle: deps regression + 3 missed hooks, both addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)