### PR TITLE
fix(ci): unblock CI — re-order useDailyNutrition imports

### DIFF
--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -4,8 +4,6 @@ import { useAuth } from '../contexts/AuthContext.tsx';
 import i18n from '../i18n/index.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
-
-const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 import type {
   DailyNutritionSummary,
   DailyNutritionTotals,
@@ -14,6 +12,8 @@ import type {
   MealType,
 } from '../types/nutrition.ts';
 import { todayYYYYMMDD } from '../utils/nutritionDate.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
 const EMPTY_TOTALS: DailyNutritionTotals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 };
 


### PR DESCRIPTION
## Summary

PR-A10 introduced an `i18n` import + `tHookError` helper between import groups in `useDailyNutrition.ts`, breaking Biome's `assist/source/organizeImports` rule. CI has been red on the last 4 merges (#129/#130/#131/#132) — I missed checking the run after each merge. Moving the helper after all imports fixes it.

## Test plan

- [x] `npm run lint` passes (0 errors, 11 pre-existing warnings)
- [x] `npm run build` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)