### PR TITLE
perf(sw): tighten exercise-video cache limits

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,13 @@ export default defineConfig(({ mode }) => ({
             handler: 'CacheFirst',
             options: {
               cacheName: 'videos-cache',
-              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 90 },
+              // Tightened from (30 entries / 90 days) to (15 / 7) — exercise
+              // videos are 1-5 MB each, and iOS Safari aggressively purges
+              // sites that exceed a few hundred MB of cached storage. The
+              // 7-day window is a deliberate trade-off: missing the cache on
+              // a less-frequent exercise costs one re-download, but bloating
+              // the cache costs everyone.
+              expiration: { maxEntries: 15, maxAgeSeconds: 60 * 60 * 24 * 7 },
               cacheableResponse: { statuses: [200] },
             },
           },


### PR DESCRIPTION
## Summary
The `videos-cache` route was set to `maxEntries: 30 / maxAgeSeconds: 90d`. With exercise videos at 1-5 MB each, that puts the on-device cache at potentially ~150 MB — a size at which iOS Safari aggressively reclaims storage from the site, evicting unrelated PWA caches in the process.

Reduced to **15 entries / 7 days**. The daily-session flow needs only ~5-10 distinct videos per session and runs daily, so the working set fits comfortably. Less-frequent exercises pay one re-download — fair trade.

## Test plan
- [x] Build green — confirmed
- [ ] Cold-load `/seance/play`, verify videos cache (DevTools Application > Cache Storage > videos-cache)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)