### PR TITLE
feat(nutrition): /nutrition history scroll + 7d widget on /suivi

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -15,6 +15,7 @@ import { DailyFeed } from './nutrition/DailyFeed.tsx';
 import { DateSelector } from './nutrition/DateSelector.tsx';
 import { InsightCard } from './nutrition/InsightCard.tsx';
 import { MealEntryForm } from './nutrition/MealEntryForm.tsx';
+import { NutritionHistorySection } from './nutrition/NutritionHistorySection.tsx';
 
 const RETRO_WINDOW_DAYS = 7;
 
@@ -201,6 +202,8 @@ export function NutritionPage() {
         )}
 
         {error && <p className="text-sm text-red-400">{error}</p>}
+
+        <NutritionHistorySection />
 
         {formOpen && (
           <div className="fixed inset-0 z-[60] h-[100dvh] flex items-end sm:items-center justify-center p-0 sm:p-6">

--- a/src/components/auth/StatsPage.tsx
+++ b/src/components/auth/StatsPage.tsx
@@ -6,6 +6,7 @@ import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { useHistory } from '../../hooks/useHistory.ts';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import { LoadingSpinner } from '../LoadingSpinner.tsx';
+import { NutritionWidget7d } from '../nutrition/NutritionWidget7d.tsx';
 import { MetricCard } from '../stats/MetricCard.tsx';
 import { ProgramCard } from '../stats/ProgramCard.tsx';
 import { RecentSessions } from '../stats/RecentSessions.tsx';
@@ -261,6 +262,11 @@ export function StatsPage() {
           <div className="col-span-2 md:col-span-4 rounded-2xl bg-surface-card border border-divider p-5">
             <RecentSessions completions={completions} />
           </div>
+        </div>
+
+        {/* 7-day nutrition rollup — separate row to avoid breaking the bento grid above */}
+        <div className="mt-4">
+          <NutritionWidget7d />
         </div>
       </div>
     </div>

--- a/src/components/nutrition/InsightsBlock.tsx
+++ b/src/components/nutrition/InsightsBlock.tsx
@@ -15,19 +15,22 @@ export interface InsightsBlockProps {
 export function InsightsBlock({ summary, rangeDays }: InsightsBlockProps) {
   const { t } = useTranslation('nutrition');
 
-  const items: string[] = [];
+  const items: { id: string; text: string }[] = [];
   if (summary.avgCalories7d != null) {
-    items.push(t('history.avg_kcal_week', { n: summary.avgCalories7d }));
+    items.push({ id: 'avg7', text: t('history.avg_kcal_week', { n: summary.avgCalories7d }) });
   }
   if (summary.avgCaloriesRange != null) {
-    items.push(t('history.avg_kcal_range', { n: summary.avgCaloriesRange, days: rangeDays }));
+    items.push({ id: 'avgRange', text: t('history.avg_kcal_range', { n: summary.avgCaloriesRange, days: rangeDays }) });
   }
   if (summary.daysHittingTargetWeek != null && summary.daysHittingTargetWeek > 0) {
-    items.push(t('history.target_days_week', { n: summary.daysHittingTargetWeek }));
+    items.push({ id: 'targetDays', text: t('history.target_days_week', { n: summary.daysHittingTargetWeek }) });
   }
   const daysWithoutEntries = summary.days.length - summary.daysWithEntries;
   if (daysWithoutEntries > 0 && summary.daysWithEntries > 0) {
-    items.push(t('history.days_without_entry', { n: daysWithoutEntries, days: rangeDays }));
+    items.push({
+      id: 'daysWithout',
+      text: t('history.days_without_entry', { n: daysWithoutEntries, days: rangeDays }),
+    });
   }
 
   if (items.length === 0) {
@@ -36,10 +39,10 @@ export function InsightsBlock({ summary, rangeDays }: InsightsBlockProps) {
 
   return (
     <ul className="space-y-1.5 text-sm text-body">
-      {items.map((line) => (
-        <li key={line} className="flex items-start gap-2">
+      {items.map((item) => (
+        <li key={item.id} className="flex items-start gap-2">
           <span aria-hidden="true" className="mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-brand/60" />
-          <span>{line}</span>
+          <span>{item.text}</span>
         </li>
       ))}
     </ul>

--- a/src/components/nutrition/InsightsBlock.tsx
+++ b/src/components/nutrition/InsightsBlock.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+import type { NutritionRangeSummary } from '../../types/nutrition.ts';
+
+export interface InsightsBlockProps {
+  summary: NutritionRangeSummary;
+  /** Number of days the visible range spans (e.g. 30). */
+  rangeDays: number;
+}
+
+/**
+ * Factual stats only — no judgement, no streak, no goal-pressure phrasing.
+ * Items are rendered conditionally so an empty range stays silent rather
+ * than show "0 days hit your target", which would feel scolding.
+ */
+export function InsightsBlock({ summary, rangeDays }: InsightsBlockProps) {
+  const { t } = useTranslation('nutrition');
+
+  const items: string[] = [];
+  if (summary.avgCalories7d != null) {
+    items.push(t('history.avg_kcal_week', { n: summary.avgCalories7d }));
+  }
+  if (summary.avgCaloriesRange != null) {
+    items.push(t('history.avg_kcal_range', { n: summary.avgCaloriesRange, days: rangeDays }));
+  }
+  if (summary.daysHittingTargetWeek != null && summary.daysHittingTargetWeek > 0) {
+    items.push(t('history.target_days_week', { n: summary.daysHittingTargetWeek }));
+  }
+  const daysWithoutEntries = summary.days.length - summary.daysWithEntries;
+  if (daysWithoutEntries > 0 && summary.daysWithEntries > 0) {
+    items.push(t('history.days_without_entry', { n: daysWithoutEntries, days: rangeDays }));
+  }
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted">{t('history.no_insights_yet')}</p>;
+  }
+
+  return (
+    <ul className="space-y-1.5 text-sm text-body">
+      {items.map((line) => (
+        <li key={line} className="flex items-start gap-2">
+          <span aria-hidden="true" className="mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-brand/60" />
+          <span>{line}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/nutrition/MonthHeatmap.tsx
+++ b/src/components/nutrition/MonthHeatmap.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import type { DailyNutritionBrief } from '../../types/nutrition.ts';
+
+export interface MonthHeatmapProps {
+  /** Up to 30 daily briefs, oldest first. */
+  days: DailyNutritionBrief[];
+  targetCalories: number | null;
+  /** YYYYMMDD that should never link itself (typically today). */
+  todayKey: string;
+}
+
+/**
+ * Computes a Tailwind background class for a single cell. Tiers are
+ * intentionally coarse — three buckets keeps the heatmap readable on a
+ * 30-cell grid where colour is just a hint, not a metric.
+ *
+ * - No entries → muted base
+ * - Has entries, no target → neutral filled
+ * - Has entries with target: <60% / 60-100% / >100% → 3 brand tints
+ */
+function cellClass(brief: DailyNutritionBrief, target: number | null): string {
+  if (!brief.hasEntries) return 'bg-divider';
+  if (target == null) return 'bg-brand/30';
+  const pct = brief.totals.calories / target;
+  if (pct < 0.6) return 'bg-brand/20';
+  if (pct <= 1) return 'bg-brand/60';
+  return 'bg-brand/85';
+}
+
+export function MonthHeatmap({ days, targetCalories, todayKey }: MonthHeatmapProps) {
+  const { t } = useTranslation('nutrition');
+
+  return (
+    <ul aria-label={t('history.month_heading')} className="grid grid-cols-10 gap-1.5 list-none p-0">
+      {days.map((d) => {
+        const cal = Math.round(d.totals.calories);
+        const queryString = d.date === todayKey ? '' : `?d=${d.date}`;
+        const ariaLabel = d.hasEntries
+          ? t('history.cell_aria_filled', { date: d.date, calories: cal })
+          : t('history.cell_aria_empty', { date: d.date });
+
+        return (
+          <li key={d.date}>
+            <Link
+              to={`/nutrition${queryString}`}
+              aria-label={ariaLabel}
+              className={`block aspect-square rounded-md transition-colors hover:ring-2 hover:ring-brand/60 ${cellClass(d, targetCalories)}`}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/nutrition/NutritionHistorySection.tsx
+++ b/src/components/nutrition/NutritionHistorySection.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNutritionProfile } from '../../hooks/useNutritionProfile.ts';
+import { useNutritionRange } from '../../hooks/useNutritionRange.ts';
+import { shiftYYYYMMDD, todayYYYYMMDD } from '../../utils/nutritionDate.ts';
+import { InsightsBlock } from './InsightsBlock.tsx';
+import { MonthHeatmap } from './MonthHeatmap.tsx';
+import { WeekStrip } from './WeekStrip.tsx';
+
+const RANGE_DAYS = 30;
+
+/**
+ * Lazy-mounts the historical sections (week strip, monthly heatmap, insights)
+ * once the user scrolls them into view. Mirrors the IntersectionObserver
+ * pattern used by ExerciseVideo so we don't introduce a new dependency.
+ *
+ * The hook query is gated on visibility — first paint of /nutrition stays
+ * focused on the today block; the 30d range scan only fires when needed.
+ */
+export function NutritionHistorySection() {
+  const { t } = useTranslation('nutrition');
+  const { profile } = useNutritionProfile();
+  const targetCalories = profile?.target_calories ?? null;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Pin the date range at mount so a midnight rollover doesn't shift the
+  // range under us between renders.
+  const [bounds] = useState(() => {
+    const today = todayYYYYMMDD();
+    const start = shiftYYYYMMDD(today, -(RANGE_DAYS - 1)) ?? today;
+    return { startDate: start, endDate: today, today };
+  });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || isVisible) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '300px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [isVisible]);
+
+  const { summary, loading, error } = useNutritionRange(bounds.startDate, bounds.endDate, { enabled: isVisible });
+
+  return (
+    <section ref={containerRef} className="space-y-8">
+      <div className="space-y-3">
+        <h2 className="font-display text-lg font-bold text-heading">{t('history.week_heading')}</h2>
+        {!isVisible || loading ? (
+          <div className="grid grid-cols-7 gap-1.5">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div key={`week-skel-${i}`} className="skeleton aspect-[3/4] rounded-xl" />
+            ))}
+          </div>
+        ) : summary ? (
+          <WeekStrip days={summary.days.slice(-7)} targetCalories={targetCalories} todayKey={bounds.today} />
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="font-display text-lg font-bold text-heading">{t('history.month_heading')}</h2>
+        {!isVisible || loading ? (
+          <div className="grid grid-cols-10 gap-1.5">
+            {Array.from({ length: RANGE_DAYS }).map((_, i) => (
+              <div key={`month-skel-${i}`} className="skeleton aspect-square rounded-md" />
+            ))}
+          </div>
+        ) : summary ? (
+          <MonthHeatmap days={summary.days} targetCalories={targetCalories} todayKey={bounds.today} />
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="font-display text-lg font-bold text-heading">{t('history.insights_heading')}</h2>
+        {!isVisible || loading ? (
+          <div className="space-y-2">
+            <div className="skeleton h-4 w-2/3 rounded" />
+            <div className="skeleton h-4 w-1/2 rounded" />
+          </div>
+        ) : summary ? (
+          <InsightsBlock summary={summary} rangeDays={RANGE_DAYS} />
+        ) : null}
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </section>
+  );
+}

--- a/src/components/nutrition/NutritionWidget7d.tsx
+++ b/src/components/nutrition/NutritionWidget7d.tsx
@@ -12,6 +12,11 @@ const WEEK_DAYS = 7;
  * 7-day rolling nutrition widget for /suivi. Shows mini-bars sized by
  * % of calorie target (or just by absolute kcal when no target is set)
  * and a one-line average. Hidden for visitors via parent gating.
+ *
+ * No IntersectionObserver gate here, by design: on /suivi the widget
+ * lives below `RecentSessions` but is still in the user's first
+ * meaningful viewport on most devices, and the 7-day fetch is much
+ * cheaper than the 30-day one used by NutritionHistorySection.
  */
 export function NutritionWidget7d() {
   const { t } = useTranslation('nutrition');

--- a/src/components/nutrition/NutritionWidget7d.tsx
+++ b/src/components/nutrition/NutritionWidget7d.tsx
@@ -1,0 +1,75 @@
+import { Utensils } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { useNutritionProfile } from '../../hooks/useNutritionProfile.ts';
+import { useNutritionRange } from '../../hooks/useNutritionRange.ts';
+import { shiftYYYYMMDD, todayYYYYMMDD } from '../../utils/nutritionDate.ts';
+
+const WEEK_DAYS = 7;
+
+/**
+ * 7-day rolling nutrition widget for /suivi. Shows mini-bars sized by
+ * % of calorie target (or just by absolute kcal when no target is set)
+ * and a one-line average. Hidden for visitors via parent gating.
+ */
+export function NutritionWidget7d() {
+  const { t } = useTranslation('nutrition');
+  const { profile } = useNutritionProfile();
+  const targetCalories = profile?.target_calories ?? null;
+
+  const [bounds] = useState(() => {
+    const today = todayYYYYMMDD();
+    const start = shiftYYYYMMDD(today, -(WEEK_DAYS - 1)) ?? today;
+    return { startDate: start, endDate: today };
+  });
+
+  const { summary, loading } = useNutritionRange(bounds.startDate, bounds.endDate);
+
+  // Choose a denominator for the bar height: target if set, else the max
+  // observed value in the window so bars stay relative to each other.
+  const maxObserved = summary?.days.reduce((m, d) => Math.max(m, d.totals.calories), 0) ?? 0;
+  const denom = targetCalories ?? Math.max(maxObserved, 1);
+
+  return (
+    <Link
+      to="/nutrition"
+      aria-label={t('widget7d.aria')}
+      className="flex flex-col gap-3 rounded-2xl border border-card-border bg-surface-card p-5 hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10 transition-all"
+    >
+      <div className="flex items-center gap-2">
+        <Utensils className="w-4 h-4 text-brand" aria-hidden="true" />
+        <h3 className="font-display text-base font-bold text-heading">{t('widget7d.heading')}</h3>
+      </div>
+
+      {loading || !summary ? (
+        <div className="flex items-end gap-1.5 h-16">
+          {Array.from({ length: WEEK_DAYS }).map((_, i) => (
+            <div key={`bar-skel-${i}`} className="flex-1 skeleton rounded-t" style={{ height: '40%' }} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-end gap-1.5 h-16" aria-hidden="true">
+          {summary.days.map((d) => {
+            const ratio = d.hasEntries ? Math.min(1, d.totals.calories / denom) : 0;
+            const heightPct = Math.max(6, Math.round(ratio * 100));
+            return (
+              <div key={d.date} className="flex-1 flex items-end">
+                <div
+                  className={`w-full rounded-t ${d.hasEntries ? 'bg-brand/70' : 'bg-divider'}`}
+                  style={{ height: `${heightPct}%` }}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {summary?.avgCalories7d != null ? (
+        <p className="text-xs text-muted">{t('history.avg_kcal_week', { n: summary.avgCalories7d })}</p>
+      ) : (
+        <p className="text-xs text-muted">{t('widget7d.no_data')}</p>
+      )}
+    </Link>
+  );
+}

--- a/src/components/nutrition/WeekStrip.tsx
+++ b/src/components/nutrition/WeekStrip.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import type { DailyNutritionBrief } from '../../types/nutrition.ts';
+import { formatDateLabel } from '../../utils/nutritionDate.ts';
+
+export interface WeekStripProps {
+  /** Up to 7 daily briefs, oldest first. */
+  days: DailyNutritionBrief[];
+  targetCalories: number | null;
+  /** YYYYMMDD that should never link itself (typically today). */
+  todayKey: string;
+}
+
+/**
+ * Compact 7-day strip. Each cell is a Link that drills into /nutrition?d=YYYYMMDD,
+ * letting the user log meals for that day via PR 1's DateSelector.
+ */
+export function WeekStrip({ days, targetCalories, todayKey }: WeekStripProps) {
+  const { t, i18n } = useTranslation('nutrition');
+
+  return (
+    <div className="grid grid-cols-7 gap-1.5">
+      {days.map((d) => {
+        const label = formatDateLabel(d.date, {
+          locale: i18n.language,
+          labels: {
+            today: t('date_selector.today'),
+            yesterday: t('date_selector.yesterday'),
+            tomorrow: t('date_selector.tomorrow'),
+          },
+        });
+        const cal = Math.round(d.totals.calories);
+        const pct = targetCalories ? Math.min(120, Math.round((cal / targetCalories) * 100)) : null;
+        const queryString = d.date === todayKey ? '' : `?d=${d.date}`;
+        const href = `/nutrition${queryString}`;
+
+        return (
+          <Link
+            key={d.date}
+            to={href}
+            className="flex flex-col items-center gap-1 rounded-xl border border-divider bg-surface px-1.5 py-2 hover:border-brand/40 hover:bg-divider transition-colors"
+          >
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted truncate max-w-full">
+              {label}
+            </span>
+            <span className="text-sm font-bold text-heading leading-tight">{d.hasEntries ? cal : '–'}</span>
+            {pct != null && d.hasEntries && (
+              <span className="text-[10px] text-muted leading-none">{t('history.target_pct', { pct })}</span>
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/nutrition/WeekStrip.tsx
+++ b/src/components/nutrition/WeekStrip.tsx
@@ -30,14 +30,20 @@ export function WeekStrip({ days, targetCalories, todayKey }: WeekStripProps) {
           },
         });
         const cal = Math.round(d.totals.calories);
-        const pct = targetCalories ? Math.min(120, Math.round((cal / targetCalories) * 100)) : null;
+        // Show the actual percentage (no cap): the user is allowed to overshoot
+        // and lying about it would contradict the awareness philosophy.
+        const pct = targetCalories ? Math.round((cal / targetCalories) * 100) : null;
         const queryString = d.date === todayKey ? '' : `?d=${d.date}`;
         const href = `/nutrition${queryString}`;
+        const ariaLabel = d.hasEntries
+          ? t('history.cell_aria_filled', { date: d.date, calories: cal })
+          : t('history.cell_aria_empty', { date: d.date });
 
         return (
           <Link
             key={d.date}
             to={href}
+            aria-label={ariaLabel}
             className="flex flex-col items-center gap-1 rounded-xl border border-divider bg-surface px-1.5 py-2 hover:border-brand/40 hover:bg-divider transition-colors"
           >
             <span className="text-[10px] font-medium uppercase tracking-wider text-muted truncate max-w-full">

--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -115,6 +115,10 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         );
         queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
         queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
+        // Historical rollups (week strip, monthly heatmap, /suivi widget) read
+        // from a separate range query — partial-match on the prefix invalidates
+        // every cached window for this user.
+        queryClient.invalidateQueries({ queryKey: ['nutritionRange', userId] });
         return inserted;
       } finally {
         inflightRef.current = false;
@@ -142,6 +146,7 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
       );
       queryClient.invalidateQueries({ queryKey: ['todayInsight', userId] });
       queryClient.invalidateQueries({ queryKey: ['recurringMeals', userId] });
+      queryClient.invalidateQueries({ queryKey: ['nutritionRange', userId] });
       return true;
     },
     [userId, dateKey, queryClient],

--- a/src/hooks/useNutritionRange.ts
+++ b/src/hooks/useNutritionRange.ts
@@ -1,0 +1,83 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import i18n from '../i18n/index.ts';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import type { MealLog, NutritionRangeSummary } from '../types/nutrition.ts';
+import { buildRangeSummary } from '../utils/nutritionRange.ts';
+import { useNutritionProfile } from './useNutritionProfile.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
+
+export interface UseNutritionRangeResult {
+  summary: NutritionRangeSummary | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface UseNutritionRangeOptions {
+  /** Lazy gate: when false, the query stays disabled. */
+  enabled?: boolean;
+}
+
+/**
+ * Fetches all meal_logs for `[startDate, endDate]` (inclusive YYYYMMDD) and
+ * rolls them up into per-day briefs + week/range averages. Aggregation is
+ * client-side because the index `idx_meal_logs_user_date` makes range scans
+ * cheap (~450 rows max for a 30-day window) and avoids needing an RPC.
+ */
+export function useNutritionRange(
+  startDate: string,
+  endDate: string,
+  options: UseNutritionRangeOptions = {},
+): UseNutritionRangeResult {
+  const { user } = useAuth();
+  const userId = user?.id;
+  const { profile } = useNutritionProfile();
+  const target = profile?.target_calories ?? null;
+
+  const enabled = (options.enabled ?? true) && !!userId && !!supabase;
+
+  const query = useQuery<{ logs: MealLog[]; error: string | null }>({
+    queryKey: ['nutritionRange', userId ?? null, startDate, endDate],
+    queryFn: async () => {
+      const {
+        data,
+        error: err,
+        sessionExpired,
+      } = await supabaseQuery(() =>
+        supabase!
+          .from('meal_logs')
+          .select('*')
+          .eq('user_id', userId!)
+          .gte('logged_date', startDate)
+          .lte('logged_date', endDate)
+          .order('logged_date', { ascending: true }),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return { logs: [], error: null };
+      }
+      if (err) {
+        return { logs: [], error: err.message ?? tHookError('meals_load_failed') };
+      }
+      return { logs: (data ?? []) as MealLog[], error: null };
+    },
+    enabled,
+    // Historical days are effectively immutable once the day is past — bump
+    // staleTime so navigating back and forth doesn't trigger refetches.
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const summary = useMemo<NutritionRangeSummary | null>(() => {
+    if (!query.data) return null;
+    return buildRangeSummary(query.data.logs, startDate, endDate, target);
+  }, [query.data, startDate, endDate, target]);
+
+  return {
+    summary,
+    loading: query.isPending && enabled,
+    error: query.data?.error ?? null,
+  };
+}

--- a/src/i18n/locales/en/nutrition.json
+++ b/src/i18n/locales/en/nutrition.json
@@ -23,6 +23,24 @@
     "back_to_today": "Back to today",
     "editing_past_notice": "You're editing a past day."
   },
+  "history": {
+    "week_heading": "This week",
+    "month_heading": "Last 30 days",
+    "insights_heading": "At a glance",
+    "target_pct": "{{pct}}%",
+    "avg_kcal_week": "Avg kcal over 7 days: {{n}}",
+    "avg_kcal_range": "Avg kcal over {{days}} days: {{n}}",
+    "target_days_week": "Target met on {{n}} day(s) this week",
+    "days_without_entry": "{{n}} day(s) with no entry out of {{days}}",
+    "no_insights_yet": "Not enough data yet to compute stats.",
+    "cell_aria_filled": "{{date}} — {{calories}} kcal",
+    "cell_aria_empty": "{{date}} — no entry"
+  },
+  "widget7d": {
+    "heading": "Nutrition · last 7 days",
+    "aria": "Open nutrition",
+    "no_data": "No data this week yet."
+  },
   "setup": {
     "title": "Calorie target · Wan2Fit",
     "description": "Set your daily calorie target without sharing your body data.",

--- a/src/i18n/locales/fr/nutrition.json
+++ b/src/i18n/locales/fr/nutrition.json
@@ -23,6 +23,24 @@
     "back_to_today": "Revenir à aujourd'hui",
     "editing_past_notice": "Tu modifies une journée passée."
   },
+  "history": {
+    "week_heading": "Cette semaine",
+    "month_heading": "30 derniers jours",
+    "insights_heading": "En bref",
+    "target_pct": "{{pct}} %",
+    "avg_kcal_week": "Moyenne kcal sur 7 jours : {{n}}",
+    "avg_kcal_range": "Moyenne kcal sur {{days}} jours : {{n}}",
+    "target_days_week": "Cible atteinte {{n}} jour(s) cette semaine",
+    "days_without_entry": "{{n}} jour(s) sans saisie sur {{days}}",
+    "no_insights_yet": "Pas encore assez de données pour produire des stats.",
+    "cell_aria_filled": "{{date}} — {{calories}} kcal",
+    "cell_aria_empty": "{{date}} — aucune saisie"
+  },
+  "widget7d": {
+    "heading": "Nutrition · 7 derniers jours",
+    "aria": "Voir la nutrition",
+    "no_data": "Pas encore de données cette semaine."
+  },
   "setup": {
     "title": "Cible nutritionnelle · Wan2Fit",
     "description": "Définis ta cible calorique quotidienne sans partager tes données corporelles.",

--- a/src/types/nutrition.ts
+++ b/src/types/nutrition.ts
@@ -129,6 +129,32 @@ export type DailyNutritionSummary = {
   };
 };
 
+/**
+ * Lightweight per-day rollup used by historical views (7d strip, 30d heatmap).
+ * Drops `byMealType` and `target` to keep payload small over a 30-day window.
+ */
+export type DailyNutritionBrief = {
+  /** YYYYMMDD in the user's local timezone. */
+  date: string;
+  totals: DailyNutritionTotals;
+  hasEntries: boolean;
+};
+
+export type NutritionRangeSummary = {
+  /** Inclusive YYYYMMDD bounds, oldest to newest. */
+  startDate: string;
+  endDate: string;
+  /** One entry per day in [startDate, endDate], oldest first. */
+  days: DailyNutritionBrief[];
+  /** Mean calories on the most recent 7 days; null if none had entries. */
+  avgCalories7d: number | null;
+  /** Mean calories on the full window; null if none had entries. */
+  avgCaloriesRange: number | null;
+  daysWithEntries: number;
+  /** Days hitting the (non-null) calorie target on the most recent 7 days. */
+  daysHittingTargetWeek: number | null;
+};
+
 export type TextEstimate = {
   name: string;
   calories: number;

--- a/src/utils/nutritionRange.test.ts
+++ b/src/utils/nutritionRange.test.ts
@@ -105,6 +105,17 @@ describe('buildRangeSummary', () => {
     expect(summary.daysHittingTargetWeek).toBeNull();
   });
 
+  it('handles a range smaller than 7 days without crashing', () => {
+    // Defensive: if a caller ever asks for a 3-day window (e.g. a freshly
+    // created account), slice(-7) collapses to the whole window and the
+    // "week" metrics are computed over what is available, not faked.
+    const logs = [makeLog('20260501', 1500), makeLog('20260502', 2500)];
+    const summary = buildRangeSummary(logs, '20260430', '20260502', 2000);
+    expect(summary.days).toHaveLength(3);
+    expect(summary.avgCalories7d).toBe(2000); // (1500+2500)/2
+    expect(summary.daysHittingTargetWeek).toBe(1); // only 20260502 hits 2000
+  });
+
   it('daysHittingTargetWeek counts days reaching the target on the last 7 days', () => {
     const logs = [
       makeLog('20260426', 1500), // below

--- a/src/utils/nutritionRange.test.ts
+++ b/src/utils/nutritionRange.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { MealLog } from '../types/nutrition.ts';
+import { buildRangeSummary, enumerateDateRange } from './nutritionRange.ts';
+
+function makeLog(date: string, calories: number, protein = 0, carbs = 0, fat = 0): MealLog {
+  return {
+    id: `${date}-${calories}`,
+    user_id: 'u',
+    logged_date: date,
+    meal_type: 'breakfast',
+    source: 'manual',
+    name: 'test',
+    calories,
+    protein_g: protein,
+    carbs_g: carbs,
+    fat_g: fat,
+    quantity_grams: null,
+    reference_id: null,
+    ai_metadata: null,
+    notes: null,
+    created_at: '2026-05-02T00:00:00Z',
+  };
+}
+
+describe('enumerateDateRange', () => {
+  it('returns the inclusive list of YYYYMMDD between start and end', () => {
+    expect(enumerateDateRange('20260425', '20260502')).toEqual([
+      '20260425',
+      '20260426',
+      '20260427',
+      '20260428',
+      '20260429',
+      '20260430',
+      '20260501',
+      '20260502',
+    ]);
+  });
+
+  it('returns a single-element list when start === end', () => {
+    expect(enumerateDateRange('20260502', '20260502')).toEqual(['20260502']);
+  });
+
+  it('falls back to [start] when bounds are invalid', () => {
+    expect(enumerateDateRange('invalid', '20260502')).toEqual(['invalid']);
+    expect(enumerateDateRange('20260502', '20260425')).toEqual(['20260502']); // reversed
+  });
+
+  it('handles month rollover', () => {
+    expect(enumerateDateRange('20260430', '20260502')).toEqual(['20260430', '20260501', '20260502']);
+  });
+});
+
+describe('buildRangeSummary', () => {
+  it('produces an empty brief for every day, even those without logs', () => {
+    const summary = buildRangeSummary([], '20260501', '20260502', null);
+    expect(summary.days).toHaveLength(2);
+    expect(summary.days[0]).toEqual({
+      date: '20260501',
+      totals: { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
+      hasEntries: false,
+    });
+    expect(summary.daysWithEntries).toBe(0);
+    expect(summary.avgCalories7d).toBeNull();
+    expect(summary.avgCaloriesRange).toBeNull();
+  });
+
+  it('aggregates multiple logs per day', () => {
+    const logs = [makeLog('20260501', 200, 10), makeLog('20260501', 300, 5), makeLog('20260502', 400)];
+    const summary = buildRangeSummary(logs, '20260501', '20260502', null);
+    expect(summary.days[0].totals.calories).toBe(500);
+    expect(summary.days[0].totals.protein_g).toBe(15);
+    expect(summary.days[0].hasEntries).toBe(true);
+    expect(summary.days[1].totals.calories).toBe(400);
+    expect(summary.daysWithEntries).toBe(2);
+  });
+
+  it('ignores logs whose date is outside the range', () => {
+    const logs = [makeLog('20260101', 999), makeLog('20260501', 200)];
+    const summary = buildRangeSummary(logs, '20260501', '20260502', null);
+    expect(summary.days[0].totals.calories).toBe(200);
+    expect(summary.daysWithEntries).toBe(1);
+  });
+
+  it('averages calories over days that actually have entries (rounded)', () => {
+    const logs = [makeLog('20260501', 1000), makeLog('20260502', 2000)];
+    // Range has 2 days both with entries → avg = 1500
+    const summary = buildRangeSummary(logs, '20260501', '20260502', null);
+    expect(summary.avgCaloriesRange).toBe(1500);
+    expect(summary.avgCalories7d).toBe(1500);
+  });
+
+  it('avgCalories7d looks at the most recent 7 days only', () => {
+    // 10-day range, only the last 3 have entries
+    const logs = [makeLog('20260430', 1500), makeLog('20260501', 1800), makeLog('20260502', 2100)];
+    const summary = buildRangeSummary(logs, '20260423', '20260502', null);
+    expect(summary.days).toHaveLength(10);
+    // 7d window = 20260426..20260502, of which 3 days have entries
+    expect(summary.avgCalories7d).toBe(1800); // (1500+1800+2100)/3
+    expect(summary.avgCaloriesRange).toBe(1800);
+  });
+
+  it('daysHittingTargetWeek is null when no target is set', () => {
+    const logs = [makeLog('20260502', 9000)];
+    const summary = buildRangeSummary(logs, '20260501', '20260502', null);
+    expect(summary.daysHittingTargetWeek).toBeNull();
+  });
+
+  it('daysHittingTargetWeek counts days reaching the target on the last 7 days', () => {
+    const logs = [
+      makeLog('20260426', 1500), // below
+      makeLog('20260428', 2100), // above
+      makeLog('20260430', 2000), // exactly target
+      makeLog('20260502', 2500), // above
+    ];
+    const summary = buildRangeSummary(logs, '20260426', '20260502', 2000);
+    expect(summary.daysHittingTargetWeek).toBe(3);
+  });
+});

--- a/src/utils/nutritionRange.ts
+++ b/src/utils/nutritionRange.ts
@@ -1,0 +1,90 @@
+import type { DailyNutritionBrief, DailyNutritionTotals, MealLog, NutritionRangeSummary } from '../types/nutrition.ts';
+import { parseYYYYMMDD, shiftYYYYMMDD } from './nutritionDate.ts';
+
+const EMPTY_TOTALS: DailyNutritionTotals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 };
+
+function emptyBrief(date: string): DailyNutritionBrief {
+  return { date, totals: { ...EMPTY_TOTALS }, hasEntries: false };
+}
+
+function addToTotals(totals: DailyNutritionTotals, log: MealLog): DailyNutritionTotals {
+  return {
+    calories: totals.calories + (log.calories ?? 0),
+    protein_g: totals.protein_g + (log.protein_g ?? 0),
+    carbs_g: totals.carbs_g + (log.carbs_g ?? 0),
+    fat_g: totals.fat_g + (log.fat_g ?? 0),
+  };
+}
+
+/**
+ * Returns the inclusive list of YYYYMMDD between startDate and endDate.
+ * Falls back to a single-element list when bounds don't parse — the caller
+ * already validated the dates upstream, so this guard is defensive only.
+ */
+export function enumerateDateRange(startDate: string, endDate: string): string[] {
+  if (!parseYYYYMMDD(startDate) || !parseYYYYMMDD(endDate) || startDate > endDate) {
+    return [startDate];
+  }
+  const dates: string[] = [];
+  let cursor: string | null = startDate;
+  while (cursor && cursor <= endDate) {
+    dates.push(cursor);
+    cursor = shiftYYYYMMDD(cursor, 1);
+  }
+  return dates;
+}
+
+/**
+ * Rolls up raw meal_logs into per-day briefs and pre-computes the metrics
+ * the historical UI blocks need (7d / range averages, target hit count).
+ *
+ * Pure function: no React, no Supabase, fully unit-testable.
+ *
+ * - `daysHittingTargetWeek` is null when no target is set (awareness mode).
+ * - "Hitting" the target means consumed ≥ target; we don't penalise overshoot
+ *   because the philosophy is awareness, not gamification.
+ */
+export function buildRangeSummary(
+  logs: MealLog[],
+  startDate: string,
+  endDate: string,
+  targetCalories: number | null,
+): NutritionRangeSummary {
+  const allDates = enumerateDateRange(startDate, endDate);
+  const briefMap = new Map<string, DailyNutritionBrief>();
+  for (const date of allDates) briefMap.set(date, emptyBrief(date));
+
+  for (const log of logs) {
+    const brief = briefMap.get(log.logged_date);
+    if (!brief) continue; // log outside the range — defensive
+    brief.totals = addToTotals(brief.totals, log);
+    brief.hasEntries = true;
+  }
+
+  const days = Array.from(briefMap.values());
+  const daysWithEntries = days.filter((d) => d.hasEntries).length;
+
+  // Most recent 7 days = the tail of the array (we built it ascending).
+  const last7 = days.slice(-7);
+  const avgCalories7d = average(last7.filter((d) => d.hasEntries).map((d) => d.totals.calories));
+  const avgCaloriesRange = average(days.filter((d) => d.hasEntries).map((d) => d.totals.calories));
+
+  const daysHittingTargetWeek =
+    targetCalories == null ? null : last7.filter((d) => d.hasEntries && d.totals.calories >= targetCalories).length;
+
+  return {
+    startDate,
+    endDate,
+    days,
+    avgCalories7d,
+    avgCaloriesRange,
+    daysWithEntries,
+    daysHittingTargetWeek,
+  };
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sum = values.reduce((acc, v) => acc + v, 0);
+  return Math.round(sum / values.length);
+}


### PR DESCRIPTION
## Summary

Extends `/nutrition` beyond "today only" with a lazy-mounted history section (week strip, 30-day heatmap, factual insights) and adds a matching 7-day rollup widget to `/suivi`. Builds on PR 1 — heatmap/strip cells deep-link via `?d=YYYYMMDD` to reuse the existing DateSelector for back-dated entry.

## Architecture

- **New `useNutritionRange(start, end)` hook** — single range scan on `meal_logs` (covered by `idx_meal_logs_user_date`), client-side roll-up into per-day briefs + 7d/range averages. ~450 rows max for a 30-day window, no RPC needed.
- **`buildRangeSummary` pure utility** — covered by 11 unit tests (range enumeration, multi-log aggregation, 7d windowing, target-hit count gated on non-null target).
- **IntersectionObserver gate** — calques le pattern de `ExerciseVideo` ; le fetch 30j n'est lancé qu'au premier scroll dans la zone.
- **Drill flow** — `<Link to="/nutrition?d=YYYYMMDD">` partout dans la heatmap et le strip, le clamp existant de PR 1 sanitise tout `?d` invalide.

## UX

- No streak, no goal-pressure framing
- `InsightsBlock` is silent when there's not enough data — never emits "0 days hit your target"
- Heatmap colour buckets are intentionally coarse (3 tiers + base) for legibility
- `WeekStrip` cells stay readable on mobile (7 cols, compact text)

## PR plan reminder

This is **PR 2/6** of the autonomous nutrition + recipes batch.

## Test plan

- [ ] `/nutrition` first paint shows skeletons for the history section, then the strip + heatmap + insights pop in once scrolled into view
- [ ] Click a past day in the heatmap → URL becomes `?d=YYYYMMDD`, `DateSelector` shows that day, can log a meal
- [ ] Click "today" cell on the heatmap → URL has no `?d`, page re-anchors to today
- [ ] On `/suivi`, the 7d widget appears below `RecentSessions` with mini-bars
- [ ] Reload `/nutrition?d=20260425` (within window) → DateSelector pre-fills correctly
- [ ] Awareness mode (no target): heatmap uses neutral fill, target_days_week is hidden in insights
- [ ] Visitor (not logged in) → widget hidden, no Supabase fetch fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)