### PR TITLE
fix(ai): apply assistant prefill to overflow estimate-nutrition call

### DIFF
--- a/supabase/functions/estimate-nutrition/index.ts
+++ b/supabase/functions/estimate-nutrition/index.ts
@@ -316,7 +316,16 @@ Deno.serve(async (req: Request) => {
   };
 
   const prompt = buildOverflowUserPrompt(ctx);
-  const aiResult = await callAnthropic(anthropicApiKey, OVERFLOW_SYSTEM_PROMPT, prompt, MAX_TOKENS_OVERFLOW);
+  // Assistant prefill mirrors the text-mode prompt-injection defense: the
+  // expected output is { summary: string, suggestions: string[] } so we
+  // anchor the response on the summary key.
+  const aiResult = await callAnthropic(
+    anthropicApiKey,
+    OVERFLOW_SYSTEM_PROMPT,
+    prompt,
+    MAX_TOKENS_OVERFLOW,
+    '{"summary":"',
+  );
   if (aiResult instanceof Response) {
     const text = await aiResult.text();
     return jsonResponse(req, JSON.parse(text), aiResult.status);


### PR DESCRIPTION
## Summary
Pre-merge review caught that `estimate-nutrition`'s overflow path called `callAnthropic` with no `assistantPrefill`, while the text path correctly passed `'{"name":"'`. Without the prefill, prompt-injected meal logs could nudge the model away from the JSON schema before it lands on the `summary` key.

The expected overflow output shape is `{ summary: string, suggestions: string[] }`, so the prefill is `'{"summary":"'`. `callAnthropic` already concats the prefill back onto the response text and parses the combined string — no other code changes are needed.

## Test plan
- [x] Tests pass (vitest)
- [ ] CI green
- [ ] Post-deploy: trigger overflow insight, confirm well-formed JSON returned (no parse error in edge function logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)