### PR TITLE
sec(ai): assistant prefill on generate-session and generate-program

### DIFF
--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -311,13 +311,20 @@ Deno.serve(async (req: Request) => {
     // prefilled — prepend the prefill back before parsing.
     const combined = `${ASSISTANT_PREFILL}${rawContent}`;
 
-    // Parse JSON (handle potential markdown wrapper)
+    // Parse JSON (handle potential markdown wrapper, kept as belt-and-
+    // suspenders even though the prefill makes it unreachable in practice).
     const cleaned = combined
       .replace(/^```json\s*/i, "")
       .replace(/```\s*$/, "")
       .trim();
 
-    const parsed = JSON.parse(cleaned);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch {
+      console.error("Failed to parse AI response:", combined.slice(0, 500));
+      throw new Error("Réponse IA invalide");
+    }
 
     return {
       data: parsed,

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -9,6 +9,10 @@ const MAX_ACTIVE_PROGRAMS = 3;
 const MAX_DAILY_GENERATIONS = 3;
 const MODEL = "claude-sonnet-4-6";
 const MAX_TOKENS = 12288;
+// Defence-in-depth against prompt injection: prefilling the assistant turn
+// with `{"` forces the model to immediately start a JSON object and pre-empts
+// any "ignore previous instructions" jailbreak embedded in user freetext.
+const ASSISTANT_PREFILL = '{"';
 
 const VALID_OBJECTIFS = [
   'perte_poids', 'prise_muscle', 'remise_forme', 'force',
@@ -271,9 +275,12 @@ Deno.serve(async (req: Request) => {
   // Call Anthropic API
   // Sonnet with 12K tokens needs more time than Haiku session generation
   async function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
+    // Last message must be the assistant prefill so the model continues from
+    // the JSON-start token instead of free-form prose.
     const messages = [
       { role: "user", content: userPrompt },
       ...extraMessages,
+      { role: "assistant", content: ASSISTANT_PREFILL },
     ];
 
     const aiResponse = await fetch("https://api.anthropic.com/v1/messages", {
@@ -300,9 +307,12 @@ Deno.serve(async (req: Request) => {
 
     const aiData = await aiResponse.json();
     const rawContent = aiData.content?.[0]?.text ?? "";
+    // Anthropic returns only the continuation when the assistant turn is
+    // prefilled — prepend the prefill back before parsing.
+    const combined = `${ASSISTANT_PREFILL}${rawContent}`;
 
     // Parse JSON (handle potential markdown wrapper)
-    const cleaned = rawContent
+    const cleaned = combined
       .replace(/^```json\s*/i, "")
       .replace(/```\s*$/, "")
       .trim();

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -7,6 +7,10 @@ import { validateSession } from "./validate.ts";
 const MAX_DAILY_GENERATIONS = 10;
 const MODEL = "claude-haiku-4-5-20251001";
 const MAX_TOKENS = 4096;
+// Defence-in-depth against prompt injection: prefilling the assistant turn
+// with `{"` forces the model to immediately start a JSON object and pre-empts
+// any "ignore previous instructions" jailbreak embedded in user freetext.
+const ASSISTANT_PREFILL = '{"';
 
 const VALID_MODES = ["quick", "detailed", "expert"];
 const VALID_PRESETS = ["transpirer", "renfo", "express", "mobilite"];
@@ -247,7 +251,10 @@ Deno.serve(async (req: Request) => {
         model: MODEL,
         max_tokens: MAX_TOKENS,
         system: systemPrompt,
-        messages: [{ role: "user", content: userPrompt }],
+        messages: [
+          { role: "user", content: userPrompt },
+          { role: "assistant", content: ASSISTANT_PREFILL },
+        ],
       }),
       signal: AbortSignal.timeout(30_000),
     });
@@ -267,19 +274,21 @@ Deno.serve(async (req: Request) => {
   const inputTokens = aiData.usage?.input_tokens ?? null;
   const outputTokens = aiData.usage?.output_tokens ?? null;
 
-  // Parse content
+  // Parse content. The assistant prefill is included only as the prompt
+  // start — Anthropic returns just the continuation, so prepend it back.
   const rawContent = aiData.content?.[0]?.text ?? "";
+  const combined = `${ASSISTANT_PREFILL}${rawContent}`;
   let sessionJson: unknown;
 
   try {
     // Handle potential ```json wrapper
-    const cleaned = rawContent
+    const cleaned = combined
       .replace(/^```json\s*/i, "")
       .replace(/```\s*$/, "")
       .trim();
     sessionJson = JSON.parse(cleaned);
   } catch {
-    console.error("Failed to parse AI response:", rawContent.slice(0, 500));
+    console.error("Failed to parse AI response:", combined.slice(0, 500));
     return errorResponse(req, "Réponse IA invalide, réessayez", 502);
   }
 


### PR DESCRIPTION
## Summary

- generate-session and generate-program now send `{ role: 'assistant', content: '{"' }` as the last message, mirroring the estimate-nutrition pattern.
- The continuation Anthropic returns is concatenated back with the prefill before JSON.parse.
- For generate-program, the multi-turn retry preserves the alternating user/assistant ordering and still terminates with the prefill.
- Hardened JSON.parse inside callAnthropic with a try/catch so a malformed AI response surfaces as "Réponse IA invalide" instead of the misleading "Erreur de communication avec l'IA".

## Why

User freetext (preferences, blessures, objectif_detail) is delimited by XML tags in the prompt, but a determined attacker can still try to break out before the JSON output starts. Forcing the model to begin with `{"` makes prose injection structurally impossible.

## Test plan

- [x] Build + 317 tests pass
- [x] Reviewed by quality-engineer (APPROVE; one tracked follow-up — JSON.parse guard — addressed in second commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)