### PR TITLE
fix(data): wrap remaining mutations in supabaseQuery

### DIFF
--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { useSubscription } from '../../hooks/useSubscription.ts';
 import { useTheme } from '../../hooks/useTheme.ts';
 import { supabase } from '../../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../../lib/supabaseQuery.ts';
 import { formatDate } from '../../utils/date.ts';
 import { getInitials } from '../../utils/getInitials.ts';
 
@@ -96,7 +97,15 @@ export function SettingsPage() {
       // Append timestamp to bust cache
       const url = `${publicUrl}?t=${Date.now()}`;
 
-      const { error: updateError } = await supabase.from('profiles').update({ avatar_url: url }).eq('id', user.id);
+      // Wrap the profile update so an expired JWT triggers a refresh + retry
+      // instead of silently failing the avatar replace.
+      const { error: updateError, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('profiles').update({ avatar_url: url }).eq('id', user.id),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        throw new Error('session_expired');
+      }
       if (updateError) throw updateError;
 
       await refreshProfile();

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -103,8 +103,11 @@ export function SettingsPage() {
         supabase!.from('profiles').update({ avatar_url: url }).eq('id', user.id),
       );
       if (sessionExpired) {
+        // Session-expired banner fires via notifySessionExpired; skip the
+        // local 'error_upload' toast since it would be misleading (the
+        // upload itself succeeded, only the profile UPDATE was rejected).
         notifySessionExpired();
-        throw new Error('session_expired');
+        return;
       }
       if (updateError) throw updateError;
 

--- a/src/hooks/useCustomSessions.ts
+++ b/src/hooks/useCustomSessions.ts
@@ -77,11 +77,16 @@ export async function confirmCustomSession(id: string): Promise<boolean> {
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return false;
-    const { error } = await supabase
-      .from('custom_sessions')
-      .update({ status: 'confirmed' })
-      .eq('id', id)
-      .eq('user_id', user.id);
+    // Wrap in supabaseQuery so an expired JWT triggers a refresh + retry.
+    // The user has just reviewed and confirmed the AI-generated session;
+    // failing silently here would lose the confirmation.
+    const { error, sessionExpired } = await supabaseQuery(() =>
+      supabase!.from('custom_sessions').update({ status: 'confirmed' }).eq('id', id).eq('user_id', user.id),
+    );
+    if (sessionExpired) {
+      notifySessionExpired();
+      return false;
+    }
     return !error;
   } catch (err) {
     console.error('Confirm custom session error:', err);

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -34,7 +34,16 @@ export function useUserPrograms() {
     async (id: string) => {
       if (!supabase || !userId) return false;
       try {
-        const { error } = await supabase.from('programs').delete().eq('id', id).eq('user_id', userId);
+        // Wrap in supabaseQuery so an expired JWT triggers a refresh + retry
+        // instead of silently failing — the user might have left the program
+        // page open for several minutes before clicking delete.
+        const { error, sessionExpired } = await supabaseQuery(() =>
+          supabase!.from('programs').delete().eq('id', id).eq('user_id', userId),
+        );
+        if (sessionExpired) {
+          notifySessionExpired();
+          return false;
+        }
         if (error) {
           console.error('Delete program error:', error);
           return false;


### PR DESCRIPTION
## Summary

Closes the follow-up tracked in PR-A3 (#122). Three mutations still bypassed `supabaseQuery`:

- `useUserPrograms.deleteProgram` — long-lived program detail page; user may click delete after JWT expiry
- `SettingsPage.handleAvatarChange` (profile UPDATE) — runs after a potentially long upload
- `confirmCustomSession` — post-review confirmation, silent failure would lose user intent

All three now route through `supabaseQuery()` and dispatch `notifySessionExpired` on refresh failure. SettingsPage uses `return` (not `throw`) on session-expired so the misleading `avatar.error_upload` toast does not surface (banner from `notifySessionExpired` is sufficient).

## Test plan

- [x] Build + 317 tests pass
- [x] Reviewed by quality-engineer (APPROVE; nit on SettingsPage throw addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)