### PR TITLE
perf(query): targeted SELECT for programs list views

### DIFF
--- a/src/hooks/useProgram.ts
+++ b/src/hooks/useProgram.ts
@@ -5,6 +5,13 @@ import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program, ProgramSession, SessionCompletion } from '../types/completion.ts';
 import type { Session } from '../types/session.ts';
 
+// Columns needed by ProgramCard / ProgramList. JSONB-heavy columns
+// (progression, consignes_semaine, onboarding_data) and note_coach
+// are intentionally excluded from list views — they're only consumed
+// by ProgramPage which uses the full select('*') below.
+const PROGRAM_LIST_COLS =
+  'id, slug, title, description, goals, duration_weeks, frequency_per_week, fitness_level, is_fixed, locale';
+
 export interface ProgramWithSessions extends Program {
   sessions: ProgramSession[];
   completedSessionIds: Set<string>;
@@ -84,7 +91,7 @@ export function usePrograms() {
     queryKey: ['programs', 'fixed'],
     queryFn: async () => {
       const { data, error, sessionExpired } = await supabaseQuery(() =>
-        supabase!.from('programs').select('*').eq('is_fixed', true).order('created_at'),
+        supabase!.from('programs').select(PROGRAM_LIST_COLS).eq('is_fixed', true).order('created_at'),
       );
       if (sessionExpired) {
         notifySessionExpired();

--- a/src/hooks/useUserPrograms.ts
+++ b/src/hooks/useUserPrograms.ts
@@ -5,6 +5,12 @@ import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Program } from '../types/completion.ts';
 
+// Same column subset as usePrograms — avoids fetching the JSONB blobs
+// (progression / consignes_semaine / onboarding_data) on the listing
+// view. ProgramPage refetches the full row by slug when needed.
+const PROGRAM_LIST_COLS =
+  'id, slug, title, description, goals, duration_weeks, frequency_per_week, fitness_level, is_fixed, locale, created_at';
+
 export function useUserPrograms() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -16,7 +22,7 @@ export function useUserPrograms() {
       const { data, sessionExpired } = await supabaseQuery(() =>
         supabase!
           .from('programs')
-          .select('*')
+          .select(PROGRAM_LIST_COLS)
           .eq('user_id', userId!)
           .eq('is_fixed', false)
           .order('created_at', { ascending: false }),


### PR DESCRIPTION
## Summary
Replace `.select('*')` with an explicit column list in `usePrograms` (fixed) and `useUserPrograms`. The list views (`ProgramCard` / `ProgramList`) only need a basic subset, but the `programs` row also carries three JSONB blobs (`progression`, `consignes_semaine`, `onboarding_data`) and a potentially-long `note_coach` used exclusively by `ProgramPage` for a single program detail.

Columns kept: `id, slug, title, description, goals, duration_weeks, frequency_per_week, fitness_level, is_fixed, locale` (+ `created_at` for `useUserPrograms` ordering).

`useProgram(slug)` detail hook keeps `select('*')` because it consumes the JSONBs.

## Test plan
- [x] Visual: `/programmes` still renders all seed + user programs (verified locally)
- [x] Build green
- [x] Tests pass (317/317)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)