### PR TITLE
feat(create-program): richer loading checklist instead of single phase

### DIFF
--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -15,8 +15,11 @@ import { StepObjective } from './create-program/StepObjective.tsx';
 import { StepPreferences } from './create-program/StepPreferences.tsx';
 import { StepProfile } from './create-program/StepProfile.tsx';
 
-/** Durations in ms for each loading phase — must match LOADING_PHASES_COUNT */
-const LOADING_PHASE_DURATIONS = [5000, 20000, 10000, 10000] as const;
+/** Durations in ms for each loading phase — must match LOADING_PHASES_COUNT.
+ * Sums to ~45s, which matches the typical generate-program latency. If the
+ * call runs longer, GeneratingOverlay clamps to the last phase rather than
+ * cycling, so the checklist never resets back to "Analyse..." mid-wait. */
+const LOADING_PHASE_DURATIONS = [3000, 5000, 7000, 8000, 8000, 6000, 5000, 3000] as const;
 
 const MAX_ACTIVE = 3;
 

--- a/src/components/create-program/GeneratingOverlay.tsx
+++ b/src/components/create-program/GeneratingOverlay.tsx
@@ -1,3 +1,4 @@
+import { Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { LOADING_PHASES_COUNT } from './formOptions.ts';
 
@@ -14,9 +15,44 @@ export function GeneratingOverlay({ phase }: GeneratingOverlayProps) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-surface/95 backdrop-blur-sm"
       aria-live="polite"
     >
-      <div className="text-center space-y-6 px-6 max-w-sm">
+      <div className="text-center space-y-6 px-6 max-w-md w-full">
         <div className="w-12 h-12 border-3 border-divider-strong border-t-brand rounded-full animate-spin mx-auto" />
-        <p className="text-lg font-semibold text-heading">{t(`loading_phases.${phase}`)}</p>
+
+        <p className="text-lg font-semibold text-heading">{t('generating.title')}</p>
+
+        <ul className="space-y-2 text-left">
+          {Array.from({ length: LOADING_PHASES_COUNT }, (_, i) => {
+            const isDone = i < phase;
+            const isActive = i === phase;
+            return (
+              <li
+                key={i}
+                className={`flex items-start gap-3 text-sm transition-opacity duration-300 ${
+                  isDone ? 'text-body' : isActive ? 'text-heading font-medium' : 'text-faint opacity-60'
+                }`}
+              >
+                <span
+                  className={`mt-0.5 w-5 h-5 rounded-full flex items-center justify-center shrink-0 transition-colors ${
+                    isDone
+                      ? 'bg-emerald-500/20 text-emerald-400'
+                      : isActive
+                        ? 'bg-brand/20 text-brand'
+                        : 'bg-white/5 text-faint'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {isDone ? (
+                    <Check className="w-3 h-3" />
+                  ) : isActive ? (
+                    <span className="w-1.5 h-1.5 rounded-full bg-brand animate-pulse" />
+                  ) : null}
+                </span>
+                <span>{t(`loading_phases.${i}`)}</span>
+              </li>
+            );
+          })}
+        </ul>
+
         <div className="h-2 rounded-full bg-white/10 overflow-hidden">
           <div
             className="h-full rounded-full bg-gradient-to-r from-brand to-brand-secondary transition-all duration-1000"

--- a/src/components/create-program/formOptions.ts
+++ b/src/components/create-program/formOptions.ts
@@ -57,4 +57,4 @@ export const DUREE_OPTIONS: { value: 4 | 8 | 12; recommended?: boolean }[] = [
   { value: 12 },
 ];
 
-export const LOADING_PHASES_COUNT = 4;
+export const LOADING_PHASES_COUNT = 8;

--- a/src/i18n/locales/en/programs.json
+++ b/src/i18n/locales/en/programs.json
@@ -125,6 +125,7 @@
     "generate": "Generate my program"
   },
   "generating": {
+    "title": "Building your program",
     "estimate": "Estimated: 30-60 seconds"
   },
   "fitness_level": {
@@ -187,9 +188,13 @@
     "12": "12 weeks"
   },
   "loading_phases": {
-    "0": "Analyzing your profile...",
-    "1": "Designing sessions...",
-    "2": "Planning the calendar...",
-    "3": "Final checks..."
+    "0": "Analyzing your profile",
+    "1": "Mapping constraints",
+    "2": "Choosing your progression",
+    "3": "Designing sessions",
+    "4": "Building the calendar",
+    "5": "Balancing the load",
+    "6": "Personalizing coaching",
+    "7": "Final checks"
   }
 }

--- a/src/i18n/locales/fr/programs.json
+++ b/src/i18n/locales/fr/programs.json
@@ -125,6 +125,7 @@
     "generate": "Générer mon programme"
   },
   "generating": {
+    "title": "Création de ton programme",
     "estimate": "Estimation : 30-60 secondes"
   },
   "fitness_level": {
@@ -187,9 +188,13 @@
     "12": "12 semaines"
   },
   "loading_phases": {
-    "0": "Analyse de ton profil...",
-    "1": "Conception des séances...",
-    "2": "Planification du calendrier...",
-    "3": "Dernières vérifications..."
+    "0": "Analyse de ton profil",
+    "1": "Identification des contraintes",
+    "2": "Choix de la progression",
+    "3": "Conception des séances",
+    "4": "Construction du calendrier",
+    "5": "Équilibrage des charges",
+    "6": "Personnalisation du coaching",
+    "7": "Vérifications finales"
   }
 }


### PR DESCRIPTION
## Summary
Replace the single-phase loading text with a **checklist of 8 stages** that fills in as the generation runs. This is the "option 3" agreed on for PR-B9: real Anthropic streaming would only buy a perception gain (the JSON output can't be rendered partially), so we get most of that gain by making the wait feel structured instead of touching the edge function.

## Changes
- **`formOptions.ts`** — `LOADING_PHASES_COUNT` 4 → 8.
- **`CreateProgramPage.tsx`** — redistribute `LOADING_PHASE_DURATIONS` across the 8 stages, summing to ~45s (matches typical `generate-program` latency). The interval clamps to the last phase rather than cycling, so a longer-than-expected call holds at "Vérifications finales" instead of resetting back to phase 0.
- **`GeneratingOverlay.tsx`** — render every phase as a list item with a state-aware icon: ✓ done · pulse current · dot pending. User sees what's been completed at a glance.
- **`programs.json` (fr/en)** — rewritten phase labels (Analyse / Contraintes / Progression / Séances / Calendrier / Charges / Coaching / Vérif) and added a `generating.title` key.

## Test plan
- [x] Build green; tests pass (317/317); biome 0 warnings
- [ ] Manual: trigger a real `generate-program` call → checklist progresses through the 8 stages; clamps if the call exceeds 45s; final stage doesn't reset on longer calls
- [ ] Visual on both FR and EN locales
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)