### PR TITLE
chore(lint): biome auto-fix

### DIFF
--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -7,13 +7,7 @@ interface BarcodeScannerProps {
   onClose: () => void;
 }
 
-type DetectorStatus =
-  | 'idle'
-  | 'loading_decoder'
-  | 'starting'
-  | 'scanning'
-  | 'permission_denied'
-  | 'error';
+type DetectorStatus = 'idle' | 'loading_decoder' | 'starting' | 'scanning' | 'permission_denied' | 'error';
 
 interface DetectorLike {
   detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string }>>;
@@ -49,8 +43,7 @@ async function loadPolyfillCtor(): Promise<DetectorCtor> {
       // dependency we don't want for an offline-capable PWA.
       prepareZXingModule({
         overrides: {
-          locateFile: (path: string, prefix: string) =>
-            path.endsWith('.wasm') ? wasmUrlMod.default : prefix + path,
+          locateFile: (path: string, prefix: string) => (path.endsWith('.wasm') ? wasmUrlMod.default : prefix + path),
         },
       });
       return BarcodeDetector as unknown as DetectorCtor;
@@ -257,9 +250,7 @@ export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
             <div className="w-3/4 h-20 border-2 border-brand/80 rounded-lg" />
           </div>
           <p className="absolute bottom-2 left-0 right-0 text-center text-xs text-white/80">
-            {status === 'scanning'
-              ? t('barcode_scanner.frame_hint')
-              : t('barcode_scanner.starting')}
+            {status === 'scanning' ? t('barcode_scanner.frame_hint') : t('barcode_scanner.starting')}
           </p>
         </div>
       )}

--- a/src/hooks/useFoodSearch.ts
+++ b/src/hooks/useFoodSearch.ts
@@ -97,8 +97,7 @@ export function useFoodSearch(query: string): UseFoodSearchResult {
           // OFF's data frequently produces — many products store the brand
           // verbatim in their product_name. Only append the brand when it
           // adds information.
-          const brandIsRedundant =
-            p.brand && p.name.toLowerCase().includes(p.brand.toLowerCase());
+          const brandIsRedundant = p.brand && p.name.toLowerCase().includes(p.brand.toLowerCase());
           return {
             id: p.barcode,
             name_fr: p.brand && !brandIsRedundant ? `${p.name} (${p.brand})` : p.name,

--- a/src/lib/openFoodFacts.ts
+++ b/src/lib/openFoodFacts.ts
@@ -10,8 +10,8 @@
  * credentials.
  */
 
-import { supabase } from './supabase.ts';
 import { captureException } from './sentryReport.ts';
+import { supabase } from './supabase.ts';
 
 const OFF_BASE = 'https://world.openfoodfacts.org/api/v2/product';
 const FIELDS = [


### PR DESCRIPTION
Trois reformatages purs (ternaire multi-ligne, déclaration multi-ligne, ordre des imports) — `biome check --write` les corrige automatiquement. Aucun changement de comportement.

Le lint a échoué silencieusement sur les 5 pushes successifs de la PR #155 sans être détecté. Cette PR ferme la dette pour débloquer la release develop → main (#156).

🤖 Generated with [Claude Code](https://claude.com/claude-code)