### PR TITLE
feat(nutrition): rework meal entry modal for mobile

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -183,7 +183,7 @@ export function NutritionPage() {
               aria-modal="true"
               aria-label={t('page.add_meal_modal_aria')}
               tabIndex={-1}
-              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-6 shadow-xl focus:outline-none"
+              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-xl focus:outline-none"
             >
               <MealEntryForm
                 initialMealType={initialMealType}

--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -183,10 +183,10 @@ export function NutritionPage() {
               aria-modal="true"
               aria-label={t('page.add_meal_modal_aria')}
               tabIndex={-1}
-              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-xl focus:outline-none"
+              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-6 shadow-xl focus:outline-none"
             >
               <MealEntryForm
-                initialMealType={initialMealType}
+                mealType={initialMealType}
                 isPremium={isPremium}
                 onSubmit={handleSubmit}
                 onSearchSelect={handleSearchSelect}

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -10,12 +10,12 @@ import { FoodSearchInput } from './FoodSearchInput.tsx';
 type Mode = 'manual' | 'search' | 'barcode' | 'ai';
 
 interface MealEntryFormProps {
-  initialMealType: MealType;
+  mealType: MealType;
   isPremium: boolean;
   onSubmit: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
   onCancel: () => void;
-  onSearchSelect?: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
-  onBarcodeSelect?: (product: OpenFoodFactsProduct, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+  onSearchSelect: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+  onBarcodeSelect: (product: OpenFoodFactsProduct, quantityGrams: number, mealType: MealType) => Promise<boolean>;
 }
 
 function parseMacro(raw: string): number | null {
@@ -32,7 +32,7 @@ function scaleByPortion(per100g: number | null | undefined, grams: number): numb
 }
 
 export function MealEntryForm({
-  initialMealType,
+  mealType,
   isPremium,
   onSubmit,
   onCancel,
@@ -42,7 +42,7 @@ export function MealEntryForm({
   const { t } = useTranslation('nutrition');
   const modes: Mode[] = isPremium ? ['barcode', 'search', 'ai', 'manual'] : ['barcode', 'search', 'manual'];
   const [mode, setMode] = useState<Mode>('barcode');
-  const mealType = initialMealType;
+  const safeMode = modes.includes(mode) ? mode : modes[0];
   const [name, setName] = useState('');
   const [calories, setCalories] = useState('');
   const [protein, setProtein] = useState('');
@@ -113,10 +113,8 @@ export function MealEntryForm({
     }
     setSubmitting(true);
     try {
-      if (onSearchSelect) {
-        const ok = await onSearchSelect(selectedFood, grams, mealType);
-        if (ok) onCancel();
-      }
+      const ok = await onSearchSelect(selectedFood, grams, mealType);
+      if (ok) onCancel();
     } finally {
       setSubmitting(false);
     }
@@ -152,9 +150,9 @@ export function MealEntryForm({
               setMode(m);
               setError(null);
             }}
-            aria-pressed={mode === m}
+            aria-pressed={safeMode === m}
             className={`flex-1 min-w-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap truncate ${
-              mode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
+              safeMode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
             }`}
           >
             {t(`meal_form.mode_${m}`)}
@@ -162,27 +160,24 @@ export function MealEntryForm({
         ))}
       </div>
 
-      {mode === 'ai' ? (
+      {safeMode === 'ai' ? (
         <AiTextPane mealType={mealType} onSubmit={onSubmit} onCancel={onCancel} />
-      ) : mode === 'barcode' ? (
+      ) : safeMode === 'barcode' ? (
         <BarcodePane
           mealType={mealType}
           onCancel={onCancel}
           onSubmit={async (product, grams) => {
             setSubmitting(true);
             try {
-              if (onBarcodeSelect) {
-                const ok = await onBarcodeSelect(product, grams, mealType);
-                if (ok) onCancel();
-                return ok;
-              }
-              return false;
+              const ok = await onBarcodeSelect(product, grams, mealType);
+              if (ok) onCancel();
+              return ok;
             } finally {
               setSubmitting(false);
             }
           }}
         />
-      ) : mode === 'manual' ? (
+      ) : safeMode === 'manual' ? (
         <form onSubmit={handleManualSubmit} className="space-y-3">
           <div>
             <label htmlFor="meal-name" className="block text-xs font-medium text-body mb-1">

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,7 +1,6 @@
 import { X } from 'lucide-react';
 import { type FormEvent, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { MEAL_TYPES } from '../../config/nutrition.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../../types/nutrition.ts';
 import { AiTextPane } from './AiTextPane.tsx';
@@ -41,9 +40,9 @@ export function MealEntryForm({
   onBarcodeSelect,
 }: MealEntryFormProps) {
   const { t } = useTranslation('nutrition');
-  const [mode, setMode] = useState<Mode>('manual');
-  const modes: Mode[] = isPremium ? ['manual', 'search', 'barcode', 'ai'] : ['manual', 'search', 'barcode'];
-  const [mealType, setMealType] = useState<MealType>(initialMealType);
+  const modes: Mode[] = isPremium ? ['barcode', 'search', 'ai', 'manual'] : ['barcode', 'search', 'manual'];
+  const [mode, setMode] = useState<Mode>('barcode');
+  const mealType = initialMealType;
   const [name, setName] = useState('');
   const [calories, setCalories] = useState('');
   const [protein, setProtein] = useState('');
@@ -129,12 +128,15 @@ export function MealEntryForm({
 
   return (
     <div className="space-y-4">
-      <header className="flex items-center justify-between">
-        <h2 className="font-display text-lg font-bold text-heading">{t('meal_form.heading')}</h2>
+      <header className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="font-display text-lg font-bold text-heading">{t('meal_form.heading')}</h2>
+          <p className="mt-0.5 text-xs text-muted">{t(`meal_type.${mealType}`)}</p>
+        </div>
         <button
           type="button"
           onClick={onCancel}
-          className="p-2 rounded-lg text-muted hover:text-heading hover:bg-divider"
+          className="-mr-2 -mt-2 p-2 rounded-lg text-muted hover:text-heading hover:bg-divider shrink-0"
           aria-label={t('meal_form.close_aria')}
         >
           <X className="w-4 h-4" />
@@ -159,25 +161,6 @@ export function MealEntryForm({
           </button>
         ))}
       </div>
-
-      <fieldset>
-        <legend className="block text-xs font-medium text-body mb-1">{t('meal_form.meal_legend')}</legend>
-        <div className="flex flex-wrap gap-1.5">
-          {MEAL_TYPES.map((mt) => (
-            <button
-              key={mt}
-              type="button"
-              onClick={() => setMealType(mt)}
-              aria-pressed={mealType === mt}
-              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                mealType === mt ? 'bg-brand text-white' : 'bg-surface border border-divider text-body'
-              }`}
-            >
-              {t(`meal_type.${mt}`)}
-            </button>
-          ))}
-        </div>
-      </fieldset>
 
       {mode === 'ai' ? (
         <AiTextPane mealType={mealType} onSubmit={onSubmit} onCancel={onCancel} />

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -129,11 +129,10 @@
   "meal_form": {
     "heading": "Add a meal",
     "close_aria": "Close",
-    "mode_manual": "Manual entry",
+    "mode_manual": "Manual",
     "mode_search": "Search",
     "mode_barcode": "Scan",
     "mode_ai": "AI",
-    "meal_legend": "Meal",
     "name_label": "Meal name",
     "name_placeholder": "E.g. homemade pasta bolognese",
     "calories_label": "Calories (kcal)",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -129,11 +129,10 @@
   "meal_form": {
     "heading": "Ajouter un repas",
     "close_aria": "Fermer",
-    "mode_manual": "Saisie libre",
+    "mode_manual": "Manuel",
     "mode_search": "Rechercher",
     "mode_barcode": "Scanner",
     "mode_ai": "IA",
-    "meal_legend": "Repas",
     "name_label": "Nom du repas",
     "name_placeholder": "Ex. pâtes bolo maison",
     "calories_label": "Calories (kcal)",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -130,7 +130,7 @@
     "heading": "Ajouter un repas",
     "close_aria": "Fermer",
     "mode_manual": "Manuel",
-    "mode_search": "Rechercher",
+    "mode_search": "Chercher",
     "mode_barcode": "Scanner",
     "mode_ai": "IA",
     "name_label": "Nom du repas",


### PR DESCRIPTION
## Summary
- Reorder tabs with **scan first** (`barcode → search → ai → manual`) so the most-used path is the default
- Drop the in-modal meal-type picker (the meal is already chosen on open via the `+` on a `MealCard`); surface it as a subheading instead so the user keeps the visual context without the extra real estate
- Tighten modal padding on mobile (`p-4 sm:p-6`) and respect iOS safe-area on the bottom sheet (`pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-6`)
- Shorten labels: "Saisie libre" → "Manuel", "Rechercher" → "Chercher", "Manual entry" → "Manual" so the 4-tab row fits a 375px viewport without truncation
- Tighten props: `mealType` (renamed from `initialMealType`), required `onSearchSelect`/`onBarcodeSelect`, `safeMode` guard against a stale `'ai'` tab if `isPremium` flips mid-session
- Cleanup: drop the now-orphaned `meal_legend` i18n key

## Test plan
- [x] `npm run lint` (Biome): clean
- [x] `npm test` (vitest): 335/335 green
- [x] `npm run build`: clean
- [ ] Manual recipe (375px mobile): open modal from each meal card → scan tab is default → meal subtitle matches the card → 4 tab labels fit without truncation → close button hits the safe-area
- [ ] Switch to manual / search / ai tabs and back, confirm no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)