### PR TITLE
release: nutrition fixes — scan working everywhere, smart portion default, OFF text fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.99.0",
         "@tanstack/react-query-devtools": "^5.99.0",
         "@vercel/analytics": "^1.6.1",
+        "barcode-detector": "^3.1.2",
         "i18next": "^26.0.7",
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-resources-to-backend": "^1.2.1",
@@ -4429,6 +4430,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4847,6 +4854,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/barcode-detector": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.1.2.tgz",
+      "integrity": "sha512-Q5kjXpVH5I3ItykNzbWmfWnNryFN1ZTWp10k9/PKJuS0RnoKR7jTrHEJODR4fn04bRomq7TJwie/Dr9fj/GoGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.0.2"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -8435,6 +8451,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -9589,6 +9617,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.2.tgz",
+      "integrity": "sha512-2YMAriaYHX9wrBY2k7H0epSo+dyCaCZg/vOtt+nEDXM9ul480gkXz/9SkwpOeHcD2H5qqDG8lWDSBwpTcZpa6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.5.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@vercel/analytics": "^1.6.1",
+    "barcode-detector": "^3.1.2",
     "i18next": "^26.0.7",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-resources-to-backend": "^1.2.1",

--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -61,10 +61,16 @@ export function NutritionPage() {
   async function handleSearchSelect(food: FoodReference, quantityGrams: number, mealType: MealType): Promise<boolean> {
     const factor = quantityGrams / 100;
     const scaled = (per100: number | null) => (per100 != null ? Math.round(per100 * factor * 10) / 10 : null);
+    // OFF results from the search fallback share the same data source as a
+    // scanned barcode (the OFF database, indexed by EAN). The DB CHECK only
+    // allows ('manual','ciqual','barcode','ai_text','overflow_insight'), so
+    // we fold OFF text-search results into 'barcode' rather than introduce
+    // a new value via migration. reference_id is the barcode either way.
+    const isOff = food.source === 'off';
     const result = await addMeal({
       meal_type: mealType,
-      source: 'ciqual',
-      name: food.name_fr,
+      source: isOff ? 'barcode' : 'ciqual',
+      name: food.name_fr.slice(0, 200),
       calories: scaled(food.calories_100g) ?? 0,
       protein_g: scaled(food.protein_100g),
       carbs_g: scaled(food.carbs_100g),

--- a/src/components/nutrition/BarcodePane.tsx
+++ b/src/components/nutrition/BarcodePane.tsx
@@ -16,6 +16,19 @@ function scaleKcal(per100g: number | null, grams: number): number {
   return Math.round(((per100g * grams) / 100) * 10) / 10;
 }
 
+// Pick the most sensible default portion for a scanned product. We prefer
+// `serving_quantity` (one normal portion as declared by the producer), then
+// fall back to `product_quantity` only when the package is small enough to
+// plausibly be a single serving — a 1 kg pasta box must NOT pre-fill 1000g.
+// 250 g covers bars, single yogurts, snacks, and individual drinks.
+const SINGLE_SERVE_GRAMS_CAP = 250;
+
+function pickDefaultGrams(servingG: number | null, productG: number | null): number {
+  if (servingG && servingG > 0) return servingG;
+  if (productG && productG > 0 && productG <= SINGLE_SERVE_GRAMS_CAP) return productG;
+  return 100;
+}
+
 export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) {
   const { t } = useTranslation('nutrition');
   const { product, loading, error, fetchByBarcode, reset } = useOpenFoodFacts();
@@ -26,6 +39,14 @@ export function BarcodePane({ mealType, onSubmit, onCancel }: BarcodePaneProps) 
 
   // Cancel in-flight OFF fetch + clear state when the pane unmounts.
   useEffect(() => () => reset(), [reset]);
+
+  // When a product loads, seed the portion input from OFF's quantity hints.
+  // The user can still override; we just provide a smarter default than 100g.
+  useEffect(() => {
+    if (!product) return;
+    const grams = pickDefaultGrams(product.serving_quantity_g, product.product_quantity_g);
+    setPortionGrams(String(grams));
+  }, [product]);
 
   const handleDetected = useCallback(
     (barcode: string) => {

--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -7,21 +7,64 @@ interface BarcodeScannerProps {
   onClose: () => void;
 }
 
-type DetectorStatus = 'idle' | 'supported' | 'unsupported' | 'permission_denied' | 'starting' | 'scanning' | 'error';
+type DetectorStatus =
+  | 'idle'
+  | 'loading_decoder'
+  | 'starting'
+  | 'scanning'
+  | 'permission_denied'
+  | 'error';
+
+interface DetectorLike {
+  detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string }>>;
+}
+
+type DetectorCtor = new (options?: { formats?: string[] }) => DetectorLike;
 
 interface GlobalWithBarcodeDetector {
-  BarcodeDetector?: new (options?: {
-    formats?: string[];
-  }) => {
-    detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string }>>;
-  };
+  BarcodeDetector?: DetectorCtor;
 }
 
 const SUPPORTED_FORMATS = ['ean_13', 'ean_8', 'upc_a', 'upc_e'];
 
+// Native BarcodeDetector exists on Chrome desktop/Android and recent Safari
+// macOS, but not on iOS Safari, Chrome iOS (= WKWebView), or Firefox. The
+// barcode-detector ponyfill (powered by zxing-wasm) fills that gap with a
+// drop-in implementation of the same standard API. It's only loaded when the
+// native API is missing — on Chrome we keep the lighter native path.
+let polyfillCtor: DetectorCtor | null = null;
+let polyfillLoading: Promise<DetectorCtor> | null = null;
+
+async function loadPolyfillCtor(): Promise<DetectorCtor> {
+  if (polyfillCtor) return polyfillCtor;
+  if (!polyfillLoading) {
+    polyfillLoading = (async () => {
+      const [{ BarcodeDetector, prepareZXingModule }, wasmUrlMod] = await Promise.all([
+        import('barcode-detector/ponyfill'),
+        import('zxing-wasm/reader/zxing_reader.wasm?url'),
+      ]);
+      // Self-host the WASM via the Vite asset pipeline (same origin, hashed
+      // filename, cached forever). The default jsDelivr URL would require
+      // loosening connect-src in the CSP and introduces a third-party runtime
+      // dependency we don't want for an offline-capable PWA.
+      prepareZXingModule({
+        overrides: {
+          locateFile: (path: string, prefix: string) =>
+            path.endsWith('.wasm') ? wasmUrlMod.default : prefix + path,
+        },
+      });
+      return BarcodeDetector as unknown as DetectorCtor;
+    })();
+  }
+  polyfillCtor = await polyfillLoading;
+  return polyfillCtor;
+}
+
 /**
- * Camera-based barcode scanner using the native BarcodeDetector API.
- * Falls back to a manual input when the API is unavailable (iOS Safari).
+ * Camera-based barcode scanner using the standard BarcodeDetector API.
+ * Uses the native implementation when available (Chrome desktop/Android),
+ * and lazy-loads the barcode-detector ponyfill (zxing-wasm) elsewhere
+ * (iOS Safari, Chrome iOS, Firefox).
  *
  * The component releases the camera stream on unmount and when the user
  * closes the scanner. The video stream is NEVER recorded nor uploaded —
@@ -59,11 +102,24 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
       const releaseTracks = (s: MediaStream) => {
         for (const track of s.getTracks()) track.stop();
       };
-      const g = globalThis as unknown as GlobalWithBarcodeDetector;
-      if (!g.BarcodeDetector) {
-        if (isCurrent()) setStatus('unsupported');
-        return;
+
+      // Resolve detector (native sync, ponyfill async). Keep the user
+      // informed while the WASM bundle is loading on slower connections.
+      let DetectorCtor: DetectorCtor;
+      const nativeCtor = (globalThis as unknown as GlobalWithBarcodeDetector).BarcodeDetector;
+      if (nativeCtor) {
+        DetectorCtor = nativeCtor;
+      } else {
+        if (isCurrent()) setStatus('loading_decoder');
+        try {
+          DetectorCtor = await loadPolyfillCtor();
+        } catch {
+          if (isCurrent()) setStatus('error');
+          return;
+        }
+        if (!isCurrent()) return;
       }
+
       if (isCurrent()) setStatus('starting');
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
@@ -89,7 +145,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
         }
         setStatus('scanning');
 
-        const detector = new g.BarcodeDetector({ formats: SUPPORTED_FORMATS });
+        const detector = new DetectorCtor({ formats: SUPPORTED_FORMATS });
 
         const tick = async () => {
           if (!isCurrent() || !videoRef.current || !streamRef.current) return;
@@ -139,7 +195,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   // `autoFocus` prop only fires on mount, but `status` flips after the async
   // permission/feature-detection result, so we focus imperatively here.
   useEffect(() => {
-    if (status === 'unsupported' || status === 'permission_denied' || status === 'error') {
+    if (status === 'permission_denied' || status === 'error') {
       manualInputRef.current?.focus();
     }
   }, [status]);
@@ -156,6 +212,10 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
     onDetected(trimmed);
   }
 
+  // Pre-decoder loading + camera startup share the same skeleton viewport so
+  // the layout doesn't reflow when the polyfill resolves. The video element
+  // mounts only when we have a stream, so a separate placeholder covers the
+  // earlier states.
   return (
     <div className="space-y-4">
       <header className="flex items-center justify-between">
@@ -175,6 +235,15 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
         </button>
       </header>
 
+      {status === 'loading_decoder' && (
+        <div className="rounded-xl bg-black/50 aspect-[4/3] flex items-center justify-center">
+          <p className="text-xs text-white/80">{t('barcode_scanner.loading_decoder')}</p>
+        </div>
+      )}
+
+      {/* Mount the video element for both 'starting' and 'scanning' so
+          videoRef is attached before startCamera tries to set srcObject.
+          The overlay differs per state. */}
       {(status === 'starting' || status === 'scanning') && (
         <div className="relative rounded-xl overflow-hidden bg-black aspect-[4/3]">
           <video
@@ -187,20 +256,14 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
             <div className="w-3/4 h-20 border-2 border-brand/80 rounded-lg" />
           </div>
-          {status === 'scanning' && (
-            <p className="absolute bottom-2 left-0 right-0 text-center text-xs text-white/80">
-              {t('barcode_scanner.frame_hint')}
-            </p>
-          )}
+          <p className="absolute bottom-2 left-0 right-0 text-center text-xs text-white/80">
+            {status === 'scanning'
+              ? t('barcode_scanner.frame_hint')
+              : t('barcode_scanner.starting')}
+          </p>
         </div>
       )}
 
-      {status === 'unsupported' && (
-        <div className="rounded-xl bg-surface-card border border-divider p-3 space-y-1">
-          <p className="text-sm text-heading font-medium">{t('barcode_scanner.unsupported_title')}</p>
-          <p className="text-xs text-body">{t('barcode_scanner.unsupported')}</p>
-        </div>
-      )}
       {status === 'permission_denied' && <p className="text-sm text-body">{t('barcode_scanner.permission_denied')}</p>}
       {status === 'error' && <p className="text-sm text-red-400">{t('barcode_scanner.error')}</p>}
 

--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -7,13 +7,7 @@ interface BarcodeScannerProps {
   onClose: () => void;
 }
 
-type DetectorStatus =
-  | 'idle'
-  | 'loading_decoder'
-  | 'starting'
-  | 'scanning'
-  | 'permission_denied'
-  | 'error';
+type DetectorStatus = 'idle' | 'loading_decoder' | 'starting' | 'scanning' | 'permission_denied' | 'error';
 
 interface DetectorLike {
   detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string }>>;
@@ -49,8 +43,7 @@ async function loadPolyfillCtor(): Promise<DetectorCtor> {
       // dependency we don't want for an offline-capable PWA.
       prepareZXingModule({
         overrides: {
-          locateFile: (path: string, prefix: string) =>
-            path.endsWith('.wasm') ? wasmUrlMod.default : prefix + path,
+          locateFile: (path: string, prefix: string) => (path.endsWith('.wasm') ? wasmUrlMod.default : prefix + path),
         },
       });
       return BarcodeDetector as unknown as DetectorCtor;
@@ -257,9 +250,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
             <div className="w-3/4 h-20 border-2 border-brand/80 rounded-lg" />
           </div>
           <p className="absolute bottom-2 left-0 right-0 text-center text-xs text-white/80">
-            {status === 'scanning'
-              ? t('barcode_scanner.frame_hint')
-              : t('barcode_scanner.starting')}
+            {status === 'scanning' ? t('barcode_scanner.frame_hint') : t('barcode_scanner.starting')}
           </p>
         </div>
       )}

--- a/src/components/nutrition/FoodSearchInput.tsx
+++ b/src/components/nutrition/FoodSearchInput.tsx
@@ -54,7 +54,15 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
                     onClick={() => onSelect(food)}
                     className="w-full text-left px-3 py-2 hover:bg-divider transition-colors border-b border-divider last:border-b-0"
                   >
-                    <p className="text-sm text-heading truncate">{food.name_fr}</p>
+                    <div className="flex items-start gap-2">
+                      <p className="text-sm text-heading truncate flex-1">{food.name_fr}</p>
+                      {food.source === 'off' && (
+                        // ODbL attribution requirement when surfacing OFF data.
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-brand/10 text-brand shrink-0">
+                          {t('food_search.off_badge')}
+                        </span>
+                      )}
+                    </div>
                     <p className="text-xs text-muted mt-0.5">
                       {food.calories_100g != null
                         ? t('food_search.kcal_per_100', { kcal: Math.round(food.calories_100g) })
@@ -67,6 +75,9 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
             </ul>
           )}
         </div>
+      )}
+      {results.some((r) => r.source === 'off') && (
+        <p className="text-[11px] text-muted italic">{t('food_search.off_attribution')}</p>
       )}
     </div>
   );

--- a/src/components/nutrition/FoodSearchInput.tsx
+++ b/src/components/nutrition/FoodSearchInput.tsx
@@ -54,21 +54,36 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
                     onClick={() => onSelect(food)}
                     className="w-full text-left px-3 py-2 hover:bg-divider transition-colors border-b border-divider last:border-b-0"
                   >
-                    <div className="flex items-start gap-2">
-                      <p className="text-sm text-heading truncate flex-1">{food.name_fr}</p>
-                      {food.source === 'off' && (
-                        // ODbL attribution requirement when surfacing OFF data.
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-brand/10 text-brand shrink-0">
-                          {t('food_search.off_badge')}
-                        </span>
+                    <div className="flex items-start gap-3">
+                      {food.image_url && (
+                        <img
+                          src={food.image_url}
+                          alt=""
+                          loading="lazy"
+                          className="w-10 h-10 rounded-md object-cover bg-surface shrink-0"
+                        />
                       )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start gap-2">
+                          {/* Drop `truncate` so multi-line names stay legible —
+                              shrinking would only hide info we just paid an
+                              edge-function call to fetch. */}
+                          <p className="text-sm text-heading flex-1 leading-snug">{food.name_fr}</p>
+                          {food.source === 'off' && (
+                            // ODbL attribution requirement when surfacing OFF data.
+                            <span className="text-[9px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-brand/10 text-brand shrink-0 whitespace-nowrap">
+                              {t('food_search.off_badge')}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted mt-0.5">
+                          {food.calories_100g != null
+                            ? t('food_search.kcal_per_100', { kcal: Math.round(food.calories_100g) })
+                            : t('food_search.calories_unavailable')}
+                          {food.group_fr && <span className="ml-2">· {food.group_fr}</span>}
+                        </p>
+                      </div>
                     </div>
-                    <p className="text-xs text-muted mt-0.5">
-                      {food.calories_100g != null
-                        ? t('food_search.kcal_per_100', { kcal: Math.round(food.calories_100g) })
-                        : t('food_search.calories_unavailable')}
-                      {food.group_fr && <span className="ml-2">· {food.group_fr}</span>}
-                    </p>
                   </button>
                 </li>
               ))}

--- a/src/components/nutrition/FoodSearchInput.tsx
+++ b/src/components/nutrition/FoodSearchInput.tsx
@@ -1,4 +1,4 @@
-import { Search } from 'lucide-react';
+import { Loader2, Search } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFoodSearch } from '../../hooks/useFoodSearch.ts';
@@ -20,10 +20,20 @@ export function FoodSearchInput({ onSelect, placeholder }: FoodSearchInputProps)
         {t('food_search.sr_label')}
       </label>
       <div className="relative block">
-        <Search
-          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none"
-          aria-hidden="true"
-        />
+        {/* Search → spinner swap during loading: the user sees that something
+            is happening even before any result appears, and the swap is in
+            the same screen position so there's no layout shift. */}
+        {loading ? (
+          <Loader2
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand animate-spin pointer-events-none"
+            aria-label={t('food_search.searching')}
+          />
+        ) : (
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none"
+            aria-hidden="true"
+          />
+        )}
         <input
           id="food-search-input"
           type="text"

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react';
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { MEAL_TYPES } from '../../config/nutrition.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
@@ -56,6 +56,20 @@ export function MealEntryForm({
   // Search tab state
   const [selectedFood, setSelectedFood] = useState<FoodReference | null>(null);
   const [portionGrams, setPortionGrams] = useState('100');
+
+  // OFF results carry quantity hints (`serving_quantity_g`, `product_quantity_g`)
+  // — use them to seed a smarter default than 100g, just like BarcodePane.
+  // Single-serve cap of 250g avoids prefilling 1 kg for a pasta box. CIQUAL
+  // rows have no quantity metadata so this no-ops for them.
+  useEffect(() => {
+    if (!selectedFood) return;
+    const serving = selectedFood.serving_quantity_g;
+    const product = selectedFood.product_quantity_g;
+    let grams = 100;
+    if (serving && serving > 0) grams = serving;
+    else if (product && product > 0 && product <= 250) grams = product;
+    setPortionGrams(String(grams));
+  }, [selectedFood]);
 
   async function handleManualSubmit(e: FormEvent) {
     e.preventDefault();

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -97,8 +97,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
           // OFF's data frequently produces — many products store the brand
           // verbatim in their product_name. Only append the brand when it
           // adds information.
-          const brandIsRedundant =
-            p.brand && p.name.toLowerCase().includes(p.brand.toLowerCase());
+          const brandIsRedundant = p.brand && p.name.toLowerCase().includes(p.brand.toLowerCase());
           return {
             id: p.barcode,
             name_fr: p.brand && !brandIsRedundant ? `${p.name} (${p.brand})` : p.name,

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import i18n from '../i18n/index.ts';
+import { searchOpenFoodFactsProducts } from '../lib/openFoodFacts.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { FoodReference } from '../types/nutrition.ts';
@@ -8,6 +9,11 @@ const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' 
 
 const DEBOUNCE_MS = 200;
 const RESULTS_LIMIT = 12;
+// CIQUAL covers ~3000 generic foods (apple, milk, bread); branded retail
+// products (e.g. Desperados, Heineken, Activia) only live in OFF. When
+// CIQUAL has zero hits, fall back to the public OFF text-search so the
+// user doesn't dead-end. Capped to keep the result list digestible.
+const OFF_FALLBACK_LIMIT = 8;
 
 export interface UseFoodSearchResult {
   results: FoodReference[];
@@ -16,8 +22,8 @@ export interface UseFoodSearchResult {
 }
 
 /**
- * Debounced fuzzy search over public.food_reference (CIQUAL).
- * Uses the `ilike` operator over the trigram-indexed `name_fr` column.
+ * Debounced fuzzy search over public.food_reference (CIQUAL), with an
+ * automatic Open Food Facts fallback when CIQUAL returns no results.
  */
 export function useFoodSearch(query: string): UseFoodSearchResult {
   const [results, setResults] = useState<FoodReference[]>([]);
@@ -40,6 +46,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
     const escaped = trimmed.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 
     let cancelled = false;
+    const offAbort = new AbortController();
     setLoading(true);
     const timer = setTimeout(async () => {
       try {
@@ -66,7 +73,46 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
           setLoading(false);
           return;
         }
-        setResults((data ?? []) as FoodReference[]);
+        const ciqualRows = (data ?? []) as FoodReference[];
+
+        if (ciqualRows.length > 0) {
+          setResults(ciqualRows);
+          setError(null);
+          setLoading(false);
+          return;
+        }
+
+        // CIQUAL miss → query OFF as a graceful fallback. Failures degrade
+        // to "no results" rather than surfacing — the search still returned,
+        // it just had nothing to offer.
+        const offHits = await searchOpenFoodFactsProducts(trimmed, OFF_FALLBACK_LIMIT, offAbort.signal);
+        if (cancelled) return;
+
+        const mapped: FoodReference[] = offHits.map((p) => {
+          // Avoid the redundant "Desperados (Desperados)" pattern that
+          // OFF's data frequently produces — many products store the brand
+          // verbatim in their product_name. Only append the brand when it
+          // adds information.
+          const brandIsRedundant =
+            p.brand && p.name.toLowerCase().includes(p.brand.toLowerCase());
+          return {
+            id: p.barcode,
+            name_fr: p.brand && !brandIsRedundant ? `${p.name} (${p.brand})` : p.name,
+            group_fr: null,
+            calories_100g: p.calories_100g,
+            protein_100g: p.protein_100g,
+            carbs_100g: p.carbs_100g,
+            fat_100g: p.fat_100g,
+            fiber_100g: p.fiber_100g,
+            source: 'off',
+            brand: p.brand,
+            image_url: p.image_url,
+            source_url: p.source_url,
+            product_quantity_g: p.product_quantity_g,
+            serving_quantity_g: p.serving_quantity_g,
+          };
+        });
+        setResults(mapped);
         setError(null);
         setLoading(false);
       } catch (err) {
@@ -79,6 +125,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
 
     return () => {
       cancelled = true;
+      offAbort.abort();
       clearTimeout(timer);
     };
   }, [query]);

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -7,7 +7,11 @@ import type { FoodReference } from '../types/nutrition.ts';
 
 const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
 
-const DEBOUNCE_MS = 200;
+// 500 ms is the sweet spot for a text search that may chain into a remote
+// edge function (OFF). 200 ms was too aggressive — fast typers hit the
+// edge function on most keystrokes, even though only the last one mattered,
+// pushing us toward OFF's 10 req/min/IP ceiling for nothing.
+const DEBOUNCE_MS = 500;
 const RESULTS_LIMIT = 12;
 // CIQUAL covers ~3000 generic foods (apple, milk, bread); branded retail
 // products (e.g. Desperados, Heineken, Activia) only live in OFF. When

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -74,9 +74,9 @@
   "barcode_scanner": {
     "heading": "Scan a barcode",
     "close": "Close",
+    "loading_decoder": "Loading the scanner…",
+    "starting": "Opening the camera…",
     "frame_hint": "Align the barcode in the frame…",
-    "unsupported_title": "Manual entry only",
-    "unsupported": "Your browser doesn't support camera scanning (iOS Safari, Chrome iOS). Type the digits below the barcode, or use the manual entry tab.",
     "permission_denied": "Camera access denied. You can enter the code manually.",
     "error": "Cannot open camera. Enter the code manually.",
     "manual_label": "Manual barcode entry",

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -103,9 +103,11 @@
     "default_placeholder": "Apple, cooked pasta, yogurt…",
     "min_chars": "Type at least 2 characters.",
     "searching": "Searching…",
-    "no_results": "No results in the CIQUAL database.",
+    "no_results": "No results found.",
     "kcal_per_100": "{{kcal}} kcal / 100 g",
-    "calories_unavailable": "Calories unavailable"
+    "calories_unavailable": "Calories unavailable",
+    "off_badge": "OFF",
+    "off_attribution": "Extended results via Open Food Facts (ODbL licence)."
   },
   "insight": {
     "heading": "AI analysis of your day",

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -106,7 +106,7 @@
     "no_results": "No results found.",
     "kcal_per_100": "{{kcal}} kcal / 100 g",
     "calories_unavailable": "Calories unavailable",
-    "off_badge": "OFF",
+    "off_badge": "Open Food Facts",
     "off_attribution": "Extended results via Open Food Facts (ODbL licence)."
   },
   "insight": {

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -74,9 +74,9 @@
   "barcode_scanner": {
     "heading": "Scanner un code-barres",
     "close": "Fermer",
+    "loading_decoder": "Chargement du scanner…",
+    "starting": "Ouverture de la caméra…",
     "frame_hint": "Aligne le code-barres dans le cadre…",
-    "unsupported_title": "Saisie manuelle uniquement",
-    "unsupported": "Ton navigateur ne permet pas le scan caméra (iOS Safari, Chrome iOS). Tape les chiffres sous le code-barres ci-dessous, ou utilise l'onglet Saisie libre.",
     "permission_denied": "Accès à la caméra refusé. Tu peux saisir le code manuellement.",
     "error": "Impossible d'ouvrir la caméra. Saisis le code manuellement.",
     "manual_label": "Saisie manuelle du code-barres",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -106,7 +106,7 @@
     "no_results": "Aucun résultat trouvé.",
     "kcal_per_100": "{{kcal}} kcal / 100 g",
     "calories_unavailable": "Calories non disponibles",
-    "off_badge": "OFF",
+    "off_badge": "Open Food Facts",
     "off_attribution": "Résultats étendus via Open Food Facts (licence ODbL)."
   },
   "insight": {

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -103,9 +103,11 @@
     "default_placeholder": "Pomme, pâtes cuites, yaourt…",
     "min_chars": "Tape au moins 2 caractères.",
     "searching": "Recherche…",
-    "no_results": "Aucun résultat dans la base CIQUAL.",
+    "no_results": "Aucun résultat trouvé.",
     "kcal_per_100": "{{kcal}} kcal / 100 g",
-    "calories_unavailable": "Calories non disponibles"
+    "calories_unavailable": "Calories non disponibles",
+    "off_badge": "OFF",
+    "off_attribution": "Résultats étendus via Open Food Facts (licence ODbL)."
   },
   "insight": {
     "heading": "Analyse IA de ta journée",

--- a/src/lib/openFoodFacts.test.ts
+++ b/src/lib/openFoodFacts.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchOpenFoodFactsProduct } from './openFoodFacts.ts';
+import { fetchOpenFoodFactsProduct, searchOpenFoodFactsProducts } from './openFoodFacts.ts';
 import { captureException } from './sentryReport.ts';
 
 vi.mock('./sentryReport.ts', () => ({
   captureException: vi.fn(),
+}));
+
+const invokeMock = vi.fn();
+vi.mock('./supabase.ts', () => ({
+  supabase: {
+    functions: {
+      invoke: (...args: unknown[]) => invokeMock(...args),
+    },
+  },
 }));
 
 const realFetch = globalThis.fetch;
@@ -255,5 +264,124 @@ describe('fetchOpenFoodFactsProduct', () => {
     expect(product).toBeNull();
     expect(error).toBe('network');
     expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('searchOpenFoodFactsProducts', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it('returns [] for queries shorter than 2 chars without invoking the edge function', async () => {
+    const out = await searchOpenFoodFactsProducts('a', 8);
+    expect(out).toEqual([]);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] without invoking when the AbortSignal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const out = await searchOpenFoodFactsProducts('foo', 8, ac.signal);
+    expect(out).toEqual([]);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('maps edge-function hits into our internal shape (brands as array)', async () => {
+    invokeMock.mockResolvedValue({
+      data: {
+        hits: [
+          {
+            code: '8718951288850',
+            product_name: 'Desperados',
+            brands: ['Desperados', 'Heineken'],
+            quantity: '33 cl',
+            product_quantity: 330,
+            serving_quantity: 330,
+            nutriments: {
+              'energy-kcal_100g': 47,
+              proteins_100g: 0.4,
+              carbohydrates_100g: 5.2,
+              fat_100g: 0,
+            },
+            image_small_url: 'https://example.test/desp.jpg',
+          },
+        ],
+      },
+      error: null,
+    });
+    const out = await searchOpenFoodFactsProducts('desperados', 8);
+    expect(invokeMock).toHaveBeenCalledWith('off-search', {
+      body: { q: 'desperados', page_size: 8 },
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].barcode).toBe('8718951288850');
+    expect(out[0].name).toBe('Desperados');
+    expect(out[0].brand).toBe('Desperados');
+    expect(out[0].calories_100g).toBe(47);
+    expect(out[0].product_quantity_g).toBe(330);
+    expect(out[0].source_url).toContain('8718951288850');
+  });
+
+  it('still parses brands when the proxy returns a comma-separated string', async () => {
+    invokeMock.mockResolvedValue({
+      data: {
+        hits: [
+          {
+            code: '111',
+            product_name: 'Test',
+            brands: 'BrandA,BrandB',
+            nutriments: { 'energy-kcal_100g': 50 },
+          },
+        ],
+      },
+      error: null,
+    });
+    const out = await searchOpenFoodFactsProducts('foo', 8);
+    expect(out[0].brand).toBe('BrandA');
+  });
+
+  it('skips hits that lack name or kcal/100g', async () => {
+    invokeMock.mockResolvedValue({
+      data: {
+        hits: [
+          { code: '111', product_name: 'No kcal', nutriments: {} },
+          { code: '222', product_name: '', nutriments: { 'energy-kcal_100g': 100 } },
+          { code: '333', product_name: 'OK', nutriments: { 'energy-kcal_100g': 200 } },
+        ],
+      },
+      error: null,
+    });
+    const out = await searchOpenFoodFactsProducts('foo', 8);
+    expect(out.map((p) => p.barcode)).toEqual(['333']);
+  });
+
+  it('returns [] on AbortError without reporting to Sentry', async () => {
+    invokeMock.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const out = await searchOpenFoodFactsProducts('foo', 8);
+    expect(out).toEqual([]);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns [] and reports to Sentry when the invoke call throws', async () => {
+    invokeMock.mockRejectedValue(new TypeError('offline'));
+    const out = await searchOpenFoodFactsProducts('foo', 8);
+    expect(out).toEqual([]);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] and reports to Sentry on an edge-function-level error', async () => {
+    invokeMock.mockResolvedValue({ data: null, error: { message: 'Upstream 502' } });
+    const out = await searchOpenFoodFactsProducts('foo', 8);
+    expect(out).toEqual([]);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps page_size to 24 and treats undefined hits as empty', async () => {
+    invokeMock.mockResolvedValue({ data: {}, error: null });
+    const out = await searchOpenFoodFactsProducts('foo', 9999);
+    expect(invokeMock).toHaveBeenCalledWith('off-search', {
+      body: { q: 'foo', page_size: 24 },
+    });
+    expect(out).toEqual([]);
   });
 });

--- a/src/lib/openFoodFacts.test.ts
+++ b/src/lib/openFoodFacts.test.ts
@@ -173,6 +173,73 @@ describe('fetchOpenFoodFactsProduct', () => {
     expect(error).toBe('missing_nutrition');
   });
 
+  it('extracts numeric product_quantity and serving_quantity when OFF returns them', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Barre céréales',
+          quantity: '40 g',
+          product_quantity: 40,
+          serving_quantity: 40,
+          nutriments: { 'energy-kcal_100g': 420 },
+        },
+      },
+    });
+    const { product } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(product?.product_quantity_g).toBe(40);
+    expect(product?.serving_quantity_g).toBe(40);
+  });
+
+  it('coerces string-typed numeric quantities (OFF often serializes them as strings)', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Yaourt',
+          product_quantity: '500',
+          serving_quantity: '125',
+          nutriments: { 'energy-kcal_100g': 60 },
+        },
+      },
+    });
+    const { product } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(product?.product_quantity_g).toBe(500);
+    expect(product?.serving_quantity_g).toBe(125);
+  });
+
+  it('drops zero / negative quantities to null so the UI falls back to a sane default', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Produit incomplet',
+          product_quantity: 0,
+          serving_quantity: -1,
+          nutriments: { 'energy-kcal_100g': 100 },
+        },
+      },
+    });
+    const { product } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(product?.product_quantity_g).toBeNull();
+    expect(product?.serving_quantity_g).toBeNull();
+  });
+
+  it('returns null for missing quantity fields rather than NaN', async () => {
+    globalThis.fetch = mockFetch({
+      _json: {
+        status: 1,
+        product: {
+          product_name: 'Ancien produit',
+          nutriments: { 'energy-kcal_100g': 100 },
+        },
+      },
+    });
+    const { product } = await fetchOpenFoodFactsProduct('3017620422003');
+    expect(product?.product_quantity_g).toBeNull();
+    expect(product?.serving_quantity_g).toBeNull();
+  });
+
   it('classifies json() parse failure as network and reports to Sentry', async () => {
     globalThis.fetch = vi.fn(
       async () =>

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -10,6 +10,7 @@
  * credentials.
  */
 
+import { supabase } from './supabase.ts';
 import { captureException } from './sentryReport.ts';
 
 const OFF_BASE = 'https://world.openfoodfacts.org/api/v2/product';
@@ -109,20 +110,7 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
     return { product: null, error: response.status === 404 ? 'not_found' : 'network' };
   }
 
-  type OffPayload = {
-    status?: number;
-    product?: {
-      product_name?: string;
-      product_name_fr?: string;
-      brands?: string;
-      quantity?: string;
-      product_quantity?: number | string;
-      serving_size?: string;
-      serving_quantity?: number | string;
-      nutriments?: Record<string, unknown>;
-      image_small_url?: string;
-    };
-  };
+  type OffPayload = { status?: number; product?: OffProductPayload };
   // json() can throw on truncated / non-JSON 200s (content-blocker
   // injections, captive portals). That is a transport failure, not a
   // missing product — surface it as 'network' so the UI message and the
@@ -139,16 +127,45 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
     return { product: null, error: 'not_found' };
   }
 
-  const p = payload.product;
+  const product = mapOffProduct(barcode, payload.product);
+  if (!product) return { product: null, error: 'missing_nutrition' };
+  return { product, error: null };
+}
+
+type OffProductPayload = {
+  code?: string;
+  product_name?: string;
+  product_name_fr?: string;
+  // /api/v2/product returns brands as a comma-separated string;
+  // search-a-licious returns it as an array. We accept both.
+  brands?: string | string[];
+  quantity?: string;
+  product_quantity?: number | string;
+  serving_size?: string;
+  serving_quantity?: number | string;
+  nutriments?: Record<string, unknown>;
+  image_small_url?: string;
+};
+
+function pickFirstBrand(brands: string | string[] | undefined): string | null {
+  if (!brands) return null;
+  if (Array.isArray(brands)) return brands[0]?.trim() || null;
+  return brands.split(',')[0]?.trim() || null;
+}
+
+/**
+ * Maps an OFF API product object to our internal shape. Returns null when
+ * the product lacks the bare minimum (name + kcal/100g) we need to render a
+ * meal entry — there's no point surfacing items we can't compute calories
+ * for. Used by both the single-product lookup and the search endpoint.
+ */
+function mapOffProduct(barcode: string, p: OffProductPayload): OpenFoodFactsProduct | null {
   const nutr = p.nutriments ?? {};
   const name = p.product_name_fr?.trim() || p.product_name?.trim() || null;
   // Only accept kcal-typed keys; `energy_100g` is in kJ on OFF and would
   // otherwise inflate calories by ~4.184x with no unit check.
   const calories = pickNumber(nutr, ['energy-kcal_100g', 'energy-kcal']);
-
-  if (!name || calories == null) {
-    return { product: null, error: 'missing_nutrition' };
-  }
+  if (!name || calories == null) return null;
 
   // OFF often returns these as numeric strings (e.g. "40"); pickNumber
   // coerces both shapes uniformly. Negative or zero values are treated as
@@ -157,21 +174,80 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
   const servingQtyRaw = pickNumber(p as unknown as Record<string, unknown>, ['serving_quantity']);
 
   return {
-    product: {
-      barcode,
-      name,
-      brand: p.brands ? p.brands.split(',')[0].trim() : null,
-      quantity: p.quantity ?? null,
-      product_quantity_g: productQtyRaw && productQtyRaw > 0 ? productQtyRaw : null,
-      serving_quantity_g: servingQtyRaw && servingQtyRaw > 0 ? servingQtyRaw : null,
-      calories_100g: calories,
-      protein_100g: pickNumber(nutr, ['proteins_100g', 'proteins']),
-      carbs_100g: pickNumber(nutr, ['carbohydrates_100g', 'carbohydrates']),
-      fat_100g: pickNumber(nutr, ['fat_100g', 'fat']),
-      fiber_100g: pickNumber(nutr, ['fiber_100g', 'fiber']),
-      image_url: p.image_small_url ?? null,
-      source_url: `https://world.openfoodfacts.org/product/${barcode}`,
-    },
-    error: null,
+    barcode,
+    name,
+    brand: pickFirstBrand(p.brands),
+    quantity: p.quantity ?? null,
+    product_quantity_g: productQtyRaw && productQtyRaw > 0 ? productQtyRaw : null,
+    serving_quantity_g: servingQtyRaw && servingQtyRaw > 0 ? servingQtyRaw : null,
+    calories_100g: calories,
+    protein_100g: pickNumber(nutr, ['proteins_100g', 'proteins']),
+    carbs_100g: pickNumber(nutr, ['carbohydrates_100g', 'carbohydrates']),
+    fat_100g: pickNumber(nutr, ['fat_100g', 'fat']),
+    fiber_100g: pickNumber(nutr, ['fiber_100g', 'fiber']),
+    image_url: p.image_small_url ?? null,
+    source_url: `https://world.openfoodfacts.org/product/${barcode}`,
   };
+}
+
+/**
+ * Free-text product search, used as a fallback when the local CIQUAL
+ * referential returns no results — CIQUAL only has generic foods (e.g.
+ * "Bière, blonde"), while OFF carries branded retail products (e.g.
+ * "Desperados").
+ *
+ * Routes through our `off-search` Supabase Edge Function rather than calling
+ * OFF directly: the proper text-search endpoint (search-a-licious) blocks
+ * browser CORS at the gateway, and the CORS-open `/api/v2/search` endpoint
+ * silently ignores its `search_terms` parameter. The proxy adds a 15-min
+ * in-memory cache and identifies us to OFF with a proper User-Agent, both
+ * required to stay under OFF's 10 req/min/IP limit.
+ *
+ * Returns an empty array on any non-fatal failure so the search UI degrades
+ * gracefully to "no results" instead of throwing.
+ */
+export async function searchOpenFoodFactsProducts(
+  query: string,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<OpenFoodFactsProduct[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < 2 || !supabase) return [];
+  // The caller's AbortSignal cancels stale-debounce searches; bail out
+  // before invoking the function on an already-aborted request.
+  if (signal?.aborted) return [];
+
+  type EdgeResponse = { hits?: OffProductPayload[]; error?: string };
+  let data: EdgeResponse | null = null;
+  let invokeError: { message?: string } | null = null;
+  try {
+    const result = await supabase.functions.invoke<EdgeResponse>('off-search', {
+      body: { q: trimmed, page_size: Math.min(Math.max(limit, 1), 24) },
+    });
+    data = result.data;
+    invokeError = result.error as { message?: string } | null;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') return [];
+    captureException(err, { contexts: { off_search: { phase: 'invoke_throw' } } });
+    return [];
+  }
+
+  if (signal?.aborted) return [];
+
+  if (invokeError) {
+    captureException(new Error(`off-search invoke error: ${invokeError.message ?? 'unknown'}`), {
+      contexts: { off_search: { phase: 'edge_error' } },
+    });
+    return [];
+  }
+
+  const items = Array.isArray(data?.hits) ? data!.hits! : [];
+  const out: OpenFoodFactsProduct[] = [];
+  for (const raw of items) {
+    const code = typeof raw.code === 'string' ? raw.code : '';
+    if (!code) continue;
+    const mapped = mapOffProduct(code, raw);
+    if (mapped) out.push(mapped);
+  }
+  return out;
 }

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -18,7 +18,9 @@ const FIELDS = [
   'product_name_fr',
   'brands',
   'quantity',
+  'product_quantity',
   'serving_size',
+  'serving_quantity',
   'nutriments',
   'image_small_url',
 ].join(',');
@@ -27,7 +29,12 @@ export interface OpenFoodFactsProduct {
   barcode: string;
   name: string;
   brand: string | null;
+  /** Human-readable total quantity, e.g. "40 g", "1 L", "270 g (3 x 90g)". */
   quantity: string | null;
+  /** Numeric total package weight in grams, when OFF reports it. */
+  product_quantity_g: number | null;
+  /** Numeric weight of one serving in grams, when OFF reports it. */
+  serving_quantity_g: number | null;
   /** kcal per 100g when available, null if unit is kJ only or missing. */
   calories_100g: number | null;
   protein_100g: number | null;
@@ -109,7 +116,9 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
       product_name_fr?: string;
       brands?: string;
       quantity?: string;
+      product_quantity?: number | string;
       serving_size?: string;
+      serving_quantity?: number | string;
       nutriments?: Record<string, unknown>;
       image_small_url?: string;
     };
@@ -141,12 +150,20 @@ export async function fetchOpenFoodFactsProduct(barcode: string, signal?: AbortS
     return { product: null, error: 'missing_nutrition' };
   }
 
+  // OFF often returns these as numeric strings (e.g. "40"); pickNumber
+  // coerces both shapes uniformly. Negative or zero values are treated as
+  // missing — they're never meaningful as a portion default.
+  const productQtyRaw = pickNumber(p as unknown as Record<string, unknown>, ['product_quantity']);
+  const servingQtyRaw = pickNumber(p as unknown as Record<string, unknown>, ['serving_quantity']);
+
   return {
     product: {
       barcode,
       name,
       brand: p.brands ? p.brands.split(',')[0].trim() : null,
       quantity: p.quantity ?? null,
+      product_quantity_g: productQtyRaw && productQtyRaw > 0 ? productQtyRaw : null,
+      serving_quantity_g: servingQtyRaw && servingQtyRaw > 0 ? servingQtyRaw : null,
       calories_100g: calories,
       protein_100g: pickNumber(nutr, ['proteins_100g', 'proteins']),
       carbs_100g: pickNumber(nutr, ['carbohydrates_100g', 'carbohydrates']),

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -10,8 +10,8 @@
  * credentials.
  */
 
-import { supabase } from './supabase.ts';
 import { captureException } from './sentryReport.ts';
+import { supabase } from './supabase.ts';
 
 const OFF_BASE = 'https://world.openfoodfacts.org/api/v2/product';
 const FIELDS = [

--- a/src/types/nutrition.ts
+++ b/src/types/nutrition.ts
@@ -94,7 +94,18 @@ export type FoodReference = {
   carbs_100g: number | null;
   fat_100g: number | null;
   fiber_100g: number | null;
+  /** 'ciqual' for rows fetched from the local CIQUAL table; 'off' when
+   *  synthesized from an Open Food Facts text-search fallback. */
   source: string;
+  // Fields below are only populated for source === 'off' search fallback.
+  // They carry product-level metadata (brand, image, OFF source URL) plus
+  // numeric quantity hints used to seed the portion input — keeping them
+  // optional preserves the CIQUAL row shape unchanged.
+  brand?: string | null;
+  image_url?: string | null;
+  source_url?: string;
+  product_quantity_g?: number | null;
+  serving_quantity_g?: number | null;
 };
 
 export type DailyNutritionTotals = {

--- a/supabase/functions/off-search/index.ts
+++ b/supabase/functions/off-search/index.ts
@@ -1,0 +1,234 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+
+/**
+ * Server-side proxy to OFF's search-a-licious endpoint.
+ *
+ * Why this exists: search-a-licious is the only OFF service that does proper
+ * relevance-ranked text search (Elasticsearch-backed), but its upstream
+ * gateway (Cloudflare/WAF) blocks browser CORS preflights with `400
+ * Disallowed CORS origin`, even from production domains. The plain
+ * `/api/v2/search?search_terms=` endpoint is CORS-open but silently ignores
+ * the search term and returns the unfiltered global product set.
+ *
+ * Design constraints:
+ * - OFF rate-limits search to ~10 req/min per IP. Our edge function shares a
+ *   small set of Supabase datacenter IPs across all our users, so caching is
+ *   not optional — it is the difference between this working and getting our
+ *   datacenter IP banned.
+ * - OFF expects a User-Agent identifying the app + contact. Without it they
+ *   may rate-limit or ban opaque clients.
+ * - search-a-licious is still flagged beta in OFF docs; we pin to the field
+ *   list we tested and pass through the response shape unmodified so client
+ *   schema drift surfaces in one place.
+ */
+
+const OFF_SEARCH_URL = "https://search.openfoodfacts.org/search";
+const USER_AGENT = "Wan2Fit/1.1.1 (erwan.viot@gmail.com https://wan2fit.fr)";
+
+// Fields we forward to OFF. Locked down to what the client actually renders
+// — sending an empty `fields` would let OFF return its 100+ field default
+// payload, wasting bandwidth and risking schema drift.
+const OFF_FIELDS = [
+  "code",
+  "product_name",
+  "product_name_fr",
+  "brands",
+  "quantity",
+  "product_quantity",
+  "serving_size",
+  "serving_quantity",
+  "nutriments",
+  "image_small_url",
+].join(",");
+
+const MAX_PAGE_SIZE = 24;
+const MIN_QUERY_LEN = 2;
+const MAX_QUERY_LEN = 100;
+// 15 minutes is conservative: product nutrition data is essentially static
+// on hour-scales, and OFF's own /api/v2 CDN advertises max-age=300 (5 min).
+// Triple that budget to cut real-world OFF load — at our traffic the cache
+// hit rate on common queries (nutella, coca-cola, activia) is what keeps us
+// well below the 10 req/min/IP ceiling.
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const UPSTREAM_TIMEOUT_MS = 8000;
+
+// In-process LRU-ish cache. Per-isolate, lost on cold start — that's fine
+// at our scale; if cold-start bursts ever cause OFF rate-limit hits in
+// production, migrate this to a Supabase `search_cache` table with a
+// 30-min TTL (cached_at timestamp + a SELECT WHERE cached_at > NOW() - …
+// guard). 200 entries × ~10 KB = ~2 MB, well within the isolate budget.
+const CACHE_MAX_ENTRIES = 200;
+type CacheEntry = { payload: unknown; expiresAt: number };
+const cache = new Map<string, CacheEntry>();
+
+// Lightweight global circuit breaker: if OFF starts returning 429/503
+// repeatedly, stop hammering them and fail fast for ~60 s. Resets once we
+// next get a 2xx response. Avoids escalating a transient OFF blip into a
+// proper IP ban.
+let upstreamFailures = 0;
+let circuitOpenUntil = 0;
+const CIRCUIT_BREAKER_THRESHOLD = 5;
+const CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
+
+function jsonResponse(req: Request, data: unknown, status = 200, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      ...getCorsHeaders(req),
+      "Content-Type": "application/json",
+      ...extraHeaders,
+    },
+  });
+}
+
+function errorResponse(req: Request, message: string, status = 400) {
+  return jsonResponse(req, { error: message }, status);
+}
+
+function cacheKey(q: string, pageSize: number): string {
+  return `${q}|${pageSize}`;
+}
+
+function readCache(key: string): unknown | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt < Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.payload;
+}
+
+function writeCache(key: string, payload: unknown): void {
+  if (cache.size >= CACHE_MAX_ENTRIES) {
+    // Naive eviction: drop the first (oldest insertion order) entry. Cheap
+    // and good enough — this cache is a load-shedding device, not a data
+    // store, so eviction quality is not a hot path.
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) cache.delete(firstKey);
+  }
+  cache.set(key, { payload, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+async function fetchUpstream(q: string, pageSize: number, signal: AbortSignal): Promise<Response> {
+  const params = new URLSearchParams({
+    q,
+    fields: OFF_FIELDS,
+    page_size: String(pageSize),
+    langs: "fr",
+  });
+  return await fetch(`${OFF_SEARCH_URL}?${params}`, {
+    signal,
+    headers: {
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+    },
+  });
+}
+
+interface RequestBody {
+  q?: string;
+  page_size?: number;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: getCorsHeaders(req) });
+  }
+  // POST matches the supabase-js `functions.invoke` default and the
+  // surrounding edge function conventions. The body shape is the same
+  // arguments we'd otherwise pass via query string.
+  if (req.method !== "POST") {
+    return errorResponse(req, "Method not allowed", 405);
+  }
+
+  // Auth: require a Supabase session token. The anon JWT is enough — it
+  // proves the request came from our frontend session, which is sufficient
+  // gating for a read-only proxy. We don't need verified-email or premium
+  // checks here.
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return errorResponse(req, "Missing authorization", 401);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !anonKey) return errorResponse(req, "Server misconfigured", 500);
+
+  const supabaseAuth = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+  if (authError || !user) return errorResponse(req, "Non autorisé", 401);
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return errorResponse(req, "Invalid JSON body", 400);
+  }
+
+  const rawQ = typeof body.q === "string" ? body.q : "";
+  const q = rawQ.trim().toLowerCase();
+  if (q.length < MIN_QUERY_LEN) return errorResponse(req, "q too short", 400);
+  if (q.length > MAX_QUERY_LEN) return errorResponse(req, "q too long", 400);
+
+  const rawPageSize = typeof body.page_size === "number" ? body.page_size : 8;
+  const pageSize = Number.isFinite(rawPageSize)
+    ? Math.min(Math.max(Math.floor(rawPageSize), 1), MAX_PAGE_SIZE)
+    : 8;
+
+  const key = cacheKey(q, pageSize);
+  const cached = readCache(key);
+  if (cached !== null) {
+    return jsonResponse(req, cached, 200, { "X-Cache": "HIT" });
+  }
+
+  if (Date.now() < circuitOpenUntil) {
+    return errorResponse(req, "Search temporarily unavailable", 503);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  let upstream: Response;
+  try {
+    upstream = await fetchUpstream(q, pageSize, controller.signal);
+  } catch (err) {
+    clearTimeout(timeout);
+    upstreamFailures++;
+    if (upstreamFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+      circuitOpenUntil = Date.now() + CIRCUIT_BREAKER_COOLDOWN_MS;
+    }
+    const aborted = err instanceof DOMException && err.name === "AbortError";
+    return errorResponse(req, aborted ? "Upstream timeout" : "Upstream unreachable", 502);
+  }
+  clearTimeout(timeout);
+
+  if (!upstream.ok) {
+    if (upstream.status === 429 || upstream.status === 503) {
+      upstreamFailures++;
+      if (upstreamFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+        circuitOpenUntil = Date.now() + CIRCUIT_BREAKER_COOLDOWN_MS;
+      }
+    }
+    // Don't cache failures — try again on the next request.
+    return errorResponse(req, `Upstream ${upstream.status}`, 502);
+  }
+
+  // 2xx — reset the breaker counter so transient blips don't accumulate.
+  upstreamFailures = 0;
+
+  let payload: unknown;
+  try {
+    payload = await upstream.json();
+  } catch {
+    return errorResponse(req, "Upstream returned non-JSON", 502);
+  }
+
+  writeCache(key, payload);
+  return jsonResponse(req, payload, 200, { "X-Cache": "MISS" });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.supabase.co https://*.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.supabase.co https://*.openfoodfacts.org; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.openfoodfacts.org https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://vitals.vercel-insights.com https://va.vercel-scripts.com; frame-src https://js.stripe.com https://hooks.stripe.com; worker-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
         },
         {
           "key": "X-Frame-Options",
@@ -24,7 +24,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+          "value": "camera=(self), microphone=(), geolocation=(), interest-cohort=()"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Release develop → main

Ramène en prod les trois fixes nutrition de la PR #155.

### 1. Scan caméra fonctionnel
Root cause double : `Permissions-Policy: camera=()` bloquait getUserMedia partout (passé à `camera=(self)`), et `BarcodeDetector` natif n'existe pas sur iOS Safari / Chrome iOS / Firefox. Ajout du ponyfill `barcode-detector` (zxing-wasm) en lazy import — **0 KB** de surcoût pour Chrome desktop/Android, ~500 KB gzipped à la première ouverture du scan ailleurs (cache PWA ensuite).

### 2. Portion par défaut intelligente
`serving_quantity` puis `product_quantity` (cap 250g single-serve) puis 100g fallback. Une barre 40g se pré-remplit à 40g au lieu de 100g.

### 3. Recherche texte avec fallback OFF
Si CIQUAL ne trouve rien (Desperados, Nutella…), interrogation server-side de search-a-licious via la nouvelle edge function `off-search`. Cache in-memory 15 min, circuit breaker, User-Agent identifiant. Badge "OPEN FOOD FACTS" + miniature + attribution ODbL côté UI. Debounce 500ms + spinner pendant la recherche.

## ⚠️ À faire AVANT de merger cette PR

Déployer l'edge function `off-search` sur le projet **prod** Supabase :

\`\`\`bash
npx supabase functions deploy off-search --no-verify-jwt --project-ref pipbhkaaqsltnvprmzrl
\`\`\`

Sans ça, la recherche fallback retournera 404 en prod (la fonction n'existe que sur le projet dev `rgwwpkyuavhqdautpciu` actuellement).

## Test plan post-deploy prod

- [ ] Scan caméra fonctionne sur iPhone Safari (path polyfill)
- [ ] Scan caméra fonctionne sur Chrome iOS (path polyfill)
- [ ] Scan caméra fonctionne sur Chrome desktop (path natif BarcodeDetector)
- [ ] Recherche "desperados" renvoie des résultats avec badge OPEN FOOD FACTS
- [ ] Pré-remplissage portion : scanner une barre de 40g doit afficher 40 par défaut
- [ ] Headers prod : `Permissions-Policy: camera=(self)` et `script-src` avec `'wasm-unsafe-eval'`
- [ ] Surveiller Sentry 24h : OFF 429/503 (signe d'approche du rate-limit), schema drift de search-a-licious

🤖 Generated with [Claude Code](https://claude.com/claude-code)