### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@sentry/react": "^10.45.0",
         "@supabase/supabase-js": "^2.97.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump 1.0.0 → 1.1.1.

- 1.1 minor bump catches up: should have shipped with the nutrition feature.
- .1 patch covers PR #150 (mobile modal scroll, manual barcode UX, OFF error diagnostics, Sentry hardening).

## Test plan
- [x] \`npm install --package-lock-only\` re-synced
- [x] No code changes — version-only bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)