### PR TITLE
fix(lint): silence the 11 useExhaustiveDependencies warnings

### DIFF
--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -70,6 +70,7 @@ export function CreateProgramPage() {
     sessionStorage.removeItem(STORAGE_KEYS.CREATE_PROGRAM_DRAFT);
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draft.step is the intentional trigger; the body doesn't read it.
   useEffect(() => {
     stepHeadingRef.current?.focus();
   }, [draft.step]);

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -54,7 +54,9 @@ export function ProgramPage() {
 
   // Initialize collapsed weeks: future weeks collapsed by default for custom programs.
   // All used values (isCustom, byWeek, currentWeek) are derived deterministically from
-  // program — so re-running only when the program identity changes is correct.
+  // program — re-running only when program identity changes is correct (byWeek is
+  // rebuilt fresh each render so depending on it would re-fire this effect every render).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: program?.id is the intentional narrower trigger; see comment above.
   useEffect(() => {
     if (!program || !isCustom) return;
     const weeks = [...byWeek.keys()];
@@ -63,7 +65,7 @@ export function ProgramPage() {
       if (w > currentWeek) collapsed.add(w);
     }
     setCollapsedWeeks(collapsed);
-  }, [program?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [program?.id]);
 
   // Focus trap for delete modal
   useEffect(() => {

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -14,6 +14,7 @@ export function PublicLayout() {
   // Scroll top on route change. Data freshness is no longer tied to
   // navigation — every hook is on TanStack Query and relies on its
   // `staleTime` + mutation-side invalidation contract.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intentional trigger; the body doesn't read it.
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -17,6 +17,9 @@ export function useGenerateProgram() {
 
   const inflightRef = useRef(false);
 
+  // i18n.t is a fresh function reference each render; depending on i18n.language
+  // is the project-wide pattern for stable callbacks resolving localised strings.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language is the stable trigger, not i18n.t.
   const generate = useCallback(
     async (input: ProgramOnboardingInput): Promise<GenerateProgramResponse | null> => {
       if (inflightRef.current) return null;

--- a/src/hooks/useGenerateSession.ts
+++ b/src/hooks/useGenerateSession.ts
@@ -17,6 +17,8 @@ export function useGenerateSession() {
 
   const inflightRef = useRef(false);
 
+  // See useGenerateProgram — i18n.t changes identity each render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: i18n.language is the stable trigger, not i18n.t.
   const generate = useCallback(
     async (input: CustomSessionInput): Promise<GenerateSessionResponse | null> => {
       if (inflightRef.current) return null;

--- a/src/hooks/useWorkout.ts
+++ b/src/hooks/useWorkout.ts
@@ -100,6 +100,8 @@ export function useWorkout(steps: AtomicStep[]) {
   // Countdown beeps for last 3 seconds
   // NB: 'transition' status is NOT handled here — branded countdown audio
   // is played by the dedicated effect above for first-block transitions.
+  // audio.beepCountdown and audio.speakCountdown are stable useCallback refs;
+  // listing them in deps is fine and shuts the linter up without changing behaviour.
   useEffect(() => {
     if (timer.remaining > 0 && timer.remaining <= 3 && timer.isRunning) {
       if (status === 'countdown') {
@@ -108,9 +110,7 @@ export function useWorkout(steps: AtomicStep[]) {
         audio.beepCountdown();
       }
     }
-    // audio.beepCountdown and audio.speakCountdown are stable useCallback refs.
-    // Only timer.remaining changes should trigger beep evaluation.
-  }, [timer.remaining, audio.beepCountdown, audio.speakCountdown, status, timer.isRunning]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [timer.remaining, audio.beepCountdown, audio.speakCountdown, status, timer.isRunning]);
 
   const start = useCallback(() => {
     if (steps.length === 0) return;
@@ -125,7 +125,7 @@ export function useWorkout(steps: AtomicStep[]) {
     } else {
       setStatus('active');
     }
-  }, [steps]);
+  }, [steps, audio.unlock, audio.preloadBrandedSounds]);
 
   const pause = useCallback(() => {
     if (status === 'paused') return;


### PR DESCRIPTION
## Summary
Address all 11 `useExhaustiveDependencies` warnings in one pass. Six call sites tripped the rule for three distinct reasons:

1. **Trigger-only deps** (`CreateProgramPage.tsx`, `PublicLayout.tsx`): `useEffect` uses a value purely as a re-run trigger and never reads it inside the body. The dep is intentional → `biome-ignore` with that justification.

2. **Intentionally narrower dep** (`ProgramPage.tsx`): the existing `[program?.id]` is correct; `isCustom / byWeek / currentWeek` all derive from `program`, and `byWeek` is rebuilt every render so listing it would re-fire the effect each render. Replaced the legacy `eslint-disable` with a `biome-ignore` that explains the trade-off.

3. **`i18n.t` re-memo churn** (`useGenerateProgram.ts`, `useGenerateSession.ts`): adding `i18n.t` to the deps re-memoizes the callback on every render. Project-wide pattern is to depend on `i18n.language` instead. `biome-ignore` mirrors that decision.

4. **Real bug fix** (`useWorkout.ts`): `start()` was missing `audio.unlock` and `audio.preloadBrandedSounds` from its deps. Added them — they're stable useCallback refs so this doesn't cause re-memo churn. Also removed the stale eslint-disable on the countdown effect (same stable refs, listing them is fine).

\`npx biome check src/\` now reports **zero warnings**.

## Test plan
- [x] Build green; tests pass (317/317)
- [x] `npx biome check src/` — 0 warnings
- [ ] Smoke: start/pause/resume the workout — beep + branded sounds still trigger correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)