### PR TITLE
sec(ai): atomicize active-program cap (DB trigger) and overflow nutrition

### DIFF
--- a/supabase/functions/estimate-nutrition/index.ts
+++ b/supabase/functions/estimate-nutrition/index.ts
@@ -232,15 +232,34 @@ Deno.serve(async (req: Request) => {
   }
 
   // mode === 'overflow'
+  // Atomic rate limit: insert a tracker row first, then count. Same pattern
+  // as text mode (ai_text_calls) and as generate-session/program. Closes
+  // the parallel-request race that previously let two simultaneous overflow
+  // analyses fire two Anthropic calls before only one upserted.
+  const { data: overflowRateRow, error: overflowRateInsertErr } = await supabaseAdmin
+    .from("ai_generation_calls")
+    .insert({ user_id: user.id, kind: "overflow" })
+    .select("id")
+    .single();
+  if (overflowRateInsertErr || !overflowRateRow) return errorResponse(req, "Erreur serveur", 500);
+
   const { count, error: countError } = await supabaseAdmin
-    .from("nutrition_insights")
+    .from("ai_generation_calls")
     .select("*", { count: "exact", head: true })
     .eq("user_id", user.id)
+    .eq("kind", "overflow")
     .gte("created_at", sinceIso);
-  if (countError) return errorResponse(req, "Erreur serveur", 500);
-  if ((count ?? 0) >= OVERFLOW_DAILY_LIMIT) {
+  if (countError) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", overflowRateRow.id);
+    return errorResponse(req, "Erreur serveur", 500);
+  }
+  if ((count ?? 0) > OVERFLOW_DAILY_LIMIT) {
+    await supabaseAdmin.from("ai_generation_calls").delete().eq("id", overflowRateRow.id);
     return errorResponse(req, "Tu as déjà ton analyse du jour. Reviens demain.", 429);
   }
+  // Note: overflowRateRow is intentionally NOT deleted on downstream failures
+  // (AI call, validation). A failed attempt still counts against the 24h
+  // quota — same anti-retry-storm policy as the other AI endpoints.
 
   const [{ data: logsData, error: logsErr }, { data: profileData, error: profileErr }] = await Promise.all([
     supabaseAdmin

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -13,6 +13,10 @@ const MAX_TOKENS = 12288;
 // with `{"` forces the model to immediately start a JSON object and pre-empts
 // any "ignore previous instructions" jailbreak embedded in user freetext.
 const ASSISTANT_PREFILL = '{"';
+// Sentinel raised by the enforce_user_active_programs_cap trigger
+// (migration 022). Kept as a constant so a future trigger message rename
+// surfaces as a TypeScript build break rather than a silent 500.
+const TRIGGER_CAP_REACHED = "active_programs_cap_reached";
 
 const VALID_OBJECTIFS = [
   'perte_poids', 'prise_muscle', 'remise_forme', 'force',
@@ -453,7 +457,7 @@ Deno.serve(async (req: Request) => {
     // The DB trigger (migration 022) raises 'active_programs_cap_reached' if
     // a race condition let us past the pre-flight count check. Translate it
     // into the same user-facing message so the experience is consistent.
-    if (rpcError?.message?.includes("active_programs_cap_reached")) {
+    if (rpcError?.message?.includes(TRIGGER_CAP_REACHED)) {
       return errorResponse(
         req,
         `Limite atteinte : ${MAX_ACTIVE_PROGRAMS} programmes actifs maximum. Supprime un programme existant pour en creer un nouveau.`,

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -450,6 +450,16 @@ Deno.serve(async (req: Request) => {
 
   if (rpcError || !programId) {
     console.error("Program RPC error:", rpcError);
+    // The DB trigger (migration 022) raises 'active_programs_cap_reached' if
+    // a race condition let us past the pre-flight count check. Translate it
+    // into the same user-facing message so the experience is consistent.
+    if (rpcError?.message?.includes("active_programs_cap_reached")) {
+      return errorResponse(
+        req,
+        `Limite atteinte : ${MAX_ACTIVE_PROGRAMS} programmes actifs maximum. Supprime un programme existant pour en creer un nouveau.`,
+        429,
+      );
+    }
     return errorResponse(req, "Erreur de sauvegarde du programme", 500);
   }
 

--- a/supabase/migrations/022_atomicize_caps.sql
+++ b/supabase/migrations/022_atomicize_caps.sql
@@ -50,7 +50,7 @@ CREATE TRIGGER programs_enforce_active_cap
   FOR EACH ROW EXECUTE FUNCTION public.enforce_user_active_programs_cap();
 
 COMMENT ON FUNCTION public.enforce_user_active_programs_cap IS
-  'Hard DB invariant for the 3-active-programs-per-user cap. Protects against race conditions in the edge function''s pre-flight count.';
+  'Hard DB invariant for the 3-active-programs-per-user cap. Protects against race conditions in the edge function''s pre-flight count. Note: this trigger fires for ALL inserts including service_role, so manual admin inserts of user programs (is_fixed=false) are also capped — by design, the cap is a data invariant, not a UI concern.';
 
 -- ── 2) Extend ai_generation_calls.kind to cover 'overflow' ───────────────
 DO $$

--- a/supabase/migrations/022_atomicize_caps.sql
+++ b/supabase/migrations/022_atomicize_caps.sql
@@ -1,0 +1,73 @@
+-- Two atomicity gaps surfaced during the PR-A5 review:
+--
+-- 1) generate-program/index.ts active-program cap (MAX_ACTIVE_PROGRAMS = 3)
+--    used SELECT COUNT → INSERT, leaving a race window where parallel
+--    requests could each observe count=2 and all insert, ending up with
+--    4-5 active programs. Adding a row-level trigger on `programs` makes
+--    the cap a hard DB invariant — the edge function's pre-flight count
+--    stays in place for fail-fast UX (saves the Anthropic call), but the
+--    trigger is the guarantee.
+--
+-- 2) estimate-nutrition overflow mode (OVERFLOW_DAILY_LIMIT = 1) used the
+--    same SELECT COUNT → INSERT pattern. Solution: extend the
+--    ai_generation_calls.kind CHECK to include 'overflow' so the existing
+--    insert-first/count/delete-if-over pattern (PR-A5) covers it.
+
+-- ── 1) Active-program cap trigger ────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.enforce_user_active_programs_cap()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_active_count INTEGER;
+BEGIN
+  -- Only count user-created (is_fixed = false) programs against the cap.
+  -- The is_fixed seed programs are unlimited.
+  IF NEW.is_fixed THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COUNT(*)
+    INTO v_active_count
+    FROM public.programs
+   WHERE user_id = NEW.user_id
+     AND is_fixed = false;
+
+  IF v_active_count >= 3 THEN
+    RAISE EXCEPTION 'active_programs_cap_reached'
+      USING HINT = 'Maximum 3 active user programs per account.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS programs_enforce_active_cap ON public.programs;
+CREATE TRIGGER programs_enforce_active_cap
+  BEFORE INSERT ON public.programs
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_user_active_programs_cap();
+
+COMMENT ON FUNCTION public.enforce_user_active_programs_cap IS
+  'Hard DB invariant for the 3-active-programs-per-user cap. Protects against race conditions in the edge function''s pre-flight count.';
+
+-- ── 2) Extend ai_generation_calls.kind to cover 'overflow' ───────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE c.conname = 'ai_generation_calls_kind_check'
+      AND n.nspname = 'public'
+      AND t.relname = 'ai_generation_calls'
+  ) THEN
+    ALTER TABLE public.ai_generation_calls
+      DROP CONSTRAINT ai_generation_calls_kind_check;
+  END IF;
+
+  ALTER TABLE public.ai_generation_calls
+    ADD CONSTRAINT ai_generation_calls_kind_check
+      CHECK (kind IN ('session', 'program', 'overflow'));
+END $$;


### PR DESCRIPTION
## Summary

Closes the two follow-ups tracked in PR-A5 (#124):

1. **Active-program cap** (`MAX_ACTIVE_PROGRAMS = 3`) — `BEFORE INSERT` trigger on `programs` raises `active_programs_cap_reached` if the user already has 3 non-fixed programs. The edge function keeps its pre-flight count for fail-fast UX (saves the Anthropic call) but the trigger is now the guarantee. The RPC error path translates the exception into the same user-facing 429 message via a `TRIGGER_CAP_REACHED` sentinel constant.
2. **Overflow nutrition** (`OVERFLOW_DAILY_LIMIT = 1`) — moved from `SELECT COUNT → INSERT` on `nutrition_insights` to the insert-first/count/delete-if-over pattern on `ai_generation_calls` (extended the `kind` CHECK to include `'overflow'`).

## Migration status

- Migration 022 applied on dev via Supabase MCP.

## Test plan

- [x] Build + 317 tests pass
- [x] Reviewed by quality-engineer (APPROVE; 2 NITs addressed: trigger sentinel constant + service_role cap comment)
- [ ] Manual: create 3 programs, attempt 4th via API → confirm 429 with the user-friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)