### PR TITLE
perf(sentry): lazy-load @sentry/react past first paint

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
-import * as Sentry from '@sentry/react';
 import { Component, type ReactNode } from 'react';
 import { type WithTranslation, withTranslation } from 'react-i18next';
+import { captureException } from '../lib/sentryReport.ts';
 
 interface Props extends WithTranslation {
   children: ReactNode;
@@ -21,7 +21,7 @@ class ErrorBoundaryBase extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    Sentry.captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
+    captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
   }
 
   render() {

--- a/src/components/PlayerErrorBoundary.tsx
+++ b/src/components/PlayerErrorBoundary.tsx
@@ -1,8 +1,8 @@
-import * as Sentry from '@sentry/react';
 import type { ReactNode } from 'react';
 import { Component } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
+import { captureException } from '../lib/sentryReport.ts';
 
 interface Props {
   children: ReactNode;
@@ -40,7 +40,7 @@ export class PlayerErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    Sentry.captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
+    captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
   }
 
   render() {

--- a/src/lib/sentryReport.ts
+++ b/src/lib/sentryReport.ts
@@ -1,0 +1,124 @@
+// Lazy-loaded Sentry reporter. The @sentry/react bundle is ~88 KB gzipped;
+// loading it eagerly puts that on the critical-path JS budget for every
+// first paint. This wrapper defers the import until either:
+//   - an error is reported (captureException), or
+//   - the deferred init runs after the first paint (initSentryAsync).
+// Errors raised before the bundle finishes loading queue up and flush
+// once Sentry is ready.
+
+// Mirror the second arg shape of Sentry.captureException without dragging
+// the full @sentry/* types into the synchronously-loaded bundle. The
+// runtime accepts ScopeContext / EventHint / scope-callback shapes; we
+// only ever pass a `{ contexts: { ... } }` ScopeContext from the error
+// boundaries, so this minimal shape is all we need.
+type CaptureContext = {
+  contexts?: Record<string, Record<string, unknown>>;
+};
+
+interface QueuedReport {
+  error: unknown;
+  context?: CaptureContext;
+}
+
+let sentryModule: typeof import('@sentry/react') | null = null;
+let sentryLoading: Promise<typeof import('@sentry/react')> | null = null;
+const queue: QueuedReport[] = [];
+
+async function loadSentry(): Promise<typeof import('@sentry/react')> {
+  if (sentryModule) return sentryModule;
+  if (!sentryLoading) sentryLoading = import('@sentry/react');
+  sentryModule = await sentryLoading;
+  return sentryModule;
+}
+
+export function captureException(error: unknown, context?: CaptureContext): void {
+  if (!import.meta.env.PROD) return;
+  if (sentryModule) {
+    sentryModule.captureException(error, context as Parameters<typeof sentryModule.captureException>[1]);
+    return;
+  }
+  // Hold the error until the bundle resolves; the load was likely already
+  // kicked off by initSentryAsync, so this just hops to the end of the
+  // microtask queue when it lands.
+  queue.push({ error, context });
+  loadSentry()
+    .then((Sentry) => {
+      while (queue.length) {
+        const { error: err, context: ctx } = queue.shift()!;
+        Sentry.captureException(err, ctx as Parameters<typeof Sentry.captureException>[1]);
+      }
+    })
+    .catch(() => {
+      // Sentry bundle failed to load — drop the queued errors silently.
+      // Reporting the loader failure to Sentry would obviously not help.
+      queue.length = 0;
+    });
+}
+
+// URL identifier scrubbing — kept here so initSentryAsync can pass it to
+// Sentry.init beforeBreadcrumb / beforeSend / beforeSendTransaction. Year
+// prefix in the date regex guards against matching arbitrary 8-digit
+// numeric IDs in unrelated paths.
+function scrubPathIds(value: string): string {
+  return value
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, ':uuid')
+    .replace(/\/(?:19|20)\d{6}(?=\/|$|\?|#)/g, '/:date');
+}
+
+export function initSentryAsync(): void {
+  if (!import.meta.env.PROD) return;
+  // Defer the import past the first paint. requestIdleCallback isn't
+  // implemented on Safari < 16.4; fall back to a small setTimeout — both
+  // schedules run after the LCP frame.
+  const start = () => {
+    loadSentry().then((Sentry) => {
+      Sentry.init({
+        dsn: import.meta.env.VITE_SENTRY_DSN,
+        environment: import.meta.env.MODE,
+        enabled: import.meta.env.PROD,
+        integrations: [
+          Sentry.browserTracingIntegration(),
+          Sentry.replayIntegration({
+            // RGPD art. 9: nutrition logs, injury declarations, calorie
+            // targets, AI coach notes and email inputs all qualify as
+            // health/personal data. Mask both inputs and rendered text,
+            // block media, and keep the network detail allowlist empty.
+            maskAllInputs: true,
+            maskAllText: true,
+            blockAllMedia: true,
+            networkDetailAllowUrls: [],
+          }),
+        ],
+        tracesSampleRate: 0.2,
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 1.0,
+        beforeBreadcrumb(breadcrumb) {
+          if (breadcrumb.category === 'fetch' || breadcrumb.category === 'xhr') {
+            if (typeof breadcrumb.data?.url === 'string') {
+              breadcrumb.data.url = scrubPathIds(breadcrumb.data.url);
+            }
+          }
+          return breadcrumb;
+        },
+        beforeSend(event) {
+          if (event.request?.url) event.request.url = scrubPathIds(event.request.url);
+          return event;
+        },
+        beforeSendTransaction(event) {
+          if (event.transaction) event.transaction = scrubPathIds(event.transaction);
+          if (event.spans) {
+            for (const span of event.spans) {
+              if (span.description) span.description = scrubPathIds(span.description);
+            }
+          }
+          return event;
+        },
+      });
+    });
+  };
+  if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+    window.requestIdleCallback(start, { timeout: 2000 });
+  } else {
+    setTimeout(start, 0);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { Analytics } from '@vercel/analytics/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -6,66 +5,7 @@ import './styles/fonts.css';
 import './index.css';
 import './i18n';
 import App from './App.tsx';
-
-// Strip identifiers (UUIDs, ISO date keys YYYYMMDD with year 19xx-20xx) from
-// URL paths so user/session IDs don't end up in Sentry transaction names,
-// fetch breadcrumbs, or span descriptions. Year prefix guards against matching
-// arbitrary 8-digit numeric IDs in unrelated paths.
-function scrubPathIds(value: string): string {
-  return value
-    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, ':uuid')
-    .replace(/\/(?:19|20)\d{6}(?=\/|$|\?|#)/g, '/:date');
-}
-
-Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
-  environment: import.meta.env.MODE,
-  enabled: import.meta.env.PROD,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration({
-      // RGPD art. 9: nutrition logs, injury declarations, calorie targets,
-      // AI coach notes and email inputs all qualify as health/personal data.
-      // Mask both form inputs AND rendered text nodes, block media, and keep
-      // the network detail allowlist empty so request/response bodies aren't
-      // captured in error replays.
-      maskAllInputs: true,
-      maskAllText: true,
-      blockAllMedia: true,
-      networkDetailAllowUrls: [],
-    }),
-  ],
-  tracesSampleRate: 0.2,
-  replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 1.0,
-  beforeBreadcrumb(breadcrumb) {
-    // Default fetch/xhr breadcrumbs include full URLs with Supabase UUID
-    // query params. Scrub before they reach the wire.
-    if (breadcrumb.category === 'fetch' || breadcrumb.category === 'xhr') {
-      if (typeof breadcrumb.data?.url === 'string') {
-        breadcrumb.data.url = scrubPathIds(breadcrumb.data.url);
-      }
-    }
-    return breadcrumb;
-  },
-  beforeSend(event) {
-    // Error events carry window.location.href in event.request.url via the
-    // HttpContext integration; routes like /seance/custom/<uuid> would leak
-    // the session id otherwise.
-    if (event.request?.url) event.request.url = scrubPathIds(event.request.url);
-    return event;
-  },
-  beforeSendTransaction(event) {
-    if (event.transaction) event.transaction = scrubPathIds(event.transaction);
-    // Each browser-tracing span carries the full fetch URL in `description`.
-    if (event.spans) {
-      for (const span of event.spans) {
-        if (span.description) span.description = scrubPathIds(span.description);
-      }
-    }
-    return event;
-  },
-});
+import { initSentryAsync } from './lib/sentryReport.ts';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -73,3 +13,8 @@ createRoot(document.getElementById('root')!).render(
     <Analytics />
   </StrictMode>,
 );
+
+// Defer Sentry init past the first paint — see src/lib/sentryReport.ts.
+// Errors thrown during the React boot before init runs are queued via
+// the captureException wrapper used by both ErrorBoundary classes.
+initSentryAsync();


### PR DESCRIPTION
## Summary
Move Sentry off the critical-path JS budget. The ~88 KB-gzipped `@sentry/react` chunk was modulepreloaded at boot because `main.tsx` imported it synchronously and so did both ErrorBoundary classes.

After this PR:
- A new `src/lib/sentryReport.ts` owns a `captureException` wrapper that triggers a **dynamic import** on first use and queues errors thrown before the bundle resolves.
- `ErrorBoundary` and `PlayerErrorBoundary` call `captureException` through that wrapper instead of importing `@sentry/react` directly.
- `main.tsx` no longer imports Sentry; it calls `initSentryAsync()` *after* `createRoot().render()`. The `Sentry.init()` call itself runs inside `requestIdleCallback` (with a `setTimeout` fallback for older Safari).

**Result**: `dist/index.html` no longer `modulepreload`s the sentry chunk. The chunk now loads lazily once the user has finished the first paint or once an error boundary triggers.

Privacy / RGPD config (maskAllInputs, maskAllText, blockAllMedia, networkDetailAllowUrls, scrubPathIds for transactions) is **preserved verbatim** — just moved into `sentryReport.ts`.

## Test plan
- [x] Build green; `dist/index.html` doesn't modulepreload sentry
- [x] Tests pass (317/317)
- [ ] Smoke: throw inside a route → ErrorBoundary triggers → confirm Sentry receives the event after init has run

🤖 Generated with [Claude Code](https://claude.com/claude-code)