### PR TITLE
feat(nutrition): suggest recurring meals at the top of the entry modal

### DIFF
--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -6,6 +6,7 @@ import type { FoodReference, MealLogInsert, MealType } from '../../types/nutriti
 import { AiTextPane } from './AiTextPane.tsx';
 import { BarcodePane } from './BarcodePane.tsx';
 import { FoodSearchInput } from './FoodSearchInput.tsx';
+import { type RecurringMealPrefill, RecurringMealsBlock } from './RecurringMealsBlock.tsx';
 
 type Mode = 'manual' | 'search' | 'barcode' | 'ai';
 
@@ -124,6 +125,29 @@ export function MealEntryForm({
     ? scaleByPortion(selectedFood.calories_100g, Number.parseFloat(portionGrams) || 0)
     : null;
 
+  async function handleQuickAdd(input: Omit<MealLogInsert, 'user_id' | 'logged_date'>): Promise<boolean> {
+    if (submitting) return false;
+    setSubmitting(true);
+    try {
+      const ok = await onSubmit(input);
+      if (ok) onCancel();
+      return ok;
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleEditPrefill(prefill: RecurringMealPrefill) {
+    setName(prefill.name);
+    setCalories(prefill.calories);
+    setProtein(prefill.protein);
+    setCarbs(prefill.carbs);
+    setFat(prefill.fat);
+    setNotes('');
+    setError(null);
+    setMode('manual');
+  }
+
   return (
     <div className="space-y-4">
       <header className="flex items-start justify-between gap-2">
@@ -140,6 +164,8 @@ export function MealEntryForm({
           <X className="w-4 h-4" />
         </button>
       </header>
+
+      <RecurringMealsBlock mealType={mealType} onQuickAdd={handleQuickAdd} onEdit={handleEditPrefill} />
 
       <div className="flex gap-1 p-1 rounded-xl bg-surface border border-divider w-full">
         {modes.map((m) => (

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -127,10 +127,15 @@ export function MealEntryForm({
 
   async function handleQuickAdd(input: Omit<MealLogInsert, 'user_id' | 'logged_date'>): Promise<boolean> {
     if (submitting) return false;
+    setError(null);
     setSubmitting(true);
     try {
       const ok = await onSubmit(input);
-      if (ok) onCancel();
+      if (ok) {
+        onCancel();
+      } else {
+        setError(t('recurring.add_failed'));
+      }
       return ok;
     } finally {
       setSubmitting(false);
@@ -166,6 +171,12 @@ export function MealEntryForm({
       </header>
 
       <RecurringMealsBlock mealType={mealType} onQuickAdd={handleQuickAdd} onEdit={handleEditPrefill} />
+
+      {error && (
+        <p className="text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
 
       <div className="flex gap-1 p-1 rounded-xl bg-surface border border-divider w-full">
         {modes.map((m) => (
@@ -296,7 +307,6 @@ export function MealEntryForm({
               className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
             />
           </div>
-          {error && <p className="text-xs text-red-400">{error}</p>}
           <div className="flex gap-2">
             <button
               type="button"
@@ -323,7 +333,6 @@ export function MealEntryForm({
             onPortionChange={setPortionGrams}
             scaledCalories={scaledCalories}
           />
-          {error && <p className="text-xs text-red-400">{error}</p>}
           <div className="flex gap-2">
             <button
               type="button"

--- a/src/components/nutrition/RecurringMealsBlock.tsx
+++ b/src/components/nutrition/RecurringMealsBlock.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRecurringMeals } from '../../hooks/useRecurringMeals.ts';
 import type { MealLogInsert, MealType } from '../../types/nutrition.ts';
@@ -58,14 +58,14 @@ export function RecurringMealsBlock({ mealType, onQuickAdd, onEdit }: RecurringM
       <h3 id="recurring-meals-heading" className="text-xs font-medium text-body">
         {t('recurring.heading')}
       </h3>
-      <ul className="flex gap-2 overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 pb-1 snap-x snap-mandatory">
+      <ul className="flex gap-2 overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 pb-1">
         {items.map((meal) => (
-          <li key={meal.signature} className="snap-start shrink-0 w-44">
-            <article className="relative h-full flex flex-col rounded-xl bg-surface-card border border-divider p-3">
+          <li key={meal.signature} className="shrink-0 w-44">
+            <div className="relative h-full rounded-xl bg-surface-card border border-divider">
               <button
                 type="button"
                 onClick={() => onQuickAdd(toMealLogInsert(meal, mealType))}
-                className="flex-1 text-left -m-3 p-3 pb-1 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                className="w-full h-full flex flex-col text-left p-3 pr-9 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                 aria-label={t('recurring.quick_add_aria', { name: meal.name })}
               >
                 <p className="text-sm font-medium text-heading line-clamp-2 leading-snug">{meal.name}</p>
@@ -73,31 +73,19 @@ export function RecurringMealsBlock({ mealType, onQuickAdd, onEdit }: RecurringM
                   {Math.round(meal.calories)} kcal
                   {meal.quantity_grams != null && ` · ${Math.round(meal.quantity_grams)} g`}
                 </p>
-              </button>
-              <div className="mt-2 flex items-center justify-between gap-2">
-                <span className="text-[10px] uppercase tracking-wider text-muted">
+                <span className="mt-2 text-[10px] uppercase tracking-wider text-muted">
                   {t('recurring.count', { count: meal.count })}
                 </span>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => onEdit(toPrefill(meal))}
-                    aria-label={t('recurring.edit_aria', { name: meal.name })}
-                    className="p-1.5 rounded-lg text-muted hover:text-heading hover:bg-divider transition-colors"
-                  >
-                    <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onQuickAdd(toMealLogInsert(meal, mealType))}
-                    aria-label={t('recurring.quick_add_aria', { name: meal.name })}
-                    className="p-1.5 rounded-lg text-white bg-brand hover:opacity-90 transition-opacity"
-                  >
-                    <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-                  </button>
-                </div>
-              </div>
-            </article>
+              </button>
+              <button
+                type="button"
+                onClick={() => onEdit(toPrefill(meal))}
+                aria-label={t('recurring.edit_aria', { name: meal.name })}
+                className="absolute top-2 right-2 p-1.5 rounded-lg text-muted hover:text-heading hover:bg-divider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              >
+                <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/components/nutrition/RecurringMealsBlock.tsx
+++ b/src/components/nutrition/RecurringMealsBlock.tsx
@@ -1,0 +1,106 @@
+import { Pencil, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useRecurringMeals } from '../../hooks/useRecurringMeals.ts';
+import type { MealLogInsert, MealType } from '../../types/nutrition.ts';
+import type { RecurringMeal } from '../../utils/recurringMeals.ts';
+
+export type RecurringMealPrefill = {
+  name: string;
+  calories: string;
+  protein: string;
+  carbs: string;
+  fat: string;
+};
+
+export interface RecurringMealsBlockProps {
+  mealType: MealType;
+  /** Called when the user taps a card to add it as-is. */
+  onQuickAdd: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
+  /** Called when the user taps the edit pencil to tweak before adding. */
+  onEdit: (prefill: RecurringMealPrefill) => void;
+}
+
+function toMealLogInsert(meal: RecurringMeal, mealType: MealType): Omit<MealLogInsert, 'user_id' | 'logged_date'> {
+  return {
+    meal_type: mealType,
+    source: meal.source,
+    name: meal.name,
+    calories: meal.calories,
+    protein_g: meal.protein_g,
+    carbs_g: meal.carbs_g,
+    fat_g: meal.fat_g,
+    quantity_grams: meal.quantity_grams,
+    reference_id: meal.reference_id,
+    ai_metadata: null,
+    notes: null,
+  };
+}
+
+function toPrefill(meal: RecurringMeal): RecurringMealPrefill {
+  const macro = (v: number | null) => (v != null ? String(v) : '');
+  return {
+    name: meal.name,
+    calories: String(Math.round(meal.calories)),
+    protein: macro(meal.protein_g),
+    carbs: macro(meal.carbs_g),
+    fat: macro(meal.fat_g),
+  };
+}
+
+export function RecurringMealsBlock({ mealType, onQuickAdd, onEdit }: RecurringMealsBlockProps) {
+  const { t } = useTranslation('nutrition');
+  const { items, loading } = useRecurringMeals(mealType);
+
+  if (loading || items.length === 0) return null;
+
+  return (
+    <section aria-labelledby="recurring-meals-heading" className="space-y-2">
+      <h3 id="recurring-meals-heading" className="text-xs font-medium text-body">
+        {t('recurring.heading')}
+      </h3>
+      <ul className="flex gap-2 overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 pb-1 snap-x snap-mandatory">
+        {items.map((meal) => (
+          <li key={meal.signature} className="snap-start shrink-0 w-44">
+            <article className="relative h-full flex flex-col rounded-xl bg-surface-card border border-divider p-3">
+              <button
+                type="button"
+                onClick={() => onQuickAdd(toMealLogInsert(meal, mealType))}
+                className="flex-1 text-left -m-3 p-3 pb-1 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                aria-label={t('recurring.quick_add_aria', { name: meal.name })}
+              >
+                <p className="text-sm font-medium text-heading line-clamp-2 leading-snug">{meal.name}</p>
+                <p className="mt-1 text-[11px] text-muted">
+                  {Math.round(meal.calories)} kcal
+                  {meal.quantity_grams != null && ` · ${Math.round(meal.quantity_grams)} g`}
+                </p>
+              </button>
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <span className="text-[10px] uppercase tracking-wider text-muted">
+                  {t('recurring.count', { count: meal.count })}
+                </span>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => onEdit(toPrefill(meal))}
+                    aria-label={t('recurring.edit_aria', { name: meal.name })}
+                    className="p-1.5 rounded-lg text-muted hover:text-heading hover:bg-divider transition-colors"
+                  >
+                    <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onQuickAdd(toMealLogInsert(meal, mealType))}
+                    aria-label={t('recurring.quick_add_aria', { name: meal.name })}
+                    className="p-1.5 rounded-lg text-white bg-brand hover:opacity-90 transition-opacity"
+                  >
+                    <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                </div>
+              </div>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -114,6 +114,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
           (prev) => ({ logs: [...(prev?.logs ?? []), inserted], error: null }),
         );
         queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
+        queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
         return inserted;
       } finally {
         inflightRef.current = false;
@@ -140,6 +141,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         (prev) => ({ logs: (prev?.logs ?? []).filter((l) => l.id !== id), error: null }),
       );
       queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
+      queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
       return true;
     },
     [userId, dateKey, queryClient],

--- a/src/hooks/useRecurringMeals.ts
+++ b/src/hooks/useRecurringMeals.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type { MealLog, MealType } from '../types/nutrition.ts';
+import { shiftYYYYMMDD, todayYYYYMMDD } from '../utils/nutritionDate.ts';
+import { buildRecurringMeals, type RecurringMeal } from '../utils/recurringMeals.ts';
+
+const WINDOW_DAYS = 30;
+
+export interface UseRecurringMealsResult {
+  items: RecurringMeal[];
+  loading: boolean;
+}
+
+export function useRecurringMeals(mealType: MealType): UseRecurringMealsResult {
+  const { user } = useAuth();
+  const userId = user?.id;
+  const today = todayYYYYMMDD();
+  const since = shiftYYYYMMDD(today, -WINDOW_DAYS) ?? today;
+
+  const query = useQuery<MealLog[]>({
+    queryKey: ['recurringMeals', userId ?? null, mealType, since],
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('meal_logs')
+          .select('*')
+          .eq('user_id', userId!)
+          .eq('meal_type', mealType)
+          .gte('logged_date', since)
+          .order('logged_date', { ascending: false })
+          .limit(200),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return [];
+      }
+      if (err) return [];
+      return (data ?? []) as MealLog[];
+    },
+    enabled: !!userId && !!supabase,
+    staleTime: 60_000,
+  });
+
+  const items = useMemo(() => buildRecurringMeals(query.data ?? []), [query.data]);
+
+  return { items, loading: query.isPending };
+}

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -131,7 +131,8 @@
     "count_one": "{{count}}× this month",
     "count_other": "{{count}}× this month",
     "quick_add_aria": "Add {{name}}",
-    "edit_aria": "Edit before adding {{name}}"
+    "edit_aria": "Edit before adding {{name}}",
+    "add_failed": "Add failed. Check your connection and try again."
   },
   "meal_form": {
     "heading": "Add a meal",

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -126,6 +126,13 @@
     "source_barcode": "Barcode",
     "source_ai": "AI"
   },
+  "recurring": {
+    "heading": "Quick add",
+    "count_one": "{{count}}× this month",
+    "count_other": "{{count}}× this month",
+    "quick_add_aria": "Add {{name}}",
+    "edit_aria": "Edit before adding {{name}}"
+  },
   "meal_form": {
     "heading": "Add a meal",
     "close_aria": "Close",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -131,7 +131,8 @@
     "count_one": "{{count}}× ce mois-ci",
     "count_other": "{{count}}× ce mois-ci",
     "quick_add_aria": "Ajouter {{name}}",
-    "edit_aria": "Modifier avant d'ajouter {{name}}"
+    "edit_aria": "Modifier avant d'ajouter {{name}}",
+    "add_failed": "L'ajout a échoué. Vérifie ta connexion puis réessaie."
   },
   "meal_form": {
     "heading": "Ajouter un repas",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -126,6 +126,13 @@
     "source_barcode": "Code-barres",
     "source_ai": "IA"
   },
+  "recurring": {
+    "heading": "À réutiliser",
+    "count_one": "{{count}}× ce mois-ci",
+    "count_other": "{{count}}× ce mois-ci",
+    "quick_add_aria": "Ajouter {{name}}",
+    "edit_aria": "Modifier avant d'ajouter {{name}}"
+  },
   "meal_form": {
     "heading": "Ajouter un repas",
     "close_aria": "Fermer",

--- a/src/utils/recurringMeals.test.ts
+++ b/src/utils/recurringMeals.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { MealLog } from '../types/nutrition.ts';
+import { buildRecurringMeals } from './recurringMeals.ts';
+
+const NOW = new Date(2026, 4, 1); // 2026-05-01 local
+
+function makeLog(overrides: Partial<MealLog> = {}): MealLog {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    user_id: 'u1',
+    logged_date: '20260501',
+    meal_type: 'breakfast',
+    source: 'manual',
+    name: 'Yaourt grec',
+    calories: 180,
+    protein_g: 18,
+    carbs_g: 8,
+    fat_g: 6,
+    quantity_grams: 200,
+    reference_id: null,
+    ai_metadata: null,
+    notes: null,
+    created_at: '2026-05-01T07:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildRecurringMeals', () => {
+  it('returns nothing when an item appears only once', () => {
+    const result = buildRecurringMeals([makeLog()], { now: NOW });
+    expect(result).toEqual([]);
+  });
+
+  it('keeps items that appear at least twice', () => {
+    const logs = [makeLog({ logged_date: '20260501' }), makeLog({ logged_date: '20260428' })];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    expect(result[0].name).toBe('Yaourt grec');
+  });
+
+  it('groups by reference_id when present, regardless of name', () => {
+    const logs = [
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt grec', logged_date: '20260501' }),
+      // Same reference, different display name (e.g. user edited it once)
+      makeLog({ reference_id: 'ciqual:42', name: 'YAOURT GREC NATURE', logged_date: '20260425' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    // Latest occurrence wins for the displayed name
+    expect(result[0].name).toBe('Yaourt grec');
+  });
+
+  it('groups by normalized name when reference_id is missing', () => {
+    const logs = [
+      makeLog({ reference_id: null, name: '  Yaourt Grec  ', logged_date: '20260501' }),
+      makeLog({ reference_id: null, name: 'yaourt grec', logged_date: '20260420' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+  });
+
+  it('does not collapse different reference_ids that share a name', () => {
+    const logs = [
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt', logged_date: '20260501' }),
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt', logged_date: '20260425' }),
+      makeLog({ reference_id: 'off:123', name: 'Yaourt', logged_date: '20260430' }),
+      makeLog({ reference_id: 'off:123', name: 'Yaourt', logged_date: '20260420' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses the latest occurrence values (name + quantity) for display', () => {
+    const logs = [
+      makeLog({ name: 'flocons avoine', quantity_grams: 60, calories: 230, logged_date: '20260420' }),
+      makeLog({ name: 'flocons avoine', quantity_grams: 80, calories: 305, logged_date: '20260430' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result[0].quantity_grams).toBe(80);
+    expect(result[0].calories).toBe(305);
+  });
+
+  it('orders by frequency, then recency', () => {
+    const logs = [
+      // A: 2 occurrences, last = 2026-04-15 (older)
+      makeLog({ name: 'A', logged_date: '20260415' }),
+      makeLog({ name: 'A', logged_date: '20260410' }),
+      // B: 4 occurrences, last = 2026-04-10
+      makeLog({ name: 'B', logged_date: '20260410' }),
+      makeLog({ name: 'B', logged_date: '20260408' }),
+      makeLog({ name: 'B', logged_date: '20260405' }),
+      makeLog({ name: 'B', logged_date: '20260403' }),
+      // C: 2 occurrences, last = 2026-04-30 (most recent)
+      makeLog({ name: 'C', logged_date: '20260430' }),
+      makeLog({ name: 'C', logged_date: '20260425' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    // B wins on count, then C beats A on recency despite same count.
+    expect(result.map((r) => r.name)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('caps the result at the requested limit', () => {
+    const names = ['A', 'B', 'C', 'D', 'E'];
+    const logs = names.flatMap((n) => [makeLog({ name: n }), makeLog({ name: n })]);
+    expect(buildRecurringMeals(logs, { now: NOW, limit: 3 })).toHaveLength(3);
+    expect(buildRecurringMeals(logs, { now: NOW, limit: 1 })).toHaveLength(1);
+  });
+
+  it('ignores meal_type filtering — caller must pre-filter', () => {
+    // Sanity check: the util does not look at meal_type. The hook is in
+    // charge of querying only the relevant meal_type. If a future caller
+    // forgets, this test documents the contract.
+    const logs = [
+      makeLog({ meal_type: 'breakfast', name: 'X', logged_date: '20260501' }),
+      makeLog({ meal_type: 'dinner', name: 'X', logged_date: '20260430' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+  });
+});

--- a/src/utils/recurringMeals.ts
+++ b/src/utils/recurringMeals.ts
@@ -1,0 +1,88 @@
+import type { MealLog, MealSource } from '../types/nutrition.ts';
+import { parseYYYYMMDD } from './nutritionDate.ts';
+
+export type RecurringMeal = {
+  /** Stable group key, used as React key. */
+  signature: string;
+  name: string;
+  calories: number;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  quantity_grams: number | null;
+  source: MealSource;
+  reference_id: string | null;
+  count: number;
+  /** YYYYMMDD of the most recent occurrence in the window. */
+  lastUsedAt: string;
+};
+
+const WINDOW_DAYS = 30;
+const MIN_OCCURRENCES = 2;
+const RECENCY_WEIGHT = 0.5;
+
+function buildSignature(log: MealLog): string {
+  if (log.reference_id) return `ref:${log.reference_id}`;
+  const normalized = log.name.trim().toLowerCase();
+  return `name:${normalized}`;
+}
+
+function dateDistance(fromYYYYMMDD: string, today: Date): number {
+  const parsed = parseYYYYMMDD(fromYYYYMMDD);
+  if (!parsed) return WINDOW_DAYS;
+  const start = new Date(today);
+  start.setHours(0, 0, 0, 0);
+  return Math.max(0, Math.round((start.getTime() - parsed.getTime()) / 86_400_000));
+}
+
+export interface BuildRecurringMealsOptions {
+  /** Defaults to 3. */
+  limit?: number;
+  /** Defaults to today. Injected for deterministic tests. */
+  now?: Date;
+}
+
+export function buildRecurringMeals(logs: MealLog[], options: BuildRecurringMealsOptions = {}): RecurringMeal[] {
+  const { limit = 3, now = new Date() } = options;
+  const groups = new Map<string, MealLog[]>();
+  for (const log of logs) {
+    const sig = buildSignature(log);
+    const list = groups.get(sig);
+    if (list) list.push(log);
+    else groups.set(sig, [log]);
+  }
+
+  const candidates: Array<RecurringMeal & { score: number }> = [];
+  for (const [signature, items] of groups) {
+    if (items.length < MIN_OCCURRENCES) continue;
+    // Most recent occurrence drives the displayed values (last used name,
+    // last used quantity) — the user is likely to want what they had last
+    // time, not an average across the window.
+    const sorted = [...items].sort((a, b) => (a.logged_date < b.logged_date ? 1 : -1));
+    const latest = sorted[0];
+    const distance = dateDistance(latest.logged_date, now);
+    const recencyScore = 1 - Math.min(distance, WINDOW_DAYS) / WINDOW_DAYS;
+    const score = items.length + RECENCY_WEIGHT * recencyScore;
+    candidates.push({
+      signature,
+      name: latest.name,
+      calories: latest.calories,
+      protein_g: latest.protein_g,
+      carbs_g: latest.carbs_g,
+      fat_g: latest.fat_g,
+      quantity_grams: latest.quantity_grams,
+      source: latest.source,
+      reference_id: latest.reference_id,
+      count: items.length,
+      lastUsedAt: latest.logged_date,
+      score,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.lastUsedAt < b.lastUsedAt ? 1 : -1;
+  });
+
+  return candidates.slice(0, limit).map(({ score: _score, ...rest }) => rest);
+}


### PR DESCRIPTION
## Summary
Reduce friction when logging the same meals over and over. Opening the entry modal now surfaces up to **3 horizontally-scrolling cards** with what the user has eaten most often for that meal type over the last 30 days.

- **Tap the card** = quick add, modal closes, optimistic update lands the meal in `DailyFeed`. Undo is the standard ✕ button on the resulting `MealCard` — no new toast system needed.
- **Tap ✏️** = prefill the manual tab so the user can adjust before adding.

## Implementation (Phase 1, no new table)
- `src/utils/recurringMeals.ts` — pure logic. Groups `meal_logs` by `reference_id` (CIQUAL/OFF) or normalized name; scores each group by `count + 0.5 × recency`; requires ≥ 2 occurrences in the 30-day window so first-time users see no noisy block.
- `src/hooks/useRecurringMeals.ts` — React Query, scoped to user × mealType × window-start, 60 s `staleTime`.
- `src/components/nutrition/RecurringMealsBlock.tsx` — horizontal scroll cards with the latest used name + kcal + quantity + occurrence count.
- `MealEntryForm` — block sits between the header and the tab row; renders nothing when loading or empty.
- `useDailyNutrition.addMeal/deleteMeal` — invalidate the `recurringMeals` cache so the "X× this month" counter reflects the live state.

## Review feedback already addressed
- Removed the redundant "+" button on each card (was a duplicate `aria-label` against the clickable card → WCAG violation)
- Added an explicit error message when quick add fails (was failing silently)
- Centralized the error display so manual/search panes no longer duplicate it
- Dropped `snap-mandatory` to avoid touch-axis conflicts with the modal's vertical scroll on iOS Safari

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run check:i18n` — 16 namespaces, 2035 keys aligned
- [x] `npm test` — 344/344 green (incl. 9 new tests for grouping/scoring)
- [x] `npm run build` — clean
- [ ] Manual recipe (375px mobile + desktop): log the same meal twice on different days → reopen the modal → block appears with that meal → tap the card adds it instantly and the modal closes → counter on next open shows the bumped count → tap ✏️ → manual tab is prefilled and focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)