### PR TITLE
perf(ai): enable Anthropic prompt caching on system prompts

### DIFF
--- a/supabase/functions/estimate-nutrition/index.ts
+++ b/supabase/functions/estimate-nutrition/index.ts
@@ -73,7 +73,11 @@ async function callAnthropic(
       body: JSON.stringify({
         model: MODEL,
         max_tokens: maxTokens,
-        system,
+        // System prompt is stable; caching it cuts input cost ~90% and shaves
+        // latency on warm cache hits within the 5-minute TTL.
+        system: [
+          { type: "text", text: system, cache_control: { type: "ephemeral" } },
+        ],
         messages,
       }),
       signal: AbortSignal.timeout(20_000),

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -297,7 +297,12 @@ Deno.serve(async (req: Request) => {
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
-        system: systemPrompt,
+        // System prompt is stable across all calls (only varies by locale).
+        // Caching cuts input cost ~90% and shaves latency on the second-and-after
+        // call within the 5-minute TTL.
+        system: [
+          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
+        ],
         messages,
       }),
       signal: AbortSignal.timeout(timeoutMs),

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -250,7 +250,11 @@ Deno.serve(async (req: Request) => {
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
-        system: systemPrompt,
+        // System prompt is stable across all calls (only varies by locale).
+        // Marking it as cacheable cuts input cost ~90% and shaves latency.
+        system: [
+          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
+        ],
         messages: [
           { role: "user", content: userPrompt },
           { role: "assistant", content: ASSISTANT_PREFILL },


### PR DESCRIPTION
## Summary
Wrap the `system` prompt of the three Anthropic-calling edge functions in a content block with `cache_control: { type: \"ephemeral\" }`. The system prompts in each function only vary by locale (FR / EN), so the cache hit rate is high and Anthropic's 5-minute TTL covers typical request bursts.

Functions touched:
- `generate-session` (Haiku 4.5)
- `generate-program` (Sonnet 4.6)
- `estimate-nutrition` (Haiku 4.5)

Cuts the input-token cost of the cached portion by ~90% on cache hits ($0.30 read vs $3.00 fresh per MTok on Sonnet) and shaves latency.

⚠️ **Deployment required** for the change to take effect:
\`\`\`
supabase functions deploy generate-session
supabase functions deploy generate-program
supabase functions deploy estimate-nutrition
\`\`\`
(part of the production deployment checklist already tracked.)

## Test plan
- [x] Tests pass (317/317)
- [x] CI green
- [ ] Post-deploy: confirm a second call within 5 min reports `cache_read_input_tokens > 0` in Anthropic response

🤖 Generated with [Claude Code](https://claude.com/claude-code)