### PR TITLE
feat(nutrition): back-dated meal entry up to 7 days

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -29,7 +29,10 @@ export function NutritionPage() {
   const isPremium = authProfile?.subscription_tier === 'premium';
   const { profile } = useNutritionProfile();
 
-  const today = todayYYYYMMDD();
+  // Lazy-init so `today` is computed once at mount, not on every render.
+  // Prevents a midnight rollover from silently re-clamping a user-chosen
+  // past date out of the now-shifted [today-7, today] window.
+  const [today] = useState(() => todayYYYYMMDD());
   const minDateKey = useMemo(() => shiftYYYYMMDD(today, -RETRO_WINDOW_DAYS) ?? today, [today]);
   const [searchParams, setSearchParams] = useSearchParams();
   // Clamp the URL-provided date into the allowed retro window so external
@@ -156,11 +159,9 @@ export function NutritionPage() {
 
         <DateSelector dateKey={dateKey} minDateKey={minDateKey} maxDateKey={today} onChange={setDateKey} />
 
-        {isPastDay && (
-          <output className="-mt-4 block text-center text-xs text-muted">
-            {t('date_selector.editing_past_notice')}
-          </output>
-        )}
+        {/* Plain paragraph (no role/live region): the notice is editorial */}
+        {/* and follows a user gesture, no need for a screen-reader announce. */}
+        {isPastDay && <p className="-mt-4 text-center text-xs text-muted">{t('date_selector.editing_past_notice')}</p>}
 
         <section className="flex flex-col sm:flex-row items-center sm:items-start gap-6 rounded-2xl bg-surface-card border border-card-border p-6">
           <div className="shrink-0">

--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -1,7 +1,7 @@
 import { Settings2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDailyNutrition } from '../hooks/useDailyNutrition.ts';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
@@ -9,10 +9,14 @@ import { useNutritionProfile } from '../hooks/useNutritionProfile.ts';
 import { useTodayInsight } from '../hooks/useTodayInsight.ts';
 import type { OpenFoodFactsProduct } from '../lib/openFoodFacts.ts';
 import type { FoodReference, MealLogInsert, MealType } from '../types/nutrition.ts';
+import { clampDateKey, shiftYYYYMMDD, todayYYYYMMDD } from '../utils/nutritionDate.ts';
 import { CalorieRing } from './nutrition/CalorieRing.tsx';
 import { DailyFeed } from './nutrition/DailyFeed.tsx';
+import { DateSelector } from './nutrition/DateSelector.tsx';
 import { InsightCard } from './nutrition/InsightCard.tsx';
 import { MealEntryForm } from './nutrition/MealEntryForm.tsx';
+
+const RETRO_WINDOW_DAYS = 7;
 
 export function NutritionPage() {
   const { t } = useTranslation('nutrition');
@@ -24,8 +28,28 @@ export function NutritionPage() {
   const { profile: authProfile } = useAuth();
   const isPremium = authProfile?.subscription_tier === 'premium';
   const { profile } = useNutritionProfile();
-  const { summary, loading, error, addMeal, deleteMeal } = useDailyNutrition();
-  const { insight, setInsight } = useTodayInsight();
+
+  const today = todayYYYYMMDD();
+  const minDateKey = useMemo(() => shiftYYYYMMDD(today, -RETRO_WINDOW_DAYS) ?? today, [today]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Clamp the URL-provided date into the allowed retro window so external
+  // links (or stale URLs) can never leak forward into the future or further
+  // back than 7 days.
+  const dateKey = clampDateKey(searchParams.get('d'), minDateKey, today);
+  const isPastDay = dateKey !== today;
+
+  const setDateKey = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams);
+      if (next === today) params.delete('d');
+      else params.set('d', next);
+      setSearchParams(params, { replace: true });
+    },
+    [searchParams, setSearchParams, today],
+  );
+
+  const { summary, loading, error, addMeal, deleteMeal } = useDailyNutrition(dateKey);
+  const { insight, setInsight } = useTodayInsight(dateKey);
   const [formOpen, setFormOpen] = useState(false);
   const [initialMealType, setInitialMealType] = useState<MealType>('breakfast');
   const modalRef = useRef<HTMLDivElement | null>(null);
@@ -129,6 +153,14 @@ export function NutritionPage() {
             {profile?.target_calories != null ? t('page.edit_target') : t('page.set_target')}
           </Link>
         </header>
+
+        <DateSelector dateKey={dateKey} minDateKey={minDateKey} maxDateKey={today} onChange={setDateKey} />
+
+        {isPastDay && (
+          <output className="-mt-4 block text-center text-xs text-muted">
+            {t('date_selector.editing_past_notice')}
+          </output>
+        )}
 
         <section className="flex flex-col sm:flex-row items-center sm:items-start gap-6 rounded-2xl bg-surface-card border border-card-border p-6">
           <div className="shrink-0">

--- a/src/components/nutrition/DateSelector.tsx
+++ b/src/components/nutrition/DateSelector.tsx
@@ -1,0 +1,72 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { formatDateLabel, shiftYYYYMMDD } from '../../utils/nutritionDate.ts';
+
+export interface DateSelectorProps {
+  dateKey: string;
+  minDateKey: string;
+  maxDateKey: string;
+  onChange: (next: string) => void;
+}
+
+export function DateSelector({ dateKey, minDateKey, maxDateKey, onChange }: DateSelectorProps) {
+  const { t, i18n } = useTranslation('nutrition');
+
+  const canGoPrev = dateKey > minDateKey;
+  const canGoNext = dateKey < maxDateKey;
+  const isToday = dateKey === maxDateKey;
+
+  const label = formatDateLabel(dateKey, {
+    locale: i18n.language,
+    labels: {
+      today: t('date_selector.today'),
+      yesterday: t('date_selector.yesterday'),
+      tomorrow: t('date_selector.tomorrow'),
+    },
+  });
+
+  function handlePrev() {
+    const next = shiftYYYYMMDD(dateKey, -1);
+    if (next && next >= minDateKey) onChange(next);
+  }
+
+  function handleNext() {
+    const next = shiftYYYYMMDD(dateKey, 1);
+    if (next && next <= maxDateKey) onChange(next);
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-1 rounded-xl bg-surface border border-divider p-1">
+      <button
+        type="button"
+        onClick={handlePrev}
+        disabled={!canGoPrev}
+        aria-label={t('date_selector.previous_day')}
+        className="p-2 rounded-lg text-body hover:bg-divider transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+      </button>
+      <div className="flex-1 text-center px-3 py-1 min-w-[10rem]">
+        <span className="text-sm font-semibold text-heading capitalize">{label}</span>
+        {!isToday && (
+          <button
+            type="button"
+            onClick={() => onChange(maxDateKey)}
+            className="block w-full text-[11px] text-brand hover:underline mt-0.5"
+          >
+            {t('date_selector.back_to_today')}
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={handleNext}
+        disabled={!canGoNext}
+        aria-label={t('date_selector.next_day')}
+        className="p-2 rounded-lg text-body hover:bg-divider transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronRight className="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -14,6 +14,15 @@
     "add_meal_modal_aria": "Add a meal",
     "footer_source": "Food database: ANSES — CIQUAL Table (Etalab 2.0 licence)"
   },
+  "date_selector": {
+    "today": "today",
+    "yesterday": "yesterday",
+    "tomorrow": "tomorrow",
+    "previous_day": "Previous day",
+    "next_day": "Next day",
+    "back_to_today": "Back to today",
+    "editing_past_notice": "You're editing a past day."
+  },
   "setup": {
     "title": "Calorie target · Wan2Fit",
     "description": "Set your daily calorie target without sharing your body data.",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -14,6 +14,15 @@
     "add_meal_modal_aria": "Ajouter un repas",
     "footer_source": "Base d'aliments : ANSES — Table CIQUAL (licence Etalab 2.0)"
   },
+  "date_selector": {
+    "today": "aujourd'hui",
+    "yesterday": "hier",
+    "tomorrow": "demain",
+    "previous_day": "Jour précédent",
+    "next_day": "Jour suivant",
+    "back_to_today": "Revenir à aujourd'hui",
+    "editing_past_notice": "Tu modifies une journée passée."
+  },
   "setup": {
     "title": "Cible nutritionnelle · Wan2Fit",
     "description": "Définis ta cible calorique quotidienne sans partager tes données corporelles.",

--- a/src/utils/nutritionDate.test.ts
+++ b/src/utils/nutritionDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatDateLabel, formatLocalYYYYMMDD, parseYYYYMMDD, shiftYYYYMMDD } from './nutritionDate.ts';
+import { clampDateKey, formatDateLabel, formatLocalYYYYMMDD, parseYYYYMMDD, shiftYYYYMMDD } from './nutritionDate.ts';
 
 describe('formatLocalYYYYMMDD', () => {
   it('uses local getters, not UTC', () => {
@@ -73,5 +73,40 @@ describe('formatDateLabel', () => {
   it('formats short date with provided locale', () => {
     const label = formatDateLabel('20260410', { now, locale: 'en' });
     expect(label).toMatch(/apr/i);
+  });
+});
+
+describe('clampDateKey', () => {
+  const min = '20260425';
+  const max = '20260502';
+
+  it('returns max when input is null', () => {
+    expect(clampDateKey(null, min, max)).toBe(max);
+  });
+
+  it('returns max when input is undefined', () => {
+    expect(clampDateKey(undefined, min, max)).toBe(max);
+  });
+
+  it('returns max when input is malformed', () => {
+    expect(clampDateKey('not-a-date', min, max)).toBe(max);
+    expect(clampDateKey('20261301', min, max)).toBe(max); // invalid month
+  });
+
+  it('returns max when input is in the future', () => {
+    expect(clampDateKey('20260601', min, max)).toBe(max);
+  });
+
+  it('returns max when input is older than min', () => {
+    expect(clampDateKey('20260101', min, max)).toBe(max);
+  });
+
+  it('returns the input unchanged when within window', () => {
+    expect(clampDateKey('20260428', min, max)).toBe('20260428');
+  });
+
+  it('accepts the boundaries inclusively', () => {
+    expect(clampDateKey(min, min, max)).toBe(min);
+    expect(clampDateKey(max, min, max)).toBe(max);
   });
 });

--- a/src/utils/nutritionDate.ts
+++ b/src/utils/nutritionDate.ts
@@ -29,6 +29,18 @@ export function todayYYYYMMDD(): string {
 }
 
 /**
+ * Clamps a candidate YYYYMMDD into the inclusive [min, max] window. Returns
+ * `max` (the safe default — typically today) when the input is missing,
+ * malformed, or out of bounds. Used to sanitise URL-provided retro dates
+ * so a stale or hostile link can never push writes outside the allowed window.
+ */
+export function clampDateKey(raw: string | null | undefined, min: string, max: string): string {
+  if (!raw || !parseYYYYMMDD(raw)) return max;
+  if (raw < min || raw > max) return max;
+  return raw;
+}
+
+/**
  * Shifts a YYYYMMDD string by `days` (positive or negative) in the local
  * timezone. Returns a new YYYYMMDD string, or null if the input is invalid.
  */


### PR DESCRIPTION
## Summary

Adds a date selector on `/nutrition` so users can log meals for any day in the last 7 days. Selection is mirrored in `?d=YYYYMMDD` for reload-safety and deep-linking (used by the upcoming heatmap drill in PR 2).

The underlying hooks (`useDailyNutrition`, `useTodayInsight`) were already fully date-parameterised on read and write — no schema or RLS change needed.

## Changes

- New `DateSelector` (chevrons + relative label + back-to-today)
- `NutritionPage` reads/writes `dateKey` from `?d=YYYYMMDD`, clamped to `[today-7, today]`
- `clampDateKey` utility (extracted to `nutritionDate.ts`) sanitises URL input → 8 unit tests
- Inline "you're editing a past day" notice when `dateKey != today`
- FR + EN i18n strings

## PR plan reminder

This is **PR 1/6** of the autonomous nutrition + recipes batch.

## Test plan

- [ ] On `/nutrition`, step back via the chevron — `dateKey` updates and the URL gets `?d=YYYYMMDD`
- [ ] Reload mid-edit: stays on the same day
- [ ] Stepping past J-7 is blocked (chevron disabled)
- [ ] Stepping past today is blocked (chevron disabled)
- [ ] Adding a meal while on a past day persists with the past `logged_date`
- [ ] "Back to today" link clears `?d`
- [ ] Manually pasting `?d=20991231` (out of range) silently falls back to today

🤖 Generated with [Claude Code](https://claude.com/claude-code)