### PR TITLE
release: meal entry modal rework + recurring meals quick add

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -183,10 +183,10 @@ export function NutritionPage() {
               aria-modal="true"
               aria-label={t('page.add_meal_modal_aria')}
               tabIndex={-1}
-              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-6 shadow-xl focus:outline-none"
+              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-6 shadow-xl focus:outline-none"
             >
               <MealEntryForm
-                initialMealType={initialMealType}
+                mealType={initialMealType}
                 isPremium={isPremium}
                 onSubmit={handleSubmit}
                 onSearchSelect={handleSearchSelect}

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -1,7 +1,6 @@
 import { X } from 'lucide-react';
 import { type FormEvent, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { MEAL_TYPES } from '../../config/nutrition.ts';
 import type { OpenFoodFactsProduct } from '../../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../../types/nutrition.ts';
 import { AiTextPane } from './AiTextPane.tsx';
@@ -11,12 +10,12 @@ import { FoodSearchInput } from './FoodSearchInput.tsx';
 type Mode = 'manual' | 'search' | 'barcode' | 'ai';
 
 interface MealEntryFormProps {
-  initialMealType: MealType;
+  mealType: MealType;
   isPremium: boolean;
   onSubmit: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
   onCancel: () => void;
-  onSearchSelect?: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
-  onBarcodeSelect?: (product: OpenFoodFactsProduct, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+  onSearchSelect: (food: FoodReference, quantityGrams: number, mealType: MealType) => Promise<boolean>;
+  onBarcodeSelect: (product: OpenFoodFactsProduct, quantityGrams: number, mealType: MealType) => Promise<boolean>;
 }
 
 function parseMacro(raw: string): number | null {
@@ -33,7 +32,7 @@ function scaleByPortion(per100g: number | null | undefined, grams: number): numb
 }
 
 export function MealEntryForm({
-  initialMealType,
+  mealType,
   isPremium,
   onSubmit,
   onCancel,
@@ -41,9 +40,9 @@ export function MealEntryForm({
   onBarcodeSelect,
 }: MealEntryFormProps) {
   const { t } = useTranslation('nutrition');
-  const [mode, setMode] = useState<Mode>('manual');
-  const modes: Mode[] = isPremium ? ['manual', 'search', 'barcode', 'ai'] : ['manual', 'search', 'barcode'];
-  const [mealType, setMealType] = useState<MealType>(initialMealType);
+  const modes: Mode[] = isPremium ? ['barcode', 'search', 'ai', 'manual'] : ['barcode', 'search', 'manual'];
+  const [mode, setMode] = useState<Mode>('barcode');
+  const safeMode = modes.includes(mode) ? mode : modes[0];
   const [name, setName] = useState('');
   const [calories, setCalories] = useState('');
   const [protein, setProtein] = useState('');
@@ -114,10 +113,8 @@ export function MealEntryForm({
     }
     setSubmitting(true);
     try {
-      if (onSearchSelect) {
-        const ok = await onSearchSelect(selectedFood, grams, mealType);
-        if (ok) onCancel();
-      }
+      const ok = await onSearchSelect(selectedFood, grams, mealType);
+      if (ok) onCancel();
     } finally {
       setSubmitting(false);
     }
@@ -129,12 +126,15 @@ export function MealEntryForm({
 
   return (
     <div className="space-y-4">
-      <header className="flex items-center justify-between">
-        <h2 className="font-display text-lg font-bold text-heading">{t('meal_form.heading')}</h2>
+      <header className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="font-display text-lg font-bold text-heading">{t('meal_form.heading')}</h2>
+          <p className="mt-0.5 text-xs text-muted">{t(`meal_type.${mealType}`)}</p>
+        </div>
         <button
           type="button"
           onClick={onCancel}
-          className="p-2 rounded-lg text-muted hover:text-heading hover:bg-divider"
+          className="-mr-2 -mt-2 p-2 rounded-lg text-muted hover:text-heading hover:bg-divider shrink-0"
           aria-label={t('meal_form.close_aria')}
         >
           <X className="w-4 h-4" />
@@ -150,9 +150,9 @@ export function MealEntryForm({
               setMode(m);
               setError(null);
             }}
-            aria-pressed={mode === m}
+            aria-pressed={safeMode === m}
             className={`flex-1 min-w-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap truncate ${
-              mode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
+              safeMode === m ? 'bg-brand text-white' : 'text-body hover:text-heading'
             }`}
           >
             {t(`meal_form.mode_${m}`)}
@@ -160,46 +160,24 @@ export function MealEntryForm({
         ))}
       </div>
 
-      <fieldset>
-        <legend className="block text-xs font-medium text-body mb-1">{t('meal_form.meal_legend')}</legend>
-        <div className="flex flex-wrap gap-1.5">
-          {MEAL_TYPES.map((mt) => (
-            <button
-              key={mt}
-              type="button"
-              onClick={() => setMealType(mt)}
-              aria-pressed={mealType === mt}
-              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                mealType === mt ? 'bg-brand text-white' : 'bg-surface border border-divider text-body'
-              }`}
-            >
-              {t(`meal_type.${mt}`)}
-            </button>
-          ))}
-        </div>
-      </fieldset>
-
-      {mode === 'ai' ? (
+      {safeMode === 'ai' ? (
         <AiTextPane mealType={mealType} onSubmit={onSubmit} onCancel={onCancel} />
-      ) : mode === 'barcode' ? (
+      ) : safeMode === 'barcode' ? (
         <BarcodePane
           mealType={mealType}
           onCancel={onCancel}
           onSubmit={async (product, grams) => {
             setSubmitting(true);
             try {
-              if (onBarcodeSelect) {
-                const ok = await onBarcodeSelect(product, grams, mealType);
-                if (ok) onCancel();
-                return ok;
-              }
-              return false;
+              const ok = await onBarcodeSelect(product, grams, mealType);
+              if (ok) onCancel();
+              return ok;
             } finally {
               setSubmitting(false);
             }
           }}
         />
-      ) : mode === 'manual' ? (
+      ) : safeMode === 'manual' ? (
         <form onSubmit={handleManualSubmit} className="space-y-3">
           <div>
             <label htmlFor="meal-name" className="block text-xs font-medium text-body mb-1">

--- a/src/components/nutrition/MealEntryForm.tsx
+++ b/src/components/nutrition/MealEntryForm.tsx
@@ -6,6 +6,7 @@ import type { FoodReference, MealLogInsert, MealType } from '../../types/nutriti
 import { AiTextPane } from './AiTextPane.tsx';
 import { BarcodePane } from './BarcodePane.tsx';
 import { FoodSearchInput } from './FoodSearchInput.tsx';
+import { type RecurringMealPrefill, RecurringMealsBlock } from './RecurringMealsBlock.tsx';
 
 type Mode = 'manual' | 'search' | 'barcode' | 'ai';
 
@@ -124,6 +125,34 @@ export function MealEntryForm({
     ? scaleByPortion(selectedFood.calories_100g, Number.parseFloat(portionGrams) || 0)
     : null;
 
+  async function handleQuickAdd(input: Omit<MealLogInsert, 'user_id' | 'logged_date'>): Promise<boolean> {
+    if (submitting) return false;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const ok = await onSubmit(input);
+      if (ok) {
+        onCancel();
+      } else {
+        setError(t('recurring.add_failed'));
+      }
+      return ok;
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleEditPrefill(prefill: RecurringMealPrefill) {
+    setName(prefill.name);
+    setCalories(prefill.calories);
+    setProtein(prefill.protein);
+    setCarbs(prefill.carbs);
+    setFat(prefill.fat);
+    setNotes('');
+    setError(null);
+    setMode('manual');
+  }
+
   return (
     <div className="space-y-4">
       <header className="flex items-start justify-between gap-2">
@@ -140,6 +169,14 @@ export function MealEntryForm({
           <X className="w-4 h-4" />
         </button>
       </header>
+
+      <RecurringMealsBlock mealType={mealType} onQuickAdd={handleQuickAdd} onEdit={handleEditPrefill} />
+
+      {error && (
+        <p className="text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
 
       <div className="flex gap-1 p-1 rounded-xl bg-surface border border-divider w-full">
         {modes.map((m) => (
@@ -270,7 +307,6 @@ export function MealEntryForm({
               className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-sm text-heading placeholder:text-muted focus:outline-none focus:border-brand"
             />
           </div>
-          {error && <p className="text-xs text-red-400">{error}</p>}
           <div className="flex gap-2">
             <button
               type="button"
@@ -297,7 +333,6 @@ export function MealEntryForm({
             onPortionChange={setPortionGrams}
             scaledCalories={scaledCalories}
           />
-          {error && <p className="text-xs text-red-400">{error}</p>}
           <div className="flex gap-2">
             <button
               type="button"

--- a/src/components/nutrition/RecurringMealsBlock.tsx
+++ b/src/components/nutrition/RecurringMealsBlock.tsx
@@ -1,0 +1,94 @@
+import { Pencil } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useRecurringMeals } from '../../hooks/useRecurringMeals.ts';
+import type { MealLogInsert, MealType } from '../../types/nutrition.ts';
+import type { RecurringMeal } from '../../utils/recurringMeals.ts';
+
+export type RecurringMealPrefill = {
+  name: string;
+  calories: string;
+  protein: string;
+  carbs: string;
+  fat: string;
+};
+
+export interface RecurringMealsBlockProps {
+  mealType: MealType;
+  /** Called when the user taps a card to add it as-is. */
+  onQuickAdd: (input: Omit<MealLogInsert, 'user_id' | 'logged_date'>) => Promise<boolean>;
+  /** Called when the user taps the edit pencil to tweak before adding. */
+  onEdit: (prefill: RecurringMealPrefill) => void;
+}
+
+function toMealLogInsert(meal: RecurringMeal, mealType: MealType): Omit<MealLogInsert, 'user_id' | 'logged_date'> {
+  return {
+    meal_type: mealType,
+    source: meal.source,
+    name: meal.name,
+    calories: meal.calories,
+    protein_g: meal.protein_g,
+    carbs_g: meal.carbs_g,
+    fat_g: meal.fat_g,
+    quantity_grams: meal.quantity_grams,
+    reference_id: meal.reference_id,
+    ai_metadata: null,
+    notes: null,
+  };
+}
+
+function toPrefill(meal: RecurringMeal): RecurringMealPrefill {
+  const macro = (v: number | null) => (v != null ? String(v) : '');
+  return {
+    name: meal.name,
+    calories: String(Math.round(meal.calories)),
+    protein: macro(meal.protein_g),
+    carbs: macro(meal.carbs_g),
+    fat: macro(meal.fat_g),
+  };
+}
+
+export function RecurringMealsBlock({ mealType, onQuickAdd, onEdit }: RecurringMealsBlockProps) {
+  const { t } = useTranslation('nutrition');
+  const { items, loading } = useRecurringMeals(mealType);
+
+  if (loading || items.length === 0) return null;
+
+  return (
+    <section aria-labelledby="recurring-meals-heading" className="space-y-2">
+      <h3 id="recurring-meals-heading" className="text-xs font-medium text-body">
+        {t('recurring.heading')}
+      </h3>
+      <ul className="flex gap-2 overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 pb-1">
+        {items.map((meal) => (
+          <li key={meal.signature} className="shrink-0 w-44">
+            <div className="relative h-full rounded-xl bg-surface-card border border-divider">
+              <button
+                type="button"
+                onClick={() => onQuickAdd(toMealLogInsert(meal, mealType))}
+                className="w-full h-full flex flex-col text-left p-3 pr-9 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                aria-label={t('recurring.quick_add_aria', { name: meal.name })}
+              >
+                <p className="text-sm font-medium text-heading line-clamp-2 leading-snug">{meal.name}</p>
+                <p className="mt-1 text-[11px] text-muted">
+                  {Math.round(meal.calories)} kcal
+                  {meal.quantity_grams != null && ` · ${Math.round(meal.quantity_grams)} g`}
+                </p>
+                <span className="mt-2 text-[10px] uppercase tracking-wider text-muted">
+                  {t('recurring.count', { count: meal.count })}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => onEdit(toPrefill(meal))}
+                aria-label={t('recurring.edit_aria', { name: meal.name })}
+                className="absolute top-2 right-2 p-1.5 rounded-lg text-muted hover:text-heading hover:bg-divider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              >
+                <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -114,6 +114,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
           (prev) => ({ logs: [...(prev?.logs ?? []), inserted], error: null }),
         );
         queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
+        queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
         return inserted;
       } finally {
         inflightRef.current = false;
@@ -140,6 +141,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         (prev) => ({ logs: (prev?.logs ?? []).filter((l) => l.id !== id), error: null }),
       );
       queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
+      queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
       return true;
     },
     [userId, dateKey, queryClient],

--- a/src/hooks/useRecurringMeals.ts
+++ b/src/hooks/useRecurringMeals.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type { MealLog, MealType } from '../types/nutrition.ts';
+import { shiftYYYYMMDD, todayYYYYMMDD } from '../utils/nutritionDate.ts';
+import { buildRecurringMeals, type RecurringMeal } from '../utils/recurringMeals.ts';
+
+const WINDOW_DAYS = 30;
+
+export interface UseRecurringMealsResult {
+  items: RecurringMeal[];
+  loading: boolean;
+}
+
+export function useRecurringMeals(mealType: MealType): UseRecurringMealsResult {
+  const { user } = useAuth();
+  const userId = user?.id;
+  const today = todayYYYYMMDD();
+  const since = shiftYYYYMMDD(today, -WINDOW_DAYS) ?? today;
+
+  const query = useQuery<MealLog[]>({
+    queryKey: ['recurringMeals', userId ?? null, mealType, since],
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('meal_logs')
+          .select('*')
+          .eq('user_id', userId!)
+          .eq('meal_type', mealType)
+          .gte('logged_date', since)
+          .order('logged_date', { ascending: false })
+          .limit(200),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return [];
+      }
+      if (err) return [];
+      return (data ?? []) as MealLog[];
+    },
+    enabled: !!userId && !!supabase,
+    staleTime: 60_000,
+  });
+
+  const items = useMemo(() => buildRecurringMeals(query.data ?? []), [query.data]);
+
+  return { items, loading: query.isPending };
+}

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -126,6 +126,14 @@
     "source_barcode": "Barcode",
     "source_ai": "AI"
   },
+  "recurring": {
+    "heading": "Quick add",
+    "count_one": "{{count}}× this month",
+    "count_other": "{{count}}× this month",
+    "quick_add_aria": "Add {{name}}",
+    "edit_aria": "Edit before adding {{name}}",
+    "add_failed": "Add failed. Check your connection and try again."
+  },
   "meal_form": {
     "heading": "Add a meal",
     "close_aria": "Close",

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -129,11 +129,10 @@
   "meal_form": {
     "heading": "Add a meal",
     "close_aria": "Close",
-    "mode_manual": "Manual entry",
+    "mode_manual": "Manual",
     "mode_search": "Search",
     "mode_barcode": "Scan",
     "mode_ai": "AI",
-    "meal_legend": "Meal",
     "name_label": "Meal name",
     "name_placeholder": "E.g. homemade pasta bolognese",
     "calories_label": "Calories (kcal)",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -129,11 +129,10 @@
   "meal_form": {
     "heading": "Ajouter un repas",
     "close_aria": "Fermer",
-    "mode_manual": "Saisie libre",
-    "mode_search": "Rechercher",
+    "mode_manual": "Manuel",
+    "mode_search": "Chercher",
     "mode_barcode": "Scanner",
     "mode_ai": "IA",
-    "meal_legend": "Repas",
     "name_label": "Nom du repas",
     "name_placeholder": "Ex. pâtes bolo maison",
     "calories_label": "Calories (kcal)",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -126,6 +126,14 @@
     "source_barcode": "Code-barres",
     "source_ai": "IA"
   },
+  "recurring": {
+    "heading": "À réutiliser",
+    "count_one": "{{count}}× ce mois-ci",
+    "count_other": "{{count}}× ce mois-ci",
+    "quick_add_aria": "Ajouter {{name}}",
+    "edit_aria": "Modifier avant d'ajouter {{name}}",
+    "add_failed": "L'ajout a échoué. Vérifie ta connexion puis réessaie."
+  },
   "meal_form": {
     "heading": "Ajouter un repas",
     "close_aria": "Fermer",

--- a/src/utils/recurringMeals.test.ts
+++ b/src/utils/recurringMeals.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { MealLog } from '../types/nutrition.ts';
+import { buildRecurringMeals } from './recurringMeals.ts';
+
+const NOW = new Date(2026, 4, 1); // 2026-05-01 local
+
+function makeLog(overrides: Partial<MealLog> = {}): MealLog {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    user_id: 'u1',
+    logged_date: '20260501',
+    meal_type: 'breakfast',
+    source: 'manual',
+    name: 'Yaourt grec',
+    calories: 180,
+    protein_g: 18,
+    carbs_g: 8,
+    fat_g: 6,
+    quantity_grams: 200,
+    reference_id: null,
+    ai_metadata: null,
+    notes: null,
+    created_at: '2026-05-01T07:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildRecurringMeals', () => {
+  it('returns nothing when an item appears only once', () => {
+    const result = buildRecurringMeals([makeLog()], { now: NOW });
+    expect(result).toEqual([]);
+  });
+
+  it('keeps items that appear at least twice', () => {
+    const logs = [makeLog({ logged_date: '20260501' }), makeLog({ logged_date: '20260428' })];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    expect(result[0].name).toBe('Yaourt grec');
+  });
+
+  it('groups by reference_id when present, regardless of name', () => {
+    const logs = [
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt grec', logged_date: '20260501' }),
+      // Same reference, different display name (e.g. user edited it once)
+      makeLog({ reference_id: 'ciqual:42', name: 'YAOURT GREC NATURE', logged_date: '20260425' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    // Latest occurrence wins for the displayed name
+    expect(result[0].name).toBe('Yaourt grec');
+  });
+
+  it('groups by normalized name when reference_id is missing', () => {
+    const logs = [
+      makeLog({ reference_id: null, name: '  Yaourt Grec  ', logged_date: '20260501' }),
+      makeLog({ reference_id: null, name: 'yaourt grec', logged_date: '20260420' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+  });
+
+  it('does not collapse different reference_ids that share a name', () => {
+    const logs = [
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt', logged_date: '20260501' }),
+      makeLog({ reference_id: 'ciqual:42', name: 'Yaourt', logged_date: '20260425' }),
+      makeLog({ reference_id: 'off:123', name: 'Yaourt', logged_date: '20260430' }),
+      makeLog({ reference_id: 'off:123', name: 'Yaourt', logged_date: '20260420' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses the latest occurrence values (name + quantity) for display', () => {
+    const logs = [
+      makeLog({ name: 'flocons avoine', quantity_grams: 60, calories: 230, logged_date: '20260420' }),
+      makeLog({ name: 'flocons avoine', quantity_grams: 80, calories: 305, logged_date: '20260430' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result[0].quantity_grams).toBe(80);
+    expect(result[0].calories).toBe(305);
+  });
+
+  it('orders by frequency, then recency', () => {
+    const logs = [
+      // A: 2 occurrences, last = 2026-04-15 (older)
+      makeLog({ name: 'A', logged_date: '20260415' }),
+      makeLog({ name: 'A', logged_date: '20260410' }),
+      // B: 4 occurrences, last = 2026-04-10
+      makeLog({ name: 'B', logged_date: '20260410' }),
+      makeLog({ name: 'B', logged_date: '20260408' }),
+      makeLog({ name: 'B', logged_date: '20260405' }),
+      makeLog({ name: 'B', logged_date: '20260403' }),
+      // C: 2 occurrences, last = 2026-04-30 (most recent)
+      makeLog({ name: 'C', logged_date: '20260430' }),
+      makeLog({ name: 'C', logged_date: '20260425' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    // B wins on count, then C beats A on recency despite same count.
+    expect(result.map((r) => r.name)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('caps the result at the requested limit', () => {
+    const names = ['A', 'B', 'C', 'D', 'E'];
+    const logs = names.flatMap((n) => [makeLog({ name: n }), makeLog({ name: n })]);
+    expect(buildRecurringMeals(logs, { now: NOW, limit: 3 })).toHaveLength(3);
+    expect(buildRecurringMeals(logs, { now: NOW, limit: 1 })).toHaveLength(1);
+  });
+
+  it('ignores meal_type filtering — caller must pre-filter', () => {
+    // Sanity check: the util does not look at meal_type. The hook is in
+    // charge of querying only the relevant meal_type. If a future caller
+    // forgets, this test documents the contract.
+    const logs = [
+      makeLog({ meal_type: 'breakfast', name: 'X', logged_date: '20260501' }),
+      makeLog({ meal_type: 'dinner', name: 'X', logged_date: '20260430' }),
+    ];
+    const result = buildRecurringMeals(logs, { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+  });
+});

--- a/src/utils/recurringMeals.ts
+++ b/src/utils/recurringMeals.ts
@@ -1,0 +1,88 @@
+import type { MealLog, MealSource } from '../types/nutrition.ts';
+import { parseYYYYMMDD } from './nutritionDate.ts';
+
+export type RecurringMeal = {
+  /** Stable group key, used as React key. */
+  signature: string;
+  name: string;
+  calories: number;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  quantity_grams: number | null;
+  source: MealSource;
+  reference_id: string | null;
+  count: number;
+  /** YYYYMMDD of the most recent occurrence in the window. */
+  lastUsedAt: string;
+};
+
+const WINDOW_DAYS = 30;
+const MIN_OCCURRENCES = 2;
+const RECENCY_WEIGHT = 0.5;
+
+function buildSignature(log: MealLog): string {
+  if (log.reference_id) return `ref:${log.reference_id}`;
+  const normalized = log.name.trim().toLowerCase();
+  return `name:${normalized}`;
+}
+
+function dateDistance(fromYYYYMMDD: string, today: Date): number {
+  const parsed = parseYYYYMMDD(fromYYYYMMDD);
+  if (!parsed) return WINDOW_DAYS;
+  const start = new Date(today);
+  start.setHours(0, 0, 0, 0);
+  return Math.max(0, Math.round((start.getTime() - parsed.getTime()) / 86_400_000));
+}
+
+export interface BuildRecurringMealsOptions {
+  /** Defaults to 3. */
+  limit?: number;
+  /** Defaults to today. Injected for deterministic tests. */
+  now?: Date;
+}
+
+export function buildRecurringMeals(logs: MealLog[], options: BuildRecurringMealsOptions = {}): RecurringMeal[] {
+  const { limit = 3, now = new Date() } = options;
+  const groups = new Map<string, MealLog[]>();
+  for (const log of logs) {
+    const sig = buildSignature(log);
+    const list = groups.get(sig);
+    if (list) list.push(log);
+    else groups.set(sig, [log]);
+  }
+
+  const candidates: Array<RecurringMeal & { score: number }> = [];
+  for (const [signature, items] of groups) {
+    if (items.length < MIN_OCCURRENCES) continue;
+    // Most recent occurrence drives the displayed values (last used name,
+    // last used quantity) — the user is likely to want what they had last
+    // time, not an average across the window.
+    const sorted = [...items].sort((a, b) => (a.logged_date < b.logged_date ? 1 : -1));
+    const latest = sorted[0];
+    const distance = dateDistance(latest.logged_date, now);
+    const recencyScore = 1 - Math.min(distance, WINDOW_DAYS) / WINDOW_DAYS;
+    const score = items.length + RECENCY_WEIGHT * recencyScore;
+    candidates.push({
+      signature,
+      name: latest.name,
+      calories: latest.calories,
+      protein_g: latest.protein_g,
+      carbs_g: latest.carbs_g,
+      fat_g: latest.fat_g,
+      quantity_grams: latest.quantity_grams,
+      source: latest.source,
+      reference_id: latest.reference_id,
+      count: items.length,
+      lastUsedAt: latest.logged_date,
+      score,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.lastUsedAt < b.lastUsedAt ? 1 : -1;
+  });
+
+  return candidates.slice(0, limit).map(({ score: _score, ...rest }) => rest);
+}


### PR DESCRIPTION
## Summary
Promote two PRs merged into \`develop\` today.

| PR | Description |
|---|---|
| [#158](https://github.com/ErwanViot/wanshape/pull/158) | Modal rework: scan-first tab order, in-modal meal-type selector dropped (now shown in the header subtitle), tighter mobile padding + iOS safe-area, hardened props |
| [#159](https://github.com/ErwanViot/wanshape/pull/159) | "À réutiliser" block above the tabs — surfaces up to 3 of the user's most-eaten items for the current meal type (last 30 days, ≥ 2 occurrences). Tap = quick add (closes modal, optimistic update); ✏️ = prefill the manual tab |

## Changed surface
\`\`\`
src/components/NutritionPage.tsx
src/components/nutrition/MealEntryForm.tsx
src/components/nutrition/RecurringMealsBlock.tsx           (new)
src/hooks/useDailyNutrition.ts                             (cache invalidation for recurringMeals)
src/hooks/useRecurringMeals.ts                             (new)
src/i18n/locales/{fr,en}/nutrition.json
src/utils/recurringMeals.{ts,test.ts}                      (new + 9 unit tests)
\`\`\`

## Verified on develop
- [x] Lint, tests (344/344, incl. 9 new), build, i18n (16 ns / 2035 keys aligned)
- [x] Vercel preview deployments on both PRs
- [x] Code review pass on each PR with feedback applied

## Release decisions still owed
- [ ] Manual smoke test on the develop preview (modal, quick add, edit prefill, undo via card delete)
- [ ] No DB migration shipped — pure frontend feature on top of the existing \`meal_logs\` schema
- [ ] No env var or secret change

🤖 Generated with [Claude Code](https://claude.com/claude-code)