### PR TITLE
perf(query): tune staleTime for immutable data

### DIFF
--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -94,6 +94,10 @@ export function usePrograms() {
       return (data as Program[]) ?? [];
     },
     enabled: !authLoading && !!supabase,
+    // Fixed programs are seed data, only modified through migrations.
+    // The user can never invalidate this cache by interacting with the
+    // app — Infinity is the right answer.
+    staleTime: Infinity,
   });
 
   return { programs: query.data ?? [], loading: query.isPending };

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -51,7 +51,11 @@ export function useSession(dateKey: string | null) {
     queryKey: ['daily-session', dateKey, locale],
     queryFn: () => fetchDailySession(dateKey!, locale),
     enabled: !!dateKey && !!supabase,
-    staleTime: 5 * 60 * 1000, // 5 min — content changes rarely
+    // Daily sessions are generated server-side ahead of time and never
+    // mutated for a given (date_key, locale). 24h is therefore a safe
+    // upper bound — the cache key already changes when dateKey or locale
+    // does, so a stale entry is impossible in normal use.
+    staleTime: 24 * 60 * 60 * 1000,
   });
 
   return {


### PR DESCRIPTION
## Summary
Two cache lifetime corrections in TanStack Query hooks:

- **`useSession`** : `staleTime` 5min → 24h. `daily_sessions` rows are generated server-side ahead of the day and never mutated; the cache key already isolates by `(dateKey, locale)`, so a stale read is impossible in normal flow.
- **`usePrograms('fixed')`** : added `staleTime: Infinity`. Seed programs only change through migrations.

Reduces refetch traffic on tab focus and route change without changing user-visible behavior.

## Test plan
- [ ] Daily session still shows correct content after 6h+ idle
- [ ] /programmes still lists the 3 fixed programs (no missing items)
- [ ] Build green — confirmed locally
- [ ] Tests pass (317/317)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)