### PR TITLE
perf(query): drop session_data JOIN from useHistory

### DIFF
--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -122,21 +122,19 @@ function getISOWeekNumber(date: Date): number {
   return Math.round(((d.getTime() - yearStart.getTime()) / 86400000 - 3 + ((yearStart.getDay() + 6) % 7)) / 7) + 1;
 }
 
-interface SessionData {
-  title?: string;
-  description?: string;
-  focus?: string[];
-  blocks?: { type: string }[];
-}
-
 export function useHistory(userId: string | undefined): HistoryStats {
   const query = useQuery<CompletionWithTitle[]>({
     queryKey: ['history', userId ?? null],
     queryFn: async () => {
+      // No JSONB join here. session_completions.metadata carries the
+      // pre-extracted title / description / focus / block_types written
+      // by useSaveCompletion at completion time. Rows from the pre-2.1
+      // window may have a partial metadata object — fields fall back to
+      // null and the UI degrades gracefully (title shows "—").
       const { data, sessionExpired } = await supabaseQuery(() =>
         supabase!
           .from('session_completions')
-          .select('*, program_sessions(session_data), custom_sessions(session_data)')
+          .select('*')
           .eq('user_id', userId!)
           .order('completed_at', { ascending: false })
           .limit(200),
@@ -145,22 +143,16 @@ export function useHistory(userId: string | undefined): HistoryStats {
         notifySessionExpired();
         return [];
       }
-      const rows = (data ?? []) as unknown as (SessionCompletion & {
-        program_sessions: { session_data?: SessionData } | null;
-        custom_sessions: { session_data?: SessionData } | null;
-      })[];
+      const rows = (data ?? []) as SessionCompletion[];
 
       return rows.map((row) => {
         const meta = row.metadata as Record<string, unknown>;
-        const sd = row.program_sessions?.session_data ?? row.custom_sessions?.session_data;
         return {
           ...row,
-          session_title: (meta?.session_title as string | undefined) ?? sd?.title ?? null,
-          session_description: (meta?.session_description as string | undefined) ?? sd?.description ?? null,
-          session_focus: (meta?.session_focus as string[] | undefined) ?? sd?.focus ?? [],
-          block_types: (meta?.block_types as string[] | undefined) ?? [
-            ...new Set((sd?.blocks ?? []).map((b) => b.type).filter((t) => t !== 'warmup' && t !== 'cooldown')),
-          ],
+          session_title: (meta?.session_title as string | undefined) ?? null,
+          session_description: (meta?.session_description as string | undefined) ?? null,
+          session_focus: (meta?.session_focus as string[] | undefined) ?? [],
+          block_types: (meta?.block_types as string[] | undefined) ?? [],
         };
       });
     },


### PR DESCRIPTION
## Summary
useHistory was joining `program_sessions(session_data)` and `custom_sessions(session_data)` for every completion row to extract title/description/focus/block_types. Each \`session_data\` is the full Session JSONB (warmup/main/cooldown blocks with all exercises) — at limit 200 rows the join inflated the wire payload by megabytes.

This PR reads those fields exclusively from `session_completions.metadata`, which `useSaveCompletion` has been populating since PR 2.1. Rows from before that window with partial metadata fall back to null (UI shows "—" for the title) — acceptable degradation given the small historical window.

## Test plan
- [x] `/suivi` (Stats page) still renders the monthly calendar and weekly chart
- [x] No console errors
- [x] Build green
- [x] Tests pass (317/317)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)