### PR TITLE
feat(recipes): public listing + detail pages and EN seed

### DIFF
--- a/scripts/data/recipes_en_seed.json
+++ b/scripts/data/recipes_en_seed.json
@@ -1,0 +1,2636 @@
+{
+  "version": "2.1",
+  "generated": "2026-04",
+  "categories": [
+    {
+      "id": "pre",
+      "label": "Pre-workout",
+      "color": "#1B6EF3"
+    },
+    {
+      "id": "post",
+      "label": "Post-workout",
+      "color": "#0D9E75"
+    },
+    {
+      "id": "breakfast",
+      "label": "Breakfast",
+      "color": "#E0860A"
+    },
+    {
+      "id": "recovery",
+      "label": "Recovery",
+      "color": "#7C3ABD"
+    },
+    {
+      "id": "snack",
+      "label": "Protein snack",
+      "color": "#C23B3B"
+    },
+    {
+      "id": "main",
+      "label": "Everyday meals",
+      "color": "#D4453A"
+    },
+    {
+      "id": "dessert",
+      "label": "Desserts",
+      "color": "#9C4A1E"
+    },
+    {
+      "id": "base",
+      "label": "Bases & doughs",
+      "color": "#5A6270"
+    }
+  ],
+  "recipes": [
+    {
+      "id": "pre-01",
+      "category": "pre",
+      "name": "Sweet potato toast & soft-boiled egg",
+      "description": "Moderate glycemic index carb base + light protein. Ideal 60 min before training.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 340,
+        "protein": 18,
+        "carbs": 44,
+        "fat": 9,
+        "fiber": 5
+      },
+      "ingredients": [
+        {
+          "qty": "2 slices",
+          "item": "Sweet potato (approx. 150g cooked)"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, pepper, smoked paprika",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Cut the sweet potato into 1 cm slices and pan-fry 5 min per side in olive oil.",
+        "Boil the eggs for 6 min for a soft-boiled center, then transfer to cold water to stop cooking.",
+        "Place the peeled and halved eggs on top of the sweet potato toasts.",
+        "Season with salt, pepper, and smoked paprika. Serve immediately."
+      ],
+      "tags": [
+        "gluten-free",
+        "quick",
+        "slow carbs"
+      ]
+    },
+    {
+      "id": "pre-02",
+      "category": "pre",
+      "name": "Banana & honey porridge",
+      "description": "A timeless classic. Steady energy release and easy to digest.",
+      "prepTime": 10,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 385,
+        "protein": 12,
+        "carbs": 66,
+        "fat": 8,
+        "fiber": 6
+      },
+      "ingredients": [
+        {
+          "qty": "80g",
+          "item": "Rolled oats"
+        },
+        {
+          "qty": "250ml",
+          "item": "Semi-skimmed milk (or plant-based milk)"
+        },
+        {
+          "qty": "1",
+          "item": "Ripe banana"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Honey"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Cinnamon"
+        }
+      ],
+      "steps": [
+        "Pour the oats and milk into a saucepan over medium heat.",
+        "Stir constantly for 4–5 min until creamy.",
+        "Slice the banana and arrange on top of the porridge.",
+        "Drizzle with honey and sprinkle with cinnamon."
+      ],
+      "tags": [
+        "vegetarian",
+        "slow carbs",
+        "quick"
+      ]
+    },
+    {
+      "id": "pre-03",
+      "category": "pre",
+      "name": "Whole wheat bread, almond butter & banana",
+      "description": "The perfect combo: complex carbs + healthy fats + fast sugars at the end.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 420,
+        "protein": 14,
+        "carbs": 56,
+        "fat": 16,
+        "fiber": 7
+      },
+      "ingredients": [
+        {
+          "qty": "2 slices",
+          "item": "Whole wheat bread (or rye bread)"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Almond butter (or peanut butter)"
+        },
+        {
+          "qty": "1",
+          "item": "Banana"
+        }
+      ],
+      "steps": [
+        "Lightly toast the bread slices.",
+        "Spread generously with almond butter.",
+        "Top with banana slices. Serve."
+      ],
+      "tags": [
+        "vegetarian",
+        "super quick",
+        "2 ingredients"
+      ]
+    },
+    {
+      "id": "pre-04",
+      "category": "pre",
+      "name": "Basmati rice & canned tuna",
+      "description": "A savory, high-density option for those who can't stomach sweet food before training.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 380,
+        "protein": 30,
+        "carbs": 52,
+        "fat": 5,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "100g (cooked weight)",
+          "item": "Basmati rice"
+        },
+        {
+          "qty": "1 can (140g drained)",
+          "item": "Tuna in water"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Light soy sauce"
+        },
+        {
+          "qty": "½ tsp",
+          "item": "Lemon juice"
+        }
+      ],
+      "steps": [
+        "Cook the rice according to the package (or use pre-cooked rice).",
+        "Drain the tuna and flake it into a bowl with soy sauce and lemon juice.",
+        "Toss with the warm rice."
+      ],
+      "tags": [
+        "gluten-free",
+        "dairy-free",
+        "high protein"
+      ]
+    },
+    {
+      "id": "pre-05",
+      "category": "pre",
+      "name": "Oat, milk & banana smoothie",
+      "description": "Light and easy to digest. Great for those with a sensitive stomach before training.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 320,
+        "protein": 13,
+        "carbs": 54,
+        "fat": 6,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "40g",
+          "item": "Rolled oats"
+        },
+        {
+          "qty": "250ml",
+          "item": "Semi-skimmed milk"
+        },
+        {
+          "qty": "1",
+          "item": "Frozen banana"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Honey"
+        }
+      ],
+      "steps": [
+        "Blend all ingredients together until smooth.",
+        "Drink immediately. Add a splash of milk if too thick."
+      ],
+      "tags": [
+        "vegetarian",
+        "super quick",
+        "liquid"
+      ]
+    },
+    {
+      "id": "post-01",
+      "category": "post",
+      "name": "Brown rice, grilled chicken & broccoli bowl",
+      "description": "The post-training classic. Optimal protein-to-carb ratio for muscle recovery.",
+      "prepTime": 20,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 490,
+        "protein": 44,
+        "carbs": 52,
+        "fat": 10,
+        "fiber": 6
+      },
+      "ingredients": [
+        {
+          "qty": "130g",
+          "item": "Chicken breast fillet"
+        },
+        {
+          "qty": "100g (cooked weight)",
+          "item": "Brown rice"
+        },
+        {
+          "qty": "150g",
+          "item": "Broccoli"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, garlic powder, herbs",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Cook the brown rice according to the package (20 min, or use pre-cooked).",
+        "Slice the chicken, season with salt and garlic, and pan-fry for 6–7 min in olive oil.",
+        "Steam the broccoli for 5 min (it should remain slightly crisp).",
+        "Assemble in a bowl and drizzle with a little olive oil."
+      ],
+      "tags": [
+        "gluten-free",
+        "dairy-free",
+        "muscle",
+        "meal prep"
+      ]
+    },
+    {
+      "id": "post-02",
+      "category": "post",
+      "name": "3-egg mushroom omelette",
+      "description": "Quick, protein-packed, low in carbs. Ideal when you prefer to skip starchy foods after training.",
+      "prepTime": 10,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 310,
+        "protein": 28,
+        "carbs": 5,
+        "fat": 20,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "3",
+          "item": "Whole eggs"
+        },
+        {
+          "qty": "100g",
+          "item": "Button mushrooms"
+        },
+        {
+          "qty": "30g",
+          "item": "Grated cheese (emmental or gruyère)"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, pepper, parsley",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Sauté the sliced mushrooms in olive oil for 4–5 min.",
+        "Beat the eggs, season, and pour over the mushrooms.",
+        "Sprinkle with cheese and fold the omelette halfway through cooking.",
+        "Cook for another 1–2 min depending on desired texture."
+      ],
+      "tags": [
+        "gluten-free",
+        "keto-friendly",
+        "quick"
+      ]
+    },
+    {
+      "id": "post-03",
+      "category": "post",
+      "name": "Grilled salmon, quinoa & broccoli",
+      "description": "Anti-inflammatory omega-3s + complete proteins. Excellent for deep muscle recovery.",
+      "prepTime": 25,
+      "difficulty": "moyen",
+      "servings": 1,
+      "nutrition": {
+        "calories": 530,
+        "protein": 46,
+        "carbs": 38,
+        "fat": 18,
+        "fiber": 5
+      },
+      "ingredients": [
+        {
+          "qty": "150g",
+          "item": "Salmon fillet"
+        },
+        {
+          "qty": "80g (dry weight)",
+          "item": "Quinoa"
+        },
+        {
+          "qty": "150g",
+          "item": "Broccoli"
+        },
+        {
+          "qty": "½",
+          "item": "Lemon"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, dill or herbes de Provence",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Rinse and cook the quinoa in 160ml of salted water, covered, for 15 min.",
+        "Season the salmon and pan-fry for 4 min per side.",
+        "Steam the broccoli for 5 min.",
+        "Plate the quinoa, broccoli and salmon. Drizzle with lemon juice and olive oil."
+      ],
+      "tags": [
+        "gluten-free",
+        "dairy-free",
+        "omega-3",
+        "anti-inflammatory"
+      ]
+    },
+    {
+      "id": "post-04",
+      "category": "post",
+      "name": "Whey & banana recovery smoothie",
+      "description": "The express post-workout option. Drink within 30 min after training.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 380,
+        "protein": 35,
+        "carbs": 44,
+        "fat": 6,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "30g",
+          "item": "Whey protein powder (vanilla or unflavored)"
+        },
+        {
+          "qty": "1",
+          "item": "Banana"
+        },
+        {
+          "qty": "250ml",
+          "item": "Semi-skimmed milk"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Peanut butter (optional)"
+        }
+      ],
+      "steps": [
+        "Blend all ingredients together.",
+        "Drink immediately after your workout."
+      ],
+      "tags": [
+        "vegetarian",
+        "super quick",
+        "30 min post-workout"
+      ]
+    },
+    {
+      "id": "post-05",
+      "category": "post",
+      "name": "Chicken & avocado wrap",
+      "description": "Easy to prep ahead. Protein + healthy fats + carbs — all in one hand.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 490,
+        "protein": 38,
+        "carbs": 40,
+        "fat": 17,
+        "fiber": 6
+      },
+      "ingredients": [
+        {
+          "qty": "1 large",
+          "item": "Whole wheat tortilla"
+        },
+        {
+          "qty": "120g",
+          "item": "Cooked sliced chicken (or leftover)"
+        },
+        {
+          "qty": "½",
+          "item": "Avocado"
+        },
+        {
+          "qty": "50g",
+          "item": "Salad leaves"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Fromage blanc 0% (or low-fat plain yogurt)"
+        },
+        {
+          "qty": "Salt, pepper, paprika",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Spread the fromage blanc over the tortilla.",
+        "Layer the salad, chicken, and sliced avocado.",
+        "Season, roll tightly, and cut in half."
+      ],
+      "tags": [
+        "meal prep",
+        "on-the-go",
+        "no cooking"
+      ]
+    },
+    {
+      "id": "post-06",
+      "category": "post",
+      "name": "Fromage blanc, mixed berries & granola",
+      "description": "A light post-workout option for short sessions or when appetite is low.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 295,
+        "protein": 22,
+        "carbs": 36,
+        "fat": 6,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "200g",
+          "item": "Fromage blanc 0% or 3.2% (or plain low-fat yogurt)"
+        },
+        {
+          "qty": "100g",
+          "item": "Mixed berries (fresh or frozen, thawed)"
+        },
+        {
+          "qty": "30g",
+          "item": "Granola (preferably no added sugar)"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Honey (optional)"
+        }
+      ],
+      "steps": [
+        "Pour the fromage blanc into a bowl.",
+        "Top with mixed berries.",
+        "Sprinkle granola just before eating (to keep it crunchy)."
+      ],
+      "tags": [
+        "vegetarian",
+        "super quick",
+        "low calorie"
+      ]
+    },
+    {
+      "id": "breakfast-01",
+      "category": "breakfast",
+      "name": "Oat & banana pancakes (3 ingredients)",
+      "description": "No flour, no added sugar. Fluffy texture and naturally sweet.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 365,
+        "protein": 18,
+        "carbs": 52,
+        "fat": 9,
+        "fiber": 5
+      },
+      "ingredients": [
+        {
+          "qty": "1",
+          "item": "Ripe banana"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "50g",
+          "item": "Rolled oats"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Cinnamon"
+        },
+        {
+          "qty": "Coconut oil spray or butter",
+          "item": "For cooking"
+        }
+      ],
+      "steps": [
+        "Mash the banana with a fork, then mix with the beaten eggs and oats.",
+        "Let rest for 2 min to allow the oats to absorb.",
+        "Cook small pancakes over medium heat, 2–3 min per side.",
+        "Serve with fresh fruit or honey."
+      ],
+      "tags": [
+        "vegetarian",
+        "gluten-free",
+        "no added sugar",
+        "3 ingredients"
+      ]
+    },
+    {
+      "id": "breakfast-02",
+      "category": "breakfast",
+      "name": "Veggie egg muffins (meal prep)",
+      "description": "Prep on Sunday, eat all week. High protein and free from unnecessary carbs.",
+      "prepTime": 30,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 230,
+        "protein": 20,
+        "carbs": 5,
+        "fat": 14,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "6",
+          "item": "Eggs"
+        },
+        {
+          "qty": "1 pepper",
+          "item": "Red bell pepper, thinly sliced"
+        },
+        {
+          "qty": "½ zucchini",
+          "item": "Zucchini, grated"
+        },
+        {
+          "qty": "50g",
+          "item": "Grated cheese"
+        },
+        {
+          "qty": "Salt, pepper, paprika, herbs",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Preheat the oven to 180°C (350°F). Grease a muffin tin.",
+        "Divide the vegetables among the muffin cups.",
+        "Beat the eggs, season, and pour over the vegetables. Sprinkle with cheese.",
+        "Bake for 20 min. Keeps for 4 days in the fridge."
+      ],
+      "tags": [
+        "meal prep",
+        "gluten-free",
+        "keto-friendly",
+        "weekday meal"
+      ]
+    },
+    {
+      "id": "breakfast-03",
+      "category": "breakfast",
+      "name": "Greek yogurt, homemade granola & fruit",
+      "description": "Probiotics + protein + complex carbs. The perfect base for a strong start.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 390,
+        "protein": 22,
+        "carbs": 50,
+        "fat": 11,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "200g",
+          "item": "Full-fat Greek yogurt"
+        },
+        {
+          "qty": "40g",
+          "item": "Granola (oats, honey, nuts)"
+        },
+        {
+          "qty": "100g",
+          "item": "Fresh seasonal fruit"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Chia seeds (optional)"
+        }
+      ],
+      "steps": [
+        "Pour the yogurt into a bowl.",
+        "Add the fruit, then the granola.",
+        "Sprinkle with chia seeds if using. Eat immediately."
+      ],
+      "tags": [
+        "vegetarian",
+        "super quick",
+        "probiotics"
+      ]
+    },
+    {
+      "id": "breakfast-04",
+      "category": "breakfast",
+      "name": "Avocado toast & poached egg",
+      "description": "Trendy and effective. Healthy fats + protein + complex carbs to keep you fueled all morning.",
+      "prepTime": 12,
+      "difficulty": "moyen",
+      "servings": 1,
+      "nutrition": {
+        "calories": 430,
+        "protein": 20,
+        "carbs": 36,
+        "fat": 22,
+        "fiber": 8
+      },
+      "ingredients": [
+        {
+          "qty": "2 slices",
+          "item": "Whole wheat bread or rye bread"
+        },
+        {
+          "qty": "1",
+          "item": "Ripe avocado"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "½",
+          "item": "Lemon"
+        },
+        {
+          "qty": "Flaky sea salt, pepper, chili flakes (optional)",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Bring water to a gentle simmer with a splash of white vinegar.",
+        "Create a swirl and gently slide in the egg. Cook for 3 min for a runny yolk.",
+        "Mash the avocado on the toasted bread, add a squeeze of lemon, season.",
+        "Top with the poached egg and a pinch of flaky salt."
+      ],
+      "tags": [
+        "vegetarian",
+        "healthy fats",
+        "long satiety"
+      ]
+    },
+    {
+      "id": "breakfast-05",
+      "category": "breakfast",
+      "name": "Protein açaí bowl",
+      "description": "Concentrated antioxidants + protein. Stunning to look at and even better to eat.",
+      "prepTime": 8,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 385,
+        "protein": 16,
+        "carbs": 54,
+        "fat": 13,
+        "fiber": 7
+      },
+      "ingredients": [
+        {
+          "qty": "100g",
+          "item": "Frozen açaí purée (packet)"
+        },
+        {
+          "qty": "1",
+          "item": "Frozen banana"
+        },
+        {
+          "qty": "100ml",
+          "item": "Plant-based milk (almond or oat)"
+        },
+        {
+          "qty": "20g",
+          "item": "Protein powder (optional)"
+        },
+        {
+          "qty": "Toppings of your choice",
+          "item": "Granola, fruit, shredded coconut"
+        }
+      ],
+      "steps": [
+        "Blend the açaí, banana, and plant-based milk until thick and smooth.",
+        "Pour into a bowl.",
+        "Decorate with your chosen toppings."
+      ],
+      "tags": [
+        "vegan",
+        "antioxidants",
+        "photogenic"
+      ]
+    },
+    {
+      "id": "recovery-01",
+      "category": "recovery",
+      "name": "Red lentil dahl",
+      "description": "Anti-inflammatory, rich in plant protein and iron. Perfect for rest days.",
+      "prepTime": 30,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 380,
+        "protein": 18,
+        "carbs": 52,
+        "fat": 10,
+        "fiber": 12
+      },
+      "ingredients": [
+        {
+          "qty": "200g",
+          "item": "Dry red lentils"
+        },
+        {
+          "qty": "1 can (400ml)",
+          "item": "Coconut milk"
+        },
+        {
+          "qty": "1 can (400g)",
+          "item": "Crushed tomatoes"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Turmeric"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Cumin"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Fresh grated ginger"
+        },
+        {
+          "qty": "1 clove",
+          "item": "Garlic"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Coconut oil or olive oil"
+        }
+      ],
+      "steps": [
+        "Sauté the garlic and ginger in oil for 2 min. Add the spices and stir for 30 sec.",
+        "Add the rinsed lentils, tomatoes, and coconut milk.",
+        "Simmer over medium heat for 20–25 min, stirring regularly, until the lentils are soft.",
+        "Adjust seasoning. Serve with rice or naan bread."
+      ],
+      "tags": [
+        "vegan",
+        "anti-inflammatory",
+        "meal prep",
+        "iron"
+      ]
+    },
+    {
+      "id": "recovery-02",
+      "category": "recovery",
+      "name": "Miso soup with tofu & edamame",
+      "description": "Light, remineralizing, and probiotic-rich. Perfect for the evening after an intense session.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 190,
+        "protein": 16,
+        "carbs": 15,
+        "fat": 7,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "1 tbsp",
+          "item": "Miso paste (white preferred)"
+        },
+        {
+          "qty": "400ml",
+          "item": "Hot water (not boiling)"
+        },
+        {
+          "qty": "100g",
+          "item": "Silken tofu, diced"
+        },
+        {
+          "qty": "50g",
+          "item": "Edamame (frozen, thawed)"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Soy sauce"
+        },
+        {
+          "qty": "Green onion or cilantro",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Dissolve the miso paste in the hot water (do not boil — this preserves the probiotics).",
+        "Add the diced tofu, edamame, and soy sauce.",
+        "Serve topped with sliced green onion."
+      ],
+      "tags": [
+        "vegan",
+        "low calorie",
+        "probiotics",
+        "light recovery"
+      ]
+    },
+    {
+      "id": "recovery-03",
+      "category": "recovery",
+      "name": "Chickpea, avocado & feta salad",
+      "description": "Plant protein + healthy fats + calcium. No cooking needed, ready in 5 min.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 430,
+        "protein": 16,
+        "carbs": 40,
+        "fat": 22,
+        "fiber": 10
+      },
+      "ingredients": [
+        {
+          "qty": "1 can (240g drained)",
+          "item": "Chickpeas"
+        },
+        {
+          "qty": "½",
+          "item": "Avocado"
+        },
+        {
+          "qty": "50g",
+          "item": "Feta cheese"
+        },
+        {
+          "qty": "1 handful",
+          "item": "Spinach or arugula"
+        },
+        {
+          "qty": "½",
+          "item": "Lemon"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, pepper, cumin",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Rinse and drain the chickpeas.",
+        "Toss all ingredients together in a bowl.",
+        "Season with lemon juice, olive oil, salt, pepper, and cumin."
+      ],
+      "tags": [
+        "vegetarian",
+        "gluten-free",
+        "no cooking",
+        "super quick"
+      ]
+    },
+    {
+      "id": "recovery-04",
+      "category": "recovery",
+      "name": "Vegetable & chickpea curry",
+      "description": "Turmeric and ginger make this an actively anti-inflammatory meal. Comforting and satisfying.",
+      "prepTime": 30,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 390,
+        "protein": 14,
+        "carbs": 54,
+        "fat": 13,
+        "fiber": 11
+      },
+      "ingredients": [
+        {
+          "qty": "1 can",
+          "item": "Cooked chickpeas"
+        },
+        {
+          "qty": "1",
+          "item": "Zucchini, diced"
+        },
+        {
+          "qty": "1",
+          "item": "Red bell pepper, diced"
+        },
+        {
+          "qty": "1 can (400ml)",
+          "item": "Coconut milk"
+        },
+        {
+          "qty": "2 tsp",
+          "item": "Curry powder"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Turmeric"
+        },
+        {
+          "qty": "Basmati rice",
+          "item": "To serve"
+        }
+      ],
+      "steps": [
+        "Sauté the vegetables in a pan for 5 min.",
+        "Add the spices and stir for 30 sec.",
+        "Add the chickpeas and coconut milk. Simmer for 15 min.",
+        "Serve over cooked basmati rice."
+      ],
+      "tags": [
+        "vegan",
+        "anti-inflammatory",
+        "meal prep"
+      ]
+    },
+    {
+      "id": "recovery-05",
+      "category": "recovery",
+      "name": "Quinoa & mint tabbouleh",
+      "description": "Complete proteins from quinoa + fresh herbs. Light, digestible, perfect for the evening.",
+      "prepTime": 20,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 320,
+        "protein": 10,
+        "carbs": 48,
+        "fat": 10,
+        "fiber": 5
+      },
+      "ingredients": [
+        {
+          "qty": "160g (dry weight)",
+          "item": "Quinoa"
+        },
+        {
+          "qty": "1",
+          "item": "Cucumber"
+        },
+        {
+          "qty": "2",
+          "item": "Tomatoes"
+        },
+        {
+          "qty": "1 bunch",
+          "item": "Flat-leaf parsley + fresh mint"
+        },
+        {
+          "qty": "2",
+          "item": "Lemons, juiced"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil"
+        }
+      ],
+      "steps": [
+        "Cook the quinoa in 320ml of salted water for 12 min. Let cool.",
+        "Finely chop the cucumber, tomatoes, and herbs.",
+        "Toss everything together and season with lemon juice, olive oil, and salt.",
+        "Can be prepared the night before (better the next day)."
+      ],
+      "tags": [
+        "vegan",
+        "gluten-free",
+        "meal prep",
+        "cold dish"
+      ]
+    },
+    {
+      "id": "snack-01",
+      "category": "snack",
+      "name": "Homemade hummus & crudités",
+      "description": "Homemade hummus in 5 min in the blender. Way tastier than store-bought.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 280,
+        "protein": 10,
+        "carbs": 28,
+        "fat": 14,
+        "fiber": 7
+      },
+      "ingredients": [
+        {
+          "qty": "1 can (240g drained)",
+          "item": "Chickpeas"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Tahini (sesame paste)"
+        },
+        {
+          "qty": "1",
+          "item": "Lemon, juiced"
+        },
+        {
+          "qty": "1 clove",
+          "item": "Garlic"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil + extra for serving"
+        },
+        {
+          "qty": "Crudités of your choice",
+          "item": "Carrots, cucumber, bell pepper, celery"
+        }
+      ],
+      "steps": [
+        "Blend all hummus ingredients with 3–4 tbsp of cold water.",
+        "Blend for a long time (3 min) for an ultra-creamy texture.",
+        "Serve in a bowl, drizzled with olive oil and paprika.",
+        "Accompany with crudités cut into sticks."
+      ],
+      "tags": [
+        "vegan",
+        "gluten-free",
+        "batch",
+        "make ahead"
+      ]
+    },
+    {
+      "id": "snack-02",
+      "category": "snack",
+      "name": "Oat & dark chocolate energy balls",
+      "description": "The ideal snack to prep on Sunday for the whole week. Zero cooking required.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 4,
+      "nutrition": {
+        "calories": 185,
+        "protein": 6,
+        "carbs": 24,
+        "fat": 8,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "100g",
+          "item": "Rolled oats"
+        },
+        {
+          "qty": "3 tbsp",
+          "item": "Peanut butter"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Honey"
+        },
+        {
+          "qty": "30g",
+          "item": "Dark chocolate chips"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Chia seeds (optional)"
+        }
+      ],
+      "steps": [
+        "Mix all the ingredients together in a bowl.",
+        "Refrigerate for 20 min to firm up.",
+        "Roll into walnut-sized balls.",
+        "Store in the fridge for up to 1 week (or freeze)."
+      ],
+      "tags": [
+        "vegetarian",
+        "no cooking",
+        "batch",
+        "on-the-go"
+      ]
+    },
+    {
+      "id": "snack-03",
+      "category": "snack",
+      "name": "Hard-boiled eggs & fromage blanc",
+      "description": "The simplest, most effective protein snack. No excuses not to have it.",
+      "prepTime": 12,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 205,
+        "protein": 24,
+        "carbs": 4,
+        "fat": 10,
+        "fiber": 0
+      },
+      "ingredients": [
+        {
+          "qty": "2",
+          "item": "Hard-boiled eggs"
+        },
+        {
+          "qty": "150g",
+          "item": "Fromage blanc 0% (or plain low-fat yogurt)"
+        },
+        {
+          "qty": "Salt, pepper, herbs",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Boil the eggs for 10 min. Cool under cold water, then peel.",
+        "Season the fromage blanc.",
+        "Eat together. Can be prepped in advance and kept for 3 days."
+      ],
+      "tags": [
+        "gluten-free",
+        "keto-friendly",
+        "ultra-simple",
+        "batch"
+      ]
+    },
+    {
+      "id": "snack-04",
+      "category": "snack",
+      "name": "Cottage cheese, nuts & honey",
+      "description": "Slow proteins (casein) + healthy fats. Ideal in the evening for overnight recovery.",
+      "prepTime": 2,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 260,
+        "protein": 20,
+        "carbs": 22,
+        "fat": 10,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "200g",
+          "item": "Cottage cheese"
+        },
+        {
+          "qty": "20g",
+          "item": "Walnuts or cashews"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Honey"
+        },
+        {
+          "qty": "Cinnamon",
+          "item": "Optional"
+        }
+      ],
+      "steps": [
+        "Pour the cottage cheese into a bowl.",
+        "Add the nuts and honey.",
+        "Sprinkle with cinnamon if desired."
+      ],
+      "tags": [
+        "vegetarian",
+        "gluten-free",
+        "casein",
+        "evening snack"
+      ]
+    },
+    {
+      "id": "main-01",
+      "category": "main",
+      "name": "Homemade beef & cheddar burger",
+      "description": "A real homemade burger. No reason to hold back — the difference from fast food is all about ingredient quality and portion size.",
+      "prepTime": 20,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 650,
+        "protein": 36,
+        "carbs": 44,
+        "fat": 36,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "150g",
+          "item": "Ground beef 15% fat"
+        },
+        {
+          "qty": "1+2+4 tbsp",
+          "item": "Burger sauce (1 mustard + 2 ketchup + 4 mayonnaise)"
+        },
+        {
+          "qty": "1 slice",
+          "item": "Cheddar"
+        },
+        {
+          "qty": "2 leaves",
+          "item": "Lettuce"
+        },
+        {
+          "qty": "2 slices",
+          "item": "Tomato"
+        },
+        {
+          "qty": "1+2+4 tbsp",
+          "item": "Burger sauce (1 mustard + 2 ketchup + 4 mayonnaise)"
+        },
+        {
+          "qty": "Salt, pepper",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Shape the ground beef into a ball, season, and press gently into a patty. Don't overwork the meat.",
+        "Cook over high heat for 2–3 min per side for a medium patty. Place the cheddar on top 30 sec before the end, cover to melt.",
+        "Lightly toast the bun, cut in half.",
+        "Assemble: sauce on both bun halves, lettuce, tomato, patty. Serve immediately."
+      ],
+      "tags": [
+        "gluten-free possible",
+        "protein",
+        "complete meal"
+      ]
+    },
+    {
+      "id": "main-02",
+      "category": "main",
+      "name": "Pasta carbonara (the real recipe)",
+      "description": "The real deal: no cream. Guanciale or lardons, egg yolks, pecorino. Simple, technical, perfect.",
+      "prepTime": 20,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 720,
+        "protein": 32,
+        "carbs": 62,
+        "fat": 38,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "160g",
+          "item": "Spaghetti or rigatoni"
+        },
+        {
+          "qty": "120g",
+          "item": "Guanciale or smoked lardons"
+        },
+        {
+          "qty": "3",
+          "item": "Egg yolks + 1 whole egg"
+        },
+        {
+          "qty": "60g",
+          "item": "Grated pecorino romano (or parmesan)"
+        },
+        {
+          "qty": "Black pepper",
+          "item": "Generous, freshly ground"
+        },
+        {
+          "qty": "Salt",
+          "item": "For pasta water"
+        }
+      ],
+      "steps": [
+        "Cook the pasta al dente in heavily salted water. Reserve 2 ladlefuls of pasta water.",
+        "Cook the guanciale in a large pan over medium heat until lightly crisp. Remove from heat.",
+        "Whisk together the egg yolks, whole egg, pecorino, and plenty of black pepper in a bowl.",
+        "Drain the pasta and add to the pan with the guanciale, off the heat. Pour the egg-cheese mixture over and toss vigorously, adding pasta water a spoonful at a time to create a creamy sauce. Never put back on the heat."
+      ],
+      "tags": [
+        "quick",
+        "no vegetables",
+        "signature dish"
+      ]
+    },
+    {
+      "id": "main-03",
+      "category": "main",
+      "name": "Pasta with basil pesto & parmesan",
+      "description": "Ten minutes, zero technique. Homemade pesto makes all the difference.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 580,
+        "protein": 18,
+        "carbs": 68,
+        "fat": 26,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "160g",
+          "item": "Penne or trofie"
+        },
+        {
+          "qty": "1 bunch",
+          "item": "Fresh basil (30g)"
+        },
+        {
+          "qty": "40g",
+          "item": "Grated parmesan"
+        },
+        {
+          "qty": "30g",
+          "item": "Pine nuts (or cashews)"
+        },
+        {
+          "qty": "1 clove",
+          "item": "Garlic"
+        },
+        {
+          "qty": "6 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt, pepper",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Cook the pasta al dente in heavily salted water.",
+        "Blend the basil, pine nuts, garlic, and oil into a paste. Add the parmesan and pulse briefly. Season.",
+        "Reserve 1 ladleful of pasta water. Drain the pasta.",
+        "Toss with the pesto off the heat. Loosen with a little pasta water if needed."
+      ],
+      "tags": [
+        "vegetarian",
+        "quick",
+        "no-cook pesto"
+      ]
+    },
+    {
+      "id": "main-04",
+      "category": "main",
+      "name": "Roast chicken with lemon & garlic",
+      "description": "The ultimate Sunday roast. One homemade roast chicken gives you 6 portions for the week.",
+      "prepTime": 90,
+      "difficulty": "facile",
+      "servings": 4,
+      "nutrition": {
+        "calories": 420,
+        "protein": 46,
+        "carbs": 4,
+        "fat": 24,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "1 (approx. 1.4kg)",
+          "item": "Whole chicken"
+        },
+        {
+          "qty": "1",
+          "item": "Lemon"
+        },
+        {
+          "qty": "6 cloves",
+          "item": "Garlic (unpeeled)"
+        },
+        {
+          "qty": "3 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Fresh thyme, rosemary",
+          "item": ""
+        },
+        {
+          "qty": "Salt, pepper",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Preheat the oven to 200°C (400°F). Take the chicken out of the fridge 30 min before.",
+        "Rub the outside with olive oil and generous salt and pepper. Stuff the herbs and halved lemon inside.",
+        "Arrange the garlic cloves around the chicken in the roasting pan.",
+        "Roast for 1h20, basting every 20 min. Check doneness by piercing a thigh — the juices should run clear."
+      ],
+      "tags": [
+        "gluten-free",
+        "dairy-free",
+        "meal prep",
+        "protein"
+      ]
+    },
+    {
+      "id": "main-05",
+      "category": "main",
+      "name": "Steak & sweet potato fries",
+      "description": "The homemade version is incomparable. Oven-baked sweet potato fries are a genuinely great swap — no cheating involved.",
+      "prepTime": 40,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 560,
+        "protein": 40,
+        "carbs": 52,
+        "fat": 18,
+        "fiber": 6
+      },
+      "ingredients": [
+        {
+          "qty": "180g",
+          "item": "Steak (flank, ribeye, or sirloin)"
+        },
+        {
+          "qty": "300g",
+          "item": "Sweet potato"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Smoked paprika"
+        },
+        {
+          "qty": "Salt, pepper, thyme",
+          "item": ""
+        },
+        {
+          "qty": "Butter or compound butter",
+          "item": "Optional, for steak cooking"
+        }
+      ],
+      "steps": [
+        "Preheat the oven to 200°C (400°F). Cut the sweet potato into sticks, toss with oil, paprika, and salt. Roast for 30 min, flipping halfway.",
+        "Take the steak out of the fridge 15 min before. Season just before cooking.",
+        "Sear over very high heat for 2 min per side for rare, or 3 min for medium. Rest for 3 min before slicing.",
+        "Serve immediately with the fries."
+      ],
+      "tags": [
+        "gluten-free",
+        "dairy-free",
+        "main course",
+        "slow carbs"
+      ]
+    },
+    {
+      "id": "main-06",
+      "category": "main",
+      "name": "Quick homemade ramen",
+      "description": "Not a 4-hour restaurant ramen — a 25-min version that's still delicious and hearty.",
+      "prepTime": 25,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 490,
+        "protein": 32,
+        "carbs": 54,
+        "fat": 16,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "160g",
+          "item": "Ramen noodles (or soba)"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs (for soft-boiled)"
+        },
+        {
+          "qty": "200g",
+          "item": "Chicken breast or thin pork belly"
+        },
+        {
+          "qty": "1 L",
+          "item": "Chicken broth (cube or homemade)"
+        },
+        {
+          "qty": "3 tbsp",
+          "item": "Soy sauce"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "White miso"
+        },
+        {
+          "qty": "Mushrooms, green onion, corn",
+          "item": "Toppings of your choice"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Sesame oil"
+        }
+      ],
+      "steps": [
+        "Boil the eggs for 6 min, cool immediately in cold water. Peel and halve.",
+        "Bring the broth to a simmer, add soy sauce and miso. Taste and adjust.",
+        "Cook the noodles separately according to the package. Brown the meat in a pan.",
+        "Divide the noodles between bowls, ladle the hot broth over, then top with meat, egg, and toppings. Finish with a drizzle of sesame oil."
+      ],
+      "tags": [
+        "complete meal",
+        "umami",
+        "winter warmer"
+      ]
+    },
+    {
+      "id": "main-07",
+      "category": "main",
+      "name": "Chicken & cheese quesadillas",
+      "description": "Ready in 15 minutes. Crispy, gooey, filling. Perfect for nights when inspiration runs low.",
+      "prepTime": 15,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 510,
+        "protein": 36,
+        "carbs": 44,
+        "fat": 20,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "2 large",
+          "item": "Flour tortillas"
+        },
+        {
+          "qty": "120g",
+          "item": "Cooked shredded chicken (leftover roast chicken works great)"
+        },
+        {
+          "qty": "60g",
+          "item": "Grated cheese (comté or emmental)"
+        },
+        {
+          "qty": "½",
+          "item": "Red bell pepper, thinly sliced"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Cumin + paprika"
+        },
+        {
+          "qty": "Sour cream or guacamole",
+          "item": "To serve"
+        }
+      ],
+      "steps": [
+        "Toss the chicken with the bell pepper and spices.",
+        "Heat a large dry pan over medium heat.",
+        "Place one tortilla in the pan, add the chicken and cheese on one half, fold over. Cook for 2–3 min per side until golden.",
+        "Cut into triangles and serve with sour cream or guacamole."
+      ],
+      "tags": [
+        "quick",
+        "leftovers",
+        "stovetop only"
+      ]
+    },
+    {
+      "id": "main-08",
+      "category": "main",
+      "name": "Parmesan & mushroom risotto",
+      "description": "The ultimate comfort dish. Needs 30 min of attention but no difficult technique.",
+      "prepTime": 35,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 520,
+        "protein": 18,
+        "carbs": 72,
+        "fat": 18,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "160g",
+          "item": "Arborio or carnaroli rice"
+        },
+        {
+          "qty": "200g",
+          "item": "Button mushrooms or shiitake"
+        },
+        {
+          "qty": "1",
+          "item": "Shallot"
+        },
+        {
+          "qty": "100ml",
+          "item": "Dry white wine"
+        },
+        {
+          "qty": "800ml",
+          "item": "Hot broth (chicken or vegetable)"
+        },
+        {
+          "qty": "60g",
+          "item": "Grated parmesan"
+        },
+        {
+          "qty": "20g",
+          "item": "Butter"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil"
+        }
+      ],
+      "steps": [
+        "Sauté the shallot and mushrooms in olive oil for 5 min.",
+        "Add the rice and stir for 2 min to toast it.",
+        "Pour in the white wine and let it absorb.",
+        "Add the hot broth one ladle at a time, stirring constantly. Each ladle must be absorbed before adding the next. This takes about 18–20 min.",
+        "Off the heat, stir in butter and parmesan vigorously (the mantecatura). Serve immediately."
+      ],
+      "tags": [
+        "vegetarian",
+        "dinner party",
+        "gluten-free possible"
+      ]
+    },
+    {
+      "id": "main-09",
+      "category": "main",
+      "name": "Spicy beef tacos & guacamole",
+      "description": "Colorful, convivial, eaten with your hands. The ideal format when you don't want to weigh every gram.",
+      "prepTime": 25,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 620,
+        "protein": 34,
+        "carbs": 52,
+        "fat": 28,
+        "fiber": 8
+      },
+      "ingredients": [
+        {
+          "qty": "250g",
+          "item": "Ground beef"
+        },
+        {
+          "qty": "4 small",
+          "item": "Corn tortillas"
+        },
+        {
+          "qty": "1",
+          "item": "Avocado"
+        },
+        {
+          "qty": "1",
+          "item": "Lime"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Cumin + chili"
+        },
+        {
+          "qty": "1",
+          "item": "Red onion, thinly sliced"
+        },
+        {
+          "qty": "Fresh cilantro, sour cream",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Brown the ground beef with the spices until cooked through. Season.",
+        "Mash the avocado with lime juice, salt, and a pinch of cumin — quick guacamole.",
+        "Warm the tortillas directly over the flame or in a dry pan.",
+        "Assemble: guacamole, spicy beef, red onion, cilantro, sour cream."
+      ],
+      "tags": [
+        "dairy-free possible",
+        "convivial",
+        "sharing format"
+      ]
+    },
+    {
+      "id": "main-10",
+      "category": "main",
+      "name": "Homemade tomato & mozzarella pizza",
+      "description": "Made with the homemade pizza dough (see Bases). A real pizza, not a lighter version.",
+      "prepTime": 30,
+      "difficulty": "moyen",
+      "servings": 2,
+      "nutrition": {
+        "calories": 580,
+        "protein": 24,
+        "carbs": 74,
+        "fat": 20,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "1 portion",
+          "item": "Homemade pizza dough (see Bases recipe)"
+        },
+        {
+          "qty": "150g",
+          "item": "Tomato sauce (passata or crushed tomatoes)"
+        },
+        {
+          "qty": "150g",
+          "item": "Buffalo mozzarella"
+        },
+        {
+          "qty": "Fresh basil",
+          "item": ""
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "Salt",
+          "item": ""
+        }
+      ],
+      "steps": [
+        "Preheat the oven to maximum heat (250°C / 480°F or higher) with the baking sheet inside.",
+        "Stretch the dough thinly over floured parchment paper, leaving the edge slightly thicker.",
+        "Spread the tomato sauce, tear the mozzarella on top. Season.",
+        "Bake for 10–12 min until the crust is golden and the mozzarella is bubbling. Add fresh basil and olive oil right out of the oven."
+      ],
+      "tags": [
+        "vegetarian",
+        "signature dish",
+        "homemade"
+      ],
+      "linkedBase": "base-02"
+    },
+    {
+      "id": "main-11",
+      "category": "breakfast",
+      "name": "Classic crêpes",
+      "description": "The base recipe. Thin, golden, to fill as you like — sweet or savory.",
+      "prepTime": 25,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 360,
+        "protein": 12,
+        "carbs": 58,
+        "fat": 10,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "125g",
+          "item": "All-purpose flour (T45)"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "300ml",
+          "item": "Milk"
+        },
+        {
+          "qty": "20g",
+          "item": "Melted butter"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Salt"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Vanilla sugar (for sweet version)"
+        }
+      ],
+      "steps": [
+        "Combine flour, salt, and sugar. Make a well and add the beaten eggs in the center.",
+        "Gradually whisk in the milk to avoid lumps. Stir in the melted butter.",
+        "Rest for 30 min if possible (not mandatory).",
+        "Cook in a lightly buttered pan over medium heat, 1 min per side."
+      ],
+      "tags": [
+        "vegetarian",
+        "base",
+        "sweet or savory"
+      ]
+    },
+    {
+      "id": "main-12",
+      "category": "breakfast",
+      "name": "Cinnamon French toast & maple syrup",
+      "description": "Day-old brioche transformed into something exceptional. Ready in 10 minutes.",
+      "prepTime": 10,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 420,
+        "protein": 16,
+        "carbs": 54,
+        "fat": 14,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "2 thick slices",
+          "item": "Brioche or day-old bread"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "60ml",
+          "item": "Milk"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Cinnamon"
+        },
+        {
+          "qty": "1 tsp",
+          "item": "Vanilla extract"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Butter"
+        },
+        {
+          "qty": "Maple syrup or honey",
+          "item": "To serve"
+        }
+      ],
+      "steps": [
+        "Beat the eggs with the milk, cinnamon, and vanilla.",
+        "Soak the brioche slices for 30 seconds per side.",
+        "Cook over medium heat in foaming butter for 2–3 min per side until golden.",
+        "Serve with maple syrup, fresh fruit, or powdered sugar."
+      ],
+      "tags": [
+        "vegetarian",
+        "zero waste",
+        "quick"
+      ]
+    },
+    {
+      "id": "dessert-01",
+      "category": "dessert",
+      "name": "Chocolate mousse (Erwan's recipe)",
+      "description": "3 ingredients, zero compromise. The purest mousse imaginable — dark chocolate, whipped egg whites, sugar.",
+      "prepTime": 15,
+      "difficulty": "moyen",
+      "servings": 4,
+      "nutrition": {
+        "calories": 255,
+        "protein": 6,
+        "carbs": 24,
+        "fat": 15,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "140g",
+          "item": "Dark chocolate (70% minimum)"
+        },
+        {
+          "qty": "4",
+          "item": "Egg whites"
+        },
+        {
+          "qty": "35g",
+          "item": "Granulated sugar"
+        }
+      ],
+      "steps": [
+        "Melt the chocolate in a bain-marie or microwave in 30-second bursts. Let cool slightly.",
+        "Whip the egg whites to stiff peaks. When they form soft peaks, gradually add the sugar and continue beating.",
+        "Gently fold the egg whites into the melted chocolate in three additions, lifting with a spatula. Do not beat — you want to preserve the air.",
+        "Pour into ramekins or glasses. Refrigerate for at least 2 hours before serving."
+      ],
+      "tags": [
+        "vegetarian",
+        "flour-free",
+        "personal recipe",
+        "3 ingredients"
+      ],
+      "personal": true,
+      "author": "Erwan"
+    },
+    {
+      "id": "dessert-02",
+      "category": "dessert",
+      "name": "Oat & dark chocolate cookies",
+      "description": "Crispy on the outside, chewy in the middle. Real cookies, not sports bars.",
+      "prepTime": 25,
+      "difficulty": "facile",
+      "servings": 4,
+      "nutrition": {
+        "calories": 210,
+        "protein": 5,
+        "carbs": 28,
+        "fat": 9,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "100g",
+          "item": "Rolled oats"
+        },
+        {
+          "qty": "80g",
+          "item": "Whole wheat flour"
+        },
+        {
+          "qty": "80g",
+          "item": "Softened butter"
+        },
+        {
+          "qty": "60g",
+          "item": "Brown sugar"
+        },
+        {
+          "qty": "1",
+          "item": "Egg"
+        },
+        {
+          "qty": "60g",
+          "item": "Dark chocolate chips"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Salt + baking soda"
+        }
+      ],
+      "steps": [
+        "Preheat the oven to 170°C (340°F). Beat the butter and sugar until creamy.",
+        "Add the egg and mix. Fold in the flour, oats, salt, and baking soda.",
+        "Stir in the chocolate chips. Roll into walnut-sized balls and press lightly onto the baking sheet.",
+        "Bake for 12–14 min. Let cool on the tray (they firm up as they cool)."
+      ],
+      "tags": [
+        "vegetarian",
+        "batch",
+        "afternoon snack"
+      ]
+    },
+    {
+      "id": "dessert-03",
+      "category": "dessert",
+      "name": "Brownie à la papy Brossard",
+      "description": "The family recipe. Dense, fudgy, with flaky salt that makes all the difference. More chocolate than classic versions.",
+      "prepTime": 35,
+      "difficulty": "facile",
+      "servings": 10,
+      "nutrition": {
+        "calories": 342,
+        "protein": 7,
+        "carbs": 40,
+        "fat": 19,
+        "fiber": 2
+      },
+      "ingredients": [
+        {
+          "qty": "200g",
+          "item": "Dark chocolate"
+        },
+        {
+          "qty": "100g",
+          "item": "Butter"
+        },
+        {
+          "qty": "20g",
+          "item": "Oil (sunflower or coconut)"
+        },
+        {
+          "qty": "2",
+          "item": "Eggs"
+        },
+        {
+          "qty": "150g",
+          "item": "Sugar"
+        },
+        {
+          "qty": "150g",
+          "item": "Flour"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Baking soda (optional)"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Flaky sea salt"
+        },
+        {
+          "qty": "40g",
+          "item": "Chocolate chips"
+        }
+      ],
+      "steps": [
+        "Melt the chocolate with the butter. Add the oil. Let cool slightly.",
+        "Whisk the eggs with the sugar until pale and fluffy.",
+        "Fold the melted chocolate into the egg-sugar mixture.",
+        "Add the sifted flour and baking soda. Mix without overworking.",
+        "Stir in the flaky salt and chocolate chips.",
+        "Pour into a greased pan. Bake at 180°C (350°F): 20 min for a large dish, 25 min for a smaller pan. The center should still jiggle slightly."
+      ],
+      "tags": [
+        "vegetarian",
+        "family recipe",
+        "batch",
+        "fudgy"
+      ],
+      "personal": true,
+      "author": "Famille"
+    },
+    {
+      "id": "dessert-04",
+      "category": "dessert",
+      "name": "Quick tiramisu",
+      "description": "No lecithin, no light mascarpone. The authentic Italian recipe, in a simplified version.",
+      "prepTime": 20,
+      "difficulty": "moyen",
+      "servings": 4,
+      "nutrition": {
+        "calories": 340,
+        "protein": 10,
+        "carbs": 36,
+        "fat": 18,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "250g",
+          "item": "Mascarpone"
+        },
+        {
+          "qty": "3",
+          "item": "Eggs (yolks and whites separated)"
+        },
+        {
+          "qty": "80g",
+          "item": "Sugar"
+        },
+        {
+          "qty": "200ml",
+          "item": "Strong espresso, cooled"
+        },
+        {
+          "qty": "16–20",
+          "item": "Ladyfingers (savoiardi)"
+        },
+        {
+          "qty": "Unsweetened cocoa powder",
+          "item": "For dusting"
+        }
+      ],
+      "steps": [
+        "Whisk the egg yolks with the sugar until pale. Fold in the mascarpone with a spatula.",
+        "Beat the egg whites to stiff peaks. Gently fold into the mascarpone cream.",
+        "Quickly dip the ladyfingers in the coffee (1 second per side — don't soak them).",
+        "Layer the cookies and cream in a dish, finishing with cream. Refrigerate for at least 3 hours.",
+        "Dust with cocoa powder just before serving."
+      ],
+      "tags": [
+        "vegetarian",
+        "make ahead",
+        "dinner party dessert"
+      ]
+    },
+    {
+      "id": "dessert-05",
+      "category": "dessert",
+      "name": "Banana nice cream",
+      "description": "2 ingredients, ice cream texture, zero guilt. Frozen blended banana does all the work.",
+      "prepTime": 5,
+      "difficulty": "facile",
+      "servings": 1,
+      "nutrition": {
+        "calories": 180,
+        "protein": 4,
+        "carbs": 38,
+        "fat": 2,
+        "fiber": 4
+      },
+      "ingredients": [
+        {
+          "qty": "3",
+          "item": "Ripe frozen bananas (cut into chunks)"
+        },
+        {
+          "qty": "1 tbsp",
+          "item": "Peanut butter or cocoa powder (optional)"
+        },
+        {
+          "qty": "Toppings of your choice",
+          "item": "Fruit, granola, shredded coconut"
+        }
+      ],
+      "steps": [
+        "Blend the frozen banana chunks alone for 3–4 min, scraping the sides regularly.",
+        "The texture will first look crumbly, then turn creamy like ice cream.",
+        "Add peanut butter or cocoa if desired, blend for another 30 sec.",
+        "Serve immediately for a soft-serve texture, or freeze for 30 min for a firmer scoop."
+      ],
+      "tags": [
+        "vegan",
+        "gluten-free",
+        "no added sugar",
+        "2 ingredients"
+      ]
+    },
+    {
+      "id": "base-01",
+      "category": "base",
+      "name": "Homemade pasta dough",
+      "description": "The foundation for all fresh pasta. Requires a pasta machine (or serious motivation with a rolling pin). The result is worlds apart from dried pasta.",
+      "prepTime": 75,
+      "difficulty": "moyen",
+      "servings": 4,
+      "nutrition": {
+        "calories": 347,
+        "protein": 13,
+        "carbs": 53,
+        "fat": 8,
+        "fiber": 2
+      },
+      "note": "Values for the dough alone, without sauce. Add 200–300 kcal depending on the topping.",
+      "ingredients": [
+        {
+          "qty": "280g",
+          "item": "Tipo 00 flour (or all-purpose as a substitute)"
+        },
+        {
+          "qty": "4",
+          "item": "Egg yolks"
+        },
+        {
+          "qty": "2",
+          "item": "Whole eggs"
+        }
+      ],
+      "steps": [
+        "Make a well with the flour. Add the yolks and whole eggs in the center.",
+        "Gradually incorporate the flour from the edges using a fork.",
+        "Knead by hand for 8–10 min until you have a smooth, elastic, non-sticky dough. Add a few drops of water if too dry.",
+        "Wrap in plastic wrap. Refrigerate for at least 1 hour (up to 24h — longer means better texture).",
+        "Divide into 4 portions. Roll through a pasta machine (setting 1 → 5 or 6) or very thinly by hand.",
+        "Cut into tagliatelle, fettuccine, or use for lasagna, ravioli, etc."
+      ],
+      "tags": [
+        "vegetarian",
+        "base",
+        "fresh pasta",
+        "personal recipe"
+      ],
+      "personal": true,
+      "author": "Erwan",
+      "usedIn": [
+        "Tagliatelle with bolognese",
+        "Carbonara",
+        "Lasagna",
+        "Ravioli"
+      ]
+    },
+    {
+      "id": "base-02",
+      "category": "base",
+      "name": "Homemade pizza dough",
+      "description": "A reliable home recipe — easier to handle than a high-hydration Neapolitan dough, with great structure thanks to olive oil.",
+      "prepTime": 75,
+      "difficulty": "facile",
+      "servings": 2,
+      "nutrition": {
+        "calories": 547,
+        "protein": 13,
+        "carbs": 93,
+        "fat": 11,
+        "fiber": 3
+      },
+      "note": "Values for 1 individual pizza base (half the recipe). Toppings are extra.",
+      "ingredients": [
+        {
+          "qty": "250g",
+          "item": "Tipo 00 or all-purpose flour"
+        },
+        {
+          "qty": "140g",
+          "item": "Warm water (approx. 30°C / 86°F)"
+        },
+        {
+          "qty": "20g",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "2.5g (½ packet)",
+          "item": "Dry active yeast"
+        },
+        {
+          "qty": "6g",
+          "item": "Salt"
+        }
+      ],
+      "steps": [
+        "Dissolve the yeast in the warm water. Let activate for 5 min.",
+        "In a large bowl, mix flour and salt. Add the water + yeast and olive oil.",
+        "Knead by hand for 10 min until you have a smooth, soft, slightly elastic dough.",
+        "Cover with a damp cloth. Let rise for 1 hour at room temperature (or overnight in the fridge for more flavor).",
+        "Divide into 2 dough balls. Stretch thinly by hand or with a rolling pin. Top and bake at 250°C (480°F) on a preheated baking sheet for 10–12 min."
+      ],
+      "tags": [
+        "vegetarian",
+        "base",
+        "pizza",
+        "personal recipe"
+      ],
+      "personal": true,
+      "author": "Erwan",
+      "usedIn": [
+        "Tomato mozzarella pizza",
+        "Pizza bianca",
+        "Calzone"
+      ]
+    },
+    {
+      "id": "post-07",
+      "category": "post",
+      "name": "Marinated salmon poke bowl",
+      "description": "The post-workout dish that doesn't look like athlete food. Vinegared rice, soy-honey-ginger marinated salmon. The homemade version is incomparable.",
+      "prepTime": 30,
+      "difficulty": "facile",
+      "servings": 4,
+      "nutrition": {
+        "calories": 480,
+        "protein": 38,
+        "carbs": 52,
+        "fat": 14,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "500g",
+          "item": "Short-grain rice (sushi rice)"
+        },
+        {
+          "qty": "600g",
+          "item": "Fresh salmon (fillet or steak)"
+        },
+        {
+          "qty": "6–7 mL",
+          "item": "Rice vinegar"
+        },
+        {
+          "qty": "2+ tsp",
+          "item": "Sugar"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Salt"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Soy sauce"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Honey"
+        },
+        {
+          "qty": "2 tsp",
+          "item": "Fresh grated ginger"
+        },
+        {
+          "qty": "Lemon juice",
+          "item": ""
+        },
+        {
+          "qty": "Toppings of your choice",
+          "item": "Avocado, edamame, cucumber, radish, sesame seeds"
+        }
+      ],
+      "steps": [
+        "Cook the rice in a rice cooker (equal volume of water to rice). Meanwhile, gently heat the rice vinegar with the sugar and salt until dissolved — do not boil.",
+        "Once cooked, gently fold the vinegar mixture into the warm rice. Let cool to room temperature.",
+        "Cut the salmon into cubes. Marinate for 15–20 min in soy sauce + honey + ginger + lemon juice.",
+        "Assemble the bowls: rice, marinated salmon, toppings. Drizzle with the remaining marinade."
+      ],
+      "tags": [
+        "gluten-free",
+        "omega-3",
+        "personal recipe",
+        "convivial",
+        "batch"
+      ],
+      "personal": true,
+      "author": "Erwan"
+    },
+    {
+      "id": "dessert-06",
+      "category": "dessert",
+      "name": "Homemade flan pâtissier",
+      "description": "The bakery flan, made at home. Creamy, vanilla-scented, with a lightly crisp pastry base.",
+      "prepTime": 70,
+      "difficulty": "moyen",
+      "servings": 8,
+      "nutrition": {
+        "calories": 310,
+        "protein": 9,
+        "carbs": 46,
+        "fat": 10,
+        "fiber": 1
+      },
+      "ingredients": [
+        {
+          "qty": "3",
+          "item": "Eggs"
+        },
+        {
+          "qty": "1 L",
+          "item": "Whole milk (875ml + 125ml)"
+        },
+        {
+          "qty": "100g",
+          "item": "Cornstarch"
+        },
+        {
+          "qty": "160g",
+          "item": "Sugar"
+        },
+        {
+          "qty": "2 packets",
+          "item": "Vanilla sugar"
+        },
+        {
+          "qty": "1",
+          "item": "Vanilla bean"
+        },
+        {
+          "qty": "1 roll",
+          "item": "Shortcrust or puff pastry (homemade or store-bought)"
+        }
+      ],
+      "steps": [
+        "Mix the 3 eggs with 125ml of cold milk and the cornstarch until smooth with no lumps.",
+        "In a saucepan, heat the remaining 875ml of milk with the sugar, vanilla sugar, and split vanilla bean. Bring to a boil.",
+        "Pour the hot milk over the egg mixture, whisking constantly. Return to the saucepan over medium heat, stirring continuously until thickened.",
+        "Line a 24–26 cm pan with the pastry. Pour the custard filling on top.",
+        "Bake at 180°C (350°F) for 40 min. The top should be lightly golden and still jiggle slightly in the center.",
+        "Let cool completely before unmolding."
+      ],
+      "tags": [
+        "vegetarian",
+        "personal recipe",
+        "dinner party dessert",
+        "make ahead"
+      ],
+      "personal": true,
+      "author": "Erwan"
+    },
+    {
+      "id": "base-03",
+      "category": "base",
+      "name": "Buckwheat galette dough",
+      "description": "The Breton buckwheat galette batter. Simple, no butter in the dough, leaving all the room for the fillings. The version that works at home.",
+      "prepTime": 75,
+      "difficulty": "facile",
+      "servings": 8,
+      "nutrition": {
+        "calories": 143,
+        "protein": 5,
+        "carbs": 22,
+        "fat": 5,
+        "fiber": 3
+      },
+      "note": "Calories for one galette alone, without filling. Add 150–400 kcal depending on the filling (complete, chicken-cheese, etc.)",
+      "ingredients": [
+        {
+          "qty": "250g",
+          "item": "Buckwheat flour"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "All-purpose flour"
+        },
+        {
+          "qty": "1 pinch",
+          "item": "Salt + pepper"
+        },
+        {
+          "qty": "1",
+          "item": "Egg"
+        },
+        {
+          "qty": "2 tbsp",
+          "item": "Olive oil"
+        },
+        {
+          "qty": "500mL",
+          "item": "Water"
+        }
+      ],
+      "steps": [
+        "Mix the flours, salt, and pepper in a large bowl. Make a well.",
+        "Add the egg and oil in the center. Incorporate by stirring from the center outward.",
+        "Gradually add the water to avoid lumps. The batter should be fluid.",
+        "Rest for at least 1 hour (or overnight in the fridge — the galettes will be better).",
+        "Cook on a very hot, lightly oiled crêpe pan or non-stick skillet for 1–2 min per side."
+      ],
+      "tags": [
+        "vegan",
+        "gluten-free",
+        "base",
+        "brittany",
+        "personal recipe"
+      ],
+      "personal": true,
+      "author": "Erwan",
+      "usedIn": [
+        "Complete galette (ham, egg, cheese)",
+        "Chicken & cheese galette",
+        "Goat cheese & honey galette"
+      ]
+    },
+    {
+      "id": "snack-05",
+      "category": "snack",
+      "name": "Chickpea & peanut butter cookies",
+      "description": "The recipe that surprises everyone. No chickpea taste, cookie texture, protein snack macros. Zero flour.",
+      "prepTime": 20,
+      "difficulty": "facile",
+      "servings": 8,
+      "nutrition": {
+        "calories": 113,
+        "protein": 8,
+        "carbs": 13,
+        "fat": 5,
+        "fiber": 3
+      },
+      "ingredients": [
+        {
+          "qty": "1 can (400g)",
+          "item": "Chickpeas, undrained"
+        },
+        {
+          "qty": "40g",
+          "item": "Peanut butter"
+        },
+        {
+          "qty": "20g",
+          "item": "Honey"
+        },
+        {
+          "qty": "60g",
+          "item": "Caramel whey protein (or cocoa powder as a substitute)"
+        },
+        {
+          "qty": "Dark chocolate chips",
+          "item": "For inside + topping"
+        }
+      ],
+      "steps": [
+        "Blend the undrained chickpeas with the peanut butter, honey, and whey until smooth.",
+        "Fold in a few chocolate chips with a spatula.",
+        "Shape into cookies on a sheet of parchment paper. Press more chips on top.",
+        "Bake for 10–12 min at 180°C (350°F). Let cool completely before handling."
+      ],
+      "tags": [
+        "flour-free",
+        "high protein",
+        "batch",
+        "gluten-free"
+      ]
+    },
+    {
+      "id": "base-04",
+      "category": "base",
+      "name": "Homemade crêpe batter",
+      "description": "The generous version — more butter, more eggs. Rich, golden crêpes. Two versions in the notes; this is the fuller one.",
+      "prepTime": 80,
+      "difficulty": "facile",
+      "servings": 15,
+      "nutrition": {
+        "calories": 148,
+        "protein": 5,
+        "carbs": 18,
+        "fat": 6,
+        "fiber": 0
+      },
+      "note": "For a lighter version: 250g flour, 3 eggs, 60g sugar, 5g salt, 400ml milk. Thinner result, no butter.",
+      "ingredients": [
+        {
+          "qty": "250g",
+          "item": "All-purpose flour (T45)"
+        },
+        {
+          "qty": "60g",
+          "item": "Sugar"
+        },
+        {
+          "qty": "6",
+          "item": "Eggs"
+        },
+        {
+          "qty": "5cl",
+          "item": "Oil"
+        },
+        {
+          "qty": "80g",
+          "item": "Butter (melted)"
+        },
+        {
+          "qty": "75cl",
+          "item": "Milk (room temperature)"
+        }
+      ],
+      "steps": [
+        "Melt the butter and let it cool slightly.",
+        "Beat the eggs in a large bowl. Add the flour and sugar, mix.",
+        "Stir in the oil and melted butter.",
+        "Gradually add 50cl of milk, whisking to avoid lumps.",
+        "Rest for 1 hour (mandatory for this recipe).",
+        "Add the remaining 25cl of milk if the batter is too thick. Cook over medium heat in a lightly buttered crêpe pan."
+      ],
+      "tags": [
+        "vegetarian",
+        "base",
+        "crêpes",
+        "personal recipe",
+        "brittany"
+      ],
+      "personal": true,
+      "author": "Erwan"
+    }
+  ],
+  "total": 49
+}

--- a/scripts/seed-recipes.ts
+++ b/scripts/seed-recipes.ts
@@ -1,20 +1,27 @@
 /**
- * Seed script — inserts the FR recipe library into Supabase.
+ * Seed script — inserts the recipe library into Supabase for one locale at
+ * a time. Defaults to seeding both fr + en sequentially.
  *
  * Usage:
- *   npx tsx scripts/seed-recipes.ts
+ *   npx tsx scripts/seed-recipes.ts          # seeds fr then en
+ *   npx tsx scripts/seed-recipes.ts fr       # seeds fr only
+ *   npx tsx scripts/seed-recipes.ts en       # seeds en only
  *
  * Requires VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars.
  *
  * Idempotent via UPSERT on the (recipe_key, locale) primary key.
- *
- * The EN translation is shipped in PR 4 with a parallel `recipes_en_seed.json`.
  */
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
-import type { RecipeCategory, RecipeDifficulty, RecipeIngredient, RecipeNutrition } from '../src/types/recipe.ts';
+import type {
+  RecipeCategory,
+  RecipeDifficulty,
+  RecipeIngredient,
+  RecipeLocale,
+  RecipeNutrition,
+} from '../src/types/recipe.ts';
 import { slugify } from '../src/utils/slug.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -63,23 +70,21 @@ interface SeedFile {
   recipes: SeedRecipe[];
 }
 
-const seedPath = join(__dirname, 'data', 'recipes_fr_seed.json');
-const seed = JSON.parse(readFileSync(seedPath, 'utf8')) as SeedFile;
-
-console.log(`[seed-recipes] loaded ${seed.recipes.length} FR recipes from ${seedPath}`);
-
 const supabase = createClient(url, serviceKey);
 
-async function main() {
-  // Pre-flight: detect slug collisions before hitting the DB so the error
-  // message is actionable rather than a generic unique-violation from PG.
+async function seedLocale(locale: RecipeLocale): Promise<{ ok: number; failed: number }> {
+  const seedPath = join(__dirname, 'data', `recipes_${locale}_seed.json`);
+  const seed = JSON.parse(readFileSync(seedPath, 'utf8')) as SeedFile;
+  console.log(`[seed-recipes] loaded ${seed.recipes.length} ${locale.toUpperCase()} recipes`);
+
+  // Pre-flight slug-collision detection per locale (the UNIQUE constraint is
+  // (locale, slug), so a collision in the same locale is what would fail PG).
   const slugIndex = new Map<string, string>();
   for (const r of seed.recipes) {
     const s = slugify(r.name);
     const previous = slugIndex.get(s);
     if (previous) {
-      console.error(`[seed-recipes] slug collision: "${s}" produced by both ${previous} and ${r.id}`);
-      process.exit(1);
+      throw new Error(`slug collision in ${locale}: "${s}" produced by both ${previous} and ${r.id}`);
     }
     slugIndex.set(s, r.id);
   }
@@ -89,7 +94,7 @@ async function main() {
   for (const r of seed.recipes) {
     const row = {
       recipe_key: r.id,
-      locale: 'fr',
+      locale,
       slug: slugify(r.name),
       category: r.category,
       name: r.name,
@@ -105,18 +110,33 @@ async function main() {
     };
 
     const { error } = await supabase.from('recipes').upsert(row, { onConflict: 'recipe_key,locale' });
-
     if (error) {
       failed++;
       console.error(`  ✗ ${r.id}: ${error.message}`);
     } else {
       ok++;
-      process.stdout.write(`\r[seed-recipes] ${ok}/${seed.recipes.length} upserted`);
+      process.stdout.write(`\r[seed-recipes:${locale}] ${ok}/${seed.recipes.length} upserted`);
     }
   }
+  console.log(`\n[seed-recipes:${locale}] ok=${ok} failed=${failed}`);
+  return { ok, failed };
+}
 
-  console.log(`\n[seed-recipes] done — ok=${ok} failed=${failed}`);
-  process.exit(failed > 0 ? 1 : 0);
+async function main() {
+  const arg = process.argv[2] as RecipeLocale | undefined;
+  const locales: RecipeLocale[] = arg ? [arg] : ['fr', 'en'];
+
+  if (arg && arg !== 'fr' && arg !== 'en') {
+    console.error(`unknown locale "${arg}" — accepted: fr | en`);
+    process.exit(1);
+  }
+
+  let totalFailed = 0;
+  for (const locale of locales) {
+    const { failed } = await seedLocale(locale);
+    totalFailed += failed;
+  }
+  process.exit(totalFailed > 0 ? 1 : 0);
 }
 
 main().catch((err) => {

--- a/src/components/recipes/RecipeCard.tsx
+++ b/src/components/recipes/RecipeCard.tsx
@@ -1,0 +1,42 @@
+import { Clock, Flame } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import type { Recipe } from '../../types/recipe.ts';
+
+export interface RecipeCardProps {
+  recipe: Recipe;
+}
+
+export function RecipeCard({ recipe }: RecipeCardProps) {
+  const { t } = useTranslation('recipes');
+
+  return (
+    <Link
+      to={`/nutrition/recettes/${recipe.slug}`}
+      className="group flex flex-col gap-3 rounded-2xl border border-card-border bg-surface-card p-5 hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10 transition-all"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-brand">
+          {t(`category.${recipe.category}`)}
+        </span>
+        {recipe.difficulty && <span className="text-[10px] text-muted">{t(`difficulty.${recipe.difficulty}`)}</span>}
+      </div>
+      <h3 className="font-display text-lg font-bold text-heading leading-tight group-hover:text-brand transition-colors">
+        {recipe.name}
+      </h3>
+      <p className="text-sm text-body line-clamp-2">{recipe.description}</p>
+      <div className="mt-auto flex items-center justify-between gap-4 pt-3 border-t border-divider text-xs text-muted">
+        <span className="flex items-center gap-1.5">
+          <Flame className="w-3.5 h-3.5" aria-hidden="true" />
+          {t('card.kcal', { n: recipe.nutrition.calories })}
+        </span>
+        {recipe.prep_time_min != null && (
+          <span className="flex items-center gap-1.5">
+            <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+            {t('card.prep_min', { n: recipe.prep_time_min })}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -1,0 +1,177 @@
+import { ArrowLeft, ChefHat, Clock, Flame, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { useRecipe } from '../../hooks/useRecipes.ts';
+
+export function RecipeDetailPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { t } = useTranslation('recipes');
+  const { recipe, loading, error } = useRecipe(slug);
+
+  useDocumentHead({
+    title: recipe ? `${recipe.name} · Wan2Fit` : t('detail.title_fallback'),
+    description: recipe?.description ?? t('detail.description_fallback'),
+  });
+
+  if (loading) {
+    return (
+      <div className="px-6 md:px-10 py-8">
+        <div className="max-w-3xl mx-auto space-y-4">
+          <div className="skeleton h-8 w-2/3 rounded-lg" />
+          <div className="skeleton h-4 w-full rounded" />
+          <div className="skeleton h-4 w-5/6 rounded" />
+          <div className="skeleton h-32 rounded-xl" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !recipe) {
+    return (
+      <div className="px-6 md:px-10 py-12">
+        <div className="max-w-2xl mx-auto text-center space-y-4">
+          <h1 className="font-display text-2xl font-bold text-heading">{t('detail.not_found_title')}</h1>
+          <p className="text-sm text-muted">{error ?? t('detail.not_found_body')}</p>
+          <Link to="/nutrition/recettes" className="inline-block text-sm text-brand hover:underline">
+            {t('detail.back_to_list')}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const macros = [
+    { label: t('macro.calories'), value: recipe.nutrition.calories, unit: 'kcal' },
+    { label: t('macro.protein'), value: recipe.nutrition.protein, unit: 'g' },
+    { label: t('macro.carbs'), value: recipe.nutrition.carbs, unit: 'g' },
+    { label: t('macro.fat'), value: recipe.nutrition.fat, unit: 'g' },
+  ];
+
+  return (
+    <article className="px-6 md:px-10 py-8">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <Link
+          to="/nutrition/recettes"
+          className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-body transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+          {t('detail.back_to_list')}
+        </Link>
+
+        <header className="space-y-3">
+          <span className="inline-block text-[10px] font-medium uppercase tracking-wider text-brand">
+            {t(`category.${recipe.category}`)}
+          </span>
+          <h1 className="font-display text-3xl sm:text-4xl font-black text-heading leading-tight">{recipe.name}</h1>
+          <p className="text-base text-body">{recipe.description}</p>
+        </header>
+
+        <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {recipe.prep_time_min != null && (
+            <Stat
+              icon={<Clock className="w-4 h-4" />}
+              label={t('detail.prep_time')}
+              value={t('card.prep_min', { n: recipe.prep_time_min })}
+            />
+          )}
+          <Stat icon={<Users className="w-4 h-4" />} label={t('detail.servings')} value={String(recipe.servings)} />
+          {recipe.difficulty && (
+            <Stat
+              icon={<ChefHat className="w-4 h-4" />}
+              label={t('detail.difficulty')}
+              value={t(`difficulty.${recipe.difficulty}`)}
+            />
+          )}
+          <Stat
+            icon={<Flame className="w-4 h-4" />}
+            label={t('macro.calories')}
+            value={`${recipe.nutrition.calories} kcal`}
+          />
+        </dl>
+
+        <section className="rounded-2xl border border-card-border bg-surface-card p-5 space-y-3">
+          <h2 className="font-display text-lg font-bold text-heading">{t('detail.nutrition_heading')}</h2>
+          <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {macros.map((m) => (
+              <div key={m.label}>
+                <dt className="text-[10px] font-medium uppercase tracking-wider text-muted">{m.label}</dt>
+                <dd className="text-base font-bold text-heading">
+                  {m.value}
+                  <span className="text-xs text-muted font-normal"> {m.unit}</span>
+                </dd>
+              </div>
+            ))}
+            {recipe.nutrition.fiber != null && (
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-wider text-muted">{t('macro.fiber')}</dt>
+                <dd className="text-base font-bold text-heading">
+                  {recipe.nutrition.fiber}
+                  <span className="text-xs text-muted font-normal"> g</span>
+                </dd>
+              </div>
+            )}
+          </dl>
+          <p className="text-[11px] text-muted">{t('detail.nutrition_per_serving', { n: recipe.servings })}</p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="font-display text-lg font-bold text-heading">{t('detail.ingredients_heading')}</h2>
+          <ul className="space-y-2">
+            {recipe.ingredients.map((ing, i) => (
+              <li
+                key={`ing-${i}-${ing.item}`}
+                className="flex gap-3 rounded-xl bg-surface-card border border-divider px-4 py-2.5 text-sm text-body"
+              >
+                {ing.qty && <span className="font-medium text-heading shrink-0 min-w-[5rem]">{ing.qty}</span>}
+                <span>{ing.item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="font-display text-lg font-bold text-heading">{t('detail.steps_heading')}</h2>
+          <ol className="space-y-3">
+            {recipe.steps.map((step, i) => (
+              <li key={`step-${i}`} className="flex gap-3">
+                <span className="shrink-0 flex items-center justify-center w-7 h-7 rounded-full bg-brand/15 text-brand text-xs font-bold">
+                  {i + 1}
+                </span>
+                <p className="text-sm text-body leading-relaxed pt-0.5">{step}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        {recipe.tags.length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-xs font-medium uppercase tracking-wider text-muted">{t('detail.tags_heading')}</h2>
+            <div className="flex flex-wrap gap-1.5">
+              {recipe.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-surface border border-divider px-2.5 py-1 text-[11px] text-body"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function Stat({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-divider bg-surface px-3 py-2">
+      <span className="text-muted shrink-0">{icon}</span>
+      <div className="min-w-0">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted truncate">{label}</div>
+        <div className="text-sm font-bold text-heading capitalize truncate">{value}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -112,7 +112,7 @@ export function RecipeDetailPage() {
               </div>
             )}
           </dl>
-          <p className="text-[11px] text-muted">{t('detail.nutrition_per_serving', { n: recipe.servings })}</p>
+          <p className="text-[11px] text-muted">{t('detail.nutrition_per_serving', { count: recipe.servings })}</p>
         </section>
 
         <section className="space-y-3">

--- a/src/components/recipes/RecipeFilters.tsx
+++ b/src/components/recipes/RecipeFilters.tsx
@@ -1,0 +1,112 @@
+import { Search, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { RecipeCategory } from '../../types/recipe.ts';
+
+export interface RecipeFiltersProps {
+  category: RecipeCategory | null;
+  search: string;
+  /** All tags found across the catalogue, already deduped & sorted. */
+  availableTags: string[];
+  selectedTags: string[];
+  onCategoryChange: (next: RecipeCategory | null) => void;
+  onSearchChange: (next: string) => void;
+  onTagToggle: (tag: string) => void;
+  onReset: () => void;
+}
+
+const CATEGORIES: RecipeCategory[] = ['pre', 'post', 'breakfast', 'recovery', 'snack', 'main', 'dessert', 'base'];
+
+export function RecipeFilters({
+  category,
+  search,
+  availableTags,
+  selectedTags,
+  onCategoryChange,
+  onSearchChange,
+  onTagToggle,
+  onReset,
+}: RecipeFiltersProps) {
+  const { t } = useTranslation('recipes');
+  const isActive = category != null || search.trim() !== '' || selectedTags.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <label className="relative block">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" aria-hidden="true" />
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={t('filters.search_placeholder')}
+          aria-label={t('filters.search_placeholder')}
+          className="w-full pl-9 pr-3 py-2 rounded-xl border border-divider bg-surface text-sm text-body placeholder:text-muted focus:outline-none focus:border-brand/50"
+        />
+      </label>
+
+      <fieldset className="flex flex-wrap gap-2 border-0 p-0 m-0">
+        <legend className="sr-only">{t('filters.category_aria')}</legend>
+        <Chip active={category == null} onClick={() => onCategoryChange(null)}>
+          {t('filters.category_all')}
+        </Chip>
+        {CATEGORIES.map((c) => (
+          <Chip key={c} active={category === c} onClick={() => onCategoryChange(category === c ? null : c)}>
+            {t(`category.${c}`)}
+          </Chip>
+        ))}
+      </fieldset>
+
+      {availableTags.length > 0 && (
+        <details className="group">
+          <summary className="text-xs text-muted cursor-pointer select-none hover:text-body transition-colors">
+            {t('filters.tags_toggle', { n: availableTags.length })}
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {availableTags.map((tag) => (
+              <Chip key={tag} active={selectedTags.includes(tag)} onClick={() => onTagToggle(tag)} small>
+                {tag}
+              </Chip>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {isActive && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex items-center gap-1 text-xs text-muted hover:text-body transition-colors"
+        >
+          <X className="w-3 h-3" aria-hidden="true" />
+          {t('filters.reset')}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Chip({
+  active,
+  onClick,
+  small = false,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  small?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-full border transition-colors ${small ? 'px-2.5 py-1 text-[11px]' : 'px-3 py-1.5 text-xs'} ${
+        active
+          ? 'bg-brand/15 border-brand/40 text-heading'
+          : 'bg-surface border-divider text-body hover:border-brand/30'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/recipes/RecipeListPage.tsx
+++ b/src/components/recipes/RecipeListPage.tsx
@@ -17,9 +17,12 @@ export function RecipeListPage() {
   const [search, setSearch] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
-  // Pull the unfiltered list once to drive both the result set AND the
-  // available-tags chip cloud — this way filtering doesn't shrink the chip
-  // options as the user narrows the result set.
+  // Two `useRecipes` calls — one unfiltered for the chip cloud, one filtered
+  // for the result grid. Both share queryKey `['recipes', locale]`, so React
+  // Query dedupes them into a single network fetch; only `applyFilters` runs
+  // twice, which is negligible at ≤ 100 rows. If the queryKey ever grows to
+  // include filters (e.g. server-side filtering), this would split into two
+  // real fetches — revisit then.
   const { recipes: allRecipes } = useRecipes();
   const { recipes, loading, error } = useRecipes({
     category,
@@ -74,7 +77,7 @@ export function RecipeListPage() {
           <p className="text-center text-sm text-muted py-12">{t('list.empty')}</p>
         ) : (
           <>
-            <p className="text-xs text-muted">{t('list.count', { n: recipes.length })}</p>
+            <p className="text-xs text-muted">{t('list.count', { count: recipes.length })}</p>
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {recipes.map((r) => (
                 <RecipeCard key={`${r.locale}-${r.recipe_key}`} recipe={r} />

--- a/src/components/recipes/RecipeListPage.tsx
+++ b/src/components/recipes/RecipeListPage.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { useRecipes } from '../../hooks/useRecipes.ts';
+import type { RecipeCategory } from '../../types/recipe.ts';
+import { RecipeCard } from './RecipeCard.tsx';
+import { RecipeFilters } from './RecipeFilters.tsx';
+
+export function RecipeListPage() {
+  const { t } = useTranslation('recipes');
+  useDocumentHead({
+    title: t('list.title'),
+    description: t('list.description'),
+  });
+
+  const [category, setCategory] = useState<RecipeCategory | null>(null);
+  const [search, setSearch] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  // Pull the unfiltered list once to drive both the result set AND the
+  // available-tags chip cloud — this way filtering doesn't shrink the chip
+  // options as the user narrows the result set.
+  const { recipes: allRecipes } = useRecipes();
+  const { recipes, loading, error } = useRecipes({
+    category,
+    tags: selectedTags,
+    search,
+  });
+
+  const availableTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of allRecipes) for (const t of r.tags) set.add(t);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [allRecipes]);
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+  }
+
+  function reset() {
+    setCategory(null);
+    setSearch('');
+    setSelectedTags([]);
+  }
+
+  return (
+    <div className="px-6 md:px-10 lg:px-14 py-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <header className="space-y-2">
+          <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">{t('list.heading')}</h1>
+          <p className="text-sm text-muted">{t('list.subtitle')}</p>
+        </header>
+
+        <RecipeFilters
+          category={category}
+          search={search}
+          availableTags={availableTags}
+          selectedTags={selectedTags}
+          onCategoryChange={setCategory}
+          onSearchChange={setSearch}
+          onTagToggle={toggleTag}
+          onReset={reset}
+        />
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {loading ? (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={`recipe-skel-${i}`} className="skeleton h-44 rounded-2xl" />
+            ))}
+          </div>
+        ) : recipes.length === 0 ? (
+          <p className="text-center text-sm text-muted py-12">{t('list.empty')}</p>
+        ) : (
+          <>
+            <p className="text-xs text-muted">{t('list.count', { n: recipes.length })}</p>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recipes.map((r) => (
+                <RecipeCard key={`${r.locale}-${r.recipe_key}`} recipe={r} />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useRecipes.test.ts
+++ b/src/hooks/useRecipes.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { Recipe } from '../types/recipe.ts';
+import { applyFilters } from './useRecipes.ts';
+
+function r(overrides: Partial<Recipe>): Recipe {
+  return {
+    recipe_key: 'k',
+    locale: 'fr',
+    slug: 's',
+    category: 'main',
+    name: 'Burger maison',
+    description: 'Boeuf, cheddar, pain brioché',
+    prep_time_min: 15,
+    difficulty: 'facile',
+    servings: 1,
+    nutrition: { calories: 600, protein: 30, carbs: 50, fat: 30 },
+    ingredients: [],
+    steps: [],
+    tags: ['protéiné', 'rapide'],
+    is_published: true,
+    created_at: '2026-05-02T00:00:00Z',
+    updated_at: '2026-05-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('applyFilters', () => {
+  const all = [
+    r({
+      recipe_key: 'a',
+      category: 'main',
+      name: 'Burger maison',
+      description: 'Boeuf, cheddar, pain brioché',
+      tags: ['protéiné', 'rapide'],
+    }),
+    r({
+      recipe_key: 'b',
+      category: 'breakfast',
+      name: 'Porridge banane',
+      description: 'Petit-dej facile et complet',
+      tags: ['végétarien', 'rapide'],
+    }),
+    r({
+      recipe_key: 'c',
+      category: 'main',
+      name: 'Salade quinoa',
+      description: 'Bowl léger riche en protéines',
+      tags: ['végétarien', 'fibres'],
+    }),
+  ];
+
+  it('returns everything with no filters', () => {
+    expect(applyFilters(all, {})).toHaveLength(3);
+  });
+
+  it('filters by category', () => {
+    expect(applyFilters(all, { category: 'main' })).toHaveLength(2);
+    expect(applyFilters(all, { category: 'breakfast' }).map((r) => r.recipe_key)).toEqual(['b']);
+  });
+
+  it('filters by single tag', () => {
+    expect(applyFilters(all, { tags: ['rapide'] }).map((r) => r.recipe_key)).toEqual(['a', 'b']);
+  });
+
+  it('treats multiple tags as AND, not OR', () => {
+    expect(applyFilters(all, { tags: ['végétarien', 'rapide'] }).map((r) => r.recipe_key)).toEqual(['b']);
+  });
+
+  it('search matches name (case-insensitive)', () => {
+    expect(applyFilters(all, { search: 'burger' }).map((r) => r.recipe_key)).toEqual(['a']);
+    expect(applyFilters(all, { search: 'BURGER' }).map((r) => r.recipe_key)).toEqual(['a']);
+  });
+
+  it('search matches description', () => {
+    expect(applyFilters(all, { search: 'cheddar' }).map((r) => r.recipe_key)).toEqual(['a']);
+  });
+
+  it('search matches tags', () => {
+    expect(applyFilters(all, { search: 'fibres' }).map((r) => r.recipe_key)).toEqual(['c']);
+  });
+
+  it('combines filters with AND semantics', () => {
+    expect(applyFilters(all, { category: 'main', tags: ['végétarien'] }).map((r) => r.recipe_key)).toEqual(['c']);
+  });
+
+  it('ignores blank search strings', () => {
+    expect(applyFilters(all, { search: '   ' })).toHaveLength(3);
+  });
+});

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -1,0 +1,113 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '../lib/supabase.ts';
+import type { Recipe, RecipeCategory, RecipeLocale } from '../types/recipe.ts';
+
+export interface RecipesFilters {
+  category?: RecipeCategory | null;
+  tags?: string[];
+  search?: string;
+}
+
+export interface UseRecipesResult {
+  recipes: Recipe[];
+  loading: boolean;
+  error: string | null;
+}
+
+function detectLocale(language: string): RecipeLocale {
+  return language?.startsWith('en') ? 'en' : 'fr';
+}
+
+/**
+ * Public listing — no auth required (recipes RLS allows anon SELECT when
+ * is_published = TRUE). Filters apply on the result set client-side because
+ * the catalogue is small (≤ 100 rows per locale) and avoids index-juggling
+ * on every filter combo.
+ */
+export function useRecipes(filters: RecipesFilters = {}): UseRecipesResult {
+  const { i18n } = useTranslation();
+  const locale = detectLocale(i18n.language);
+
+  const query = useQuery<{ recipes: Recipe[]; error: string | null }>({
+    queryKey: ['recipes', locale],
+    queryFn: async () => {
+      if (!supabase) return { recipes: [], error: null };
+      const { data, error } = await supabase
+        .from('recipes')
+        .select('*')
+        .eq('locale', locale)
+        .eq('is_published', true)
+        .order('category', { ascending: true })
+        .order('name', { ascending: true });
+
+      if (error) return { recipes: [], error: error.message };
+      return { recipes: (data ?? []) as Recipe[], error: null };
+    },
+    // Recipes are editorial content with infrequent changes; a longer staleTime
+    // keeps category/tag flips snappy without spamming Supabase.
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const all = query.data?.recipes ?? [];
+  const filtered = applyFilters(all, filters);
+
+  return {
+    recipes: filtered,
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+  };
+}
+
+export function applyFilters(recipes: Recipe[], filters: RecipesFilters): Recipe[] {
+  let out = recipes;
+  if (filters.category) out = out.filter((r) => r.category === filters.category);
+  if (filters.tags?.length) {
+    const wanted = filters.tags;
+    out = out.filter((r) => wanted.every((t) => r.tags.includes(t)));
+  }
+  if (filters.search?.trim()) {
+    const needle = filters.search.trim().toLowerCase();
+    out = out.filter(
+      (r) =>
+        r.name.toLowerCase().includes(needle) ||
+        r.description.toLowerCase().includes(needle) ||
+        r.tags.some((t) => t.toLowerCase().includes(needle)),
+    );
+  }
+  return out;
+}
+
+export function useRecipe(slug: string | undefined): {
+  recipe: Recipe | null;
+  loading: boolean;
+  error: string | null;
+} {
+  const { i18n } = useTranslation();
+  const locale = detectLocale(i18n.language);
+
+  const query = useQuery<{ recipe: Recipe | null; error: string | null }>({
+    queryKey: ['recipe', locale, slug ?? null],
+    queryFn: async () => {
+      if (!supabase || !slug) return { recipe: null, error: null };
+      const { data, error } = await supabase
+        .from('recipes')
+        .select('*')
+        .eq('locale', locale)
+        .eq('slug', slug)
+        .eq('is_published', true)
+        .maybeSingle();
+
+      if (error) return { recipe: null, error: error.message };
+      return { recipe: (data as Recipe) ?? null, error: null };
+    },
+    enabled: !!slug,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return {
+    recipe: query.data?.recipe ?? null,
+    loading: query.isPending,
+    error: query.data?.error ?? null,
+  };
+}

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -55,7 +55,10 @@ export function useRecipes(filters: RecipesFilters = {}): UseRecipesResult {
   return {
     recipes: filtered,
     loading: query.isPending,
-    error: query.data?.error ?? null,
+    // Distinguish a Supabase-returned error (in `data.error`) from an
+    // un-caught network failure (React Query's `query.error`). Without this,
+    // a connectivity blip looked like an empty catalogue.
+    error: query.data?.error ?? (query.isError ? String(query.error ?? '') : null),
   };
 }
 
@@ -78,6 +81,12 @@ export function applyFilters(recipes: Recipe[], filters: RecipesFilters): Recipe
   return out;
 }
 
+/**
+ * Slug↔locale invariant: each (recipe_key, locale) row has its own slug.
+ * If the user switches language while sitting on a FR slug, this hook will
+ * legitimately return `recipe: null` because the EN row has a different slug.
+ * Per-recipe URL rewrite/redirect on locale toggle lands in PR 5.
+ */
 export function useRecipe(slug: string | undefined): {
   recipe: Recipe | null;
   loading: boolean;
@@ -108,6 +117,6 @@ export function useRecipe(slug: string | undefined): {
   return {
     recipe: query.data?.recipe ?? null,
     loading: query.isPending,
-    error: query.data?.error ?? null,
+    error: query.data?.error ?? (query.isError ? String(query.error ?? '') : null),
   };
 }

--- a/src/i18n/locales/en/recipes.json
+++ b/src/i18n/locales/en/recipes.json
@@ -1,0 +1,62 @@
+{
+  "list": {
+    "title": "Wan2Fit Recipes · Sport and nutrition cooking",
+    "description": "49 recipes built for performance, recovery, and everyday meals. Filter by category, tag, ingredient.",
+    "heading": "Recipes",
+    "subtitle": "49 recipes built for performance, recovery, and everyday meals.",
+    "empty": "No recipe matches your filters.",
+    "count_one": "{{n}} recipe",
+    "count_other": "{{n}} recipes",
+    "count": "{{n}} recipes"
+  },
+  "detail": {
+    "title_fallback": "Recipe · Wan2Fit",
+    "description_fallback": "A Wan2Fit recipe.",
+    "not_found_title": "Recipe not found",
+    "not_found_body": "This recipe doesn't exist or has been removed.",
+    "back_to_list": "All recipes",
+    "prep_time": "Prep time",
+    "servings": "Servings",
+    "difficulty": "Difficulty",
+    "nutrition_heading": "Nutrition facts",
+    "nutrition_per_serving_one": "For {{n}} serving",
+    "nutrition_per_serving_other": "For {{n}} servings",
+    "nutrition_per_serving": "For {{n}} serving(s)",
+    "ingredients_heading": "Ingredients",
+    "steps_heading": "Steps",
+    "tags_heading": "Tags"
+  },
+  "filters": {
+    "search_placeholder": "Search by name or ingredient…",
+    "category_all": "All",
+    "category_aria": "Filter by category",
+    "tags_toggle": "Filter by tag ({{n}})",
+    "reset": "Reset filters"
+  },
+  "category": {
+    "pre": "Pre-workout",
+    "post": "Post-workout",
+    "breakfast": "Breakfast",
+    "recovery": "Recovery",
+    "snack": "Protein snack",
+    "main": "Everyday meals",
+    "dessert": "Desserts",
+    "base": "Bases & pastes"
+  },
+  "difficulty": {
+    "facile": "easy",
+    "moyen": "medium",
+    "difficile": "hard"
+  },
+  "macro": {
+    "calories": "Calories",
+    "protein": "Protein",
+    "carbs": "Carbs",
+    "fat": "Fat",
+    "fiber": "Fiber"
+  },
+  "card": {
+    "kcal": "{{n}} kcal",
+    "prep_min": "{{n}} min"
+  }
+}

--- a/src/i18n/locales/en/recipes.json
+++ b/src/i18n/locales/en/recipes.json
@@ -5,9 +5,8 @@
     "heading": "Recipes",
     "subtitle": "49 recipes built for performance, recovery, and everyday meals.",
     "empty": "No recipe matches your filters.",
-    "count_one": "{{n}} recipe",
-    "count_other": "{{n}} recipes",
-    "count": "{{n}} recipes"
+    "count_one": "{{count}} recipe",
+    "count_other": "{{count}} recipes"
   },
   "detail": {
     "title_fallback": "Recipe · Wan2Fit",
@@ -19,9 +18,8 @@
     "servings": "Servings",
     "difficulty": "Difficulty",
     "nutrition_heading": "Nutrition facts",
-    "nutrition_per_serving_one": "For {{n}} serving",
-    "nutrition_per_serving_other": "For {{n}} servings",
-    "nutrition_per_serving": "For {{n}} serving(s)",
+    "nutrition_per_serving_one": "For {{count}} serving",
+    "nutrition_per_serving_other": "For {{count}} servings",
     "ingredients_heading": "Ingredients",
     "steps_heading": "Steps",
     "tags_heading": "Tags"

--- a/src/i18n/locales/fr/recipes.json
+++ b/src/i18n/locales/fr/recipes.json
@@ -5,9 +5,8 @@
     "heading": "Recettes",
     "subtitle": "49 recettes pensées pour la performance, la récupération et le quotidien.",
     "empty": "Aucune recette ne correspond aux filtres.",
-    "count_one": "{{n}} recette",
-    "count_other": "{{n}} recettes",
-    "count": "{{n}} recettes"
+    "count_one": "{{count}} recette",
+    "count_other": "{{count}} recettes"
   },
   "detail": {
     "title_fallback": "Recette · Wan2Fit",
@@ -19,9 +18,8 @@
     "servings": "Portions",
     "difficulty": "Difficulté",
     "nutrition_heading": "Valeurs nutritionnelles",
-    "nutrition_per_serving_one": "Pour {{n}} portion",
-    "nutrition_per_serving_other": "Pour {{n}} portions",
-    "nutrition_per_serving": "Pour {{n}} portion(s)",
+    "nutrition_per_serving_one": "Pour {{count}} portion",
+    "nutrition_per_serving_other": "Pour {{count}} portions",
     "ingredients_heading": "Ingrédients",
     "steps_heading": "Préparation",
     "tags_heading": "Tags"

--- a/src/i18n/locales/fr/recipes.json
+++ b/src/i18n/locales/fr/recipes.json
@@ -1,0 +1,62 @@
+{
+  "list": {
+    "title": "Recettes Wan2Fit · Cuisine sport et nutrition",
+    "description": "49 recettes pensées pour la performance, la récupération et le quotidien. Filtre par catégorie, tag, ingrédient.",
+    "heading": "Recettes",
+    "subtitle": "49 recettes pensées pour la performance, la récupération et le quotidien.",
+    "empty": "Aucune recette ne correspond aux filtres.",
+    "count_one": "{{n}} recette",
+    "count_other": "{{n}} recettes",
+    "count": "{{n}} recettes"
+  },
+  "detail": {
+    "title_fallback": "Recette · Wan2Fit",
+    "description_fallback": "Une recette Wan2Fit.",
+    "not_found_title": "Recette introuvable",
+    "not_found_body": "Cette recette n'existe pas ou a été retirée.",
+    "back_to_list": "Toutes les recettes",
+    "prep_time": "Préparation",
+    "servings": "Portions",
+    "difficulty": "Difficulté",
+    "nutrition_heading": "Valeurs nutritionnelles",
+    "nutrition_per_serving_one": "Pour {{n}} portion",
+    "nutrition_per_serving_other": "Pour {{n}} portions",
+    "nutrition_per_serving": "Pour {{n}} portion(s)",
+    "ingredients_heading": "Ingrédients",
+    "steps_heading": "Préparation",
+    "tags_heading": "Tags"
+  },
+  "filters": {
+    "search_placeholder": "Rechercher une recette, un ingrédient…",
+    "category_all": "Toutes",
+    "category_aria": "Filtrer par catégorie",
+    "tags_toggle": "Filtrer par tag ({{n}})",
+    "reset": "Réinitialiser les filtres"
+  },
+  "category": {
+    "pre": "Pré-entraînement",
+    "post": "Post-entraînement",
+    "breakfast": "Petit-déjeuner",
+    "recovery": "Récupération",
+    "snack": "Snack protéiné",
+    "main": "Plats du quotidien",
+    "dessert": "Desserts",
+    "base": "Bases & pâtes"
+  },
+  "difficulty": {
+    "facile": "facile",
+    "moyen": "moyen",
+    "difficile": "difficile"
+  },
+  "macro": {
+    "calories": "Calories",
+    "protein": "Protéines",
+    "carbs": "Glucides",
+    "fat": "Lipides",
+    "fiber": "Fibres"
+  },
+  "card": {
+    "kcal": "{{n}} kcal",
+    "prep_min": "{{n}} min"
+  }
+}

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -13,6 +13,9 @@ const STATIC_ROUTES: SeoRoute[] = [
   { path: '/formats', changefreq: 'monthly', priority: 0.8 },
   { path: '/exercices', changefreq: 'monthly', priority: 0.8 },
   { path: '/programmes', changefreq: 'monthly', priority: 0.8 },
+  // Recipe listing — public, indexable. Per-recipe pages are emitted by PR 5
+  // (Supabase fetch at build time + sitemap entries with hreflang).
+  { path: '/nutrition/recettes', changefreq: 'weekly', priority: 0.8 },
   { path: '/tarifs', changefreq: 'monthly', priority: 0.8 },
   { path: '/premium', changefreq: 'monthly', priority: 0.7 },
   { path: '/a-propos', changefreq: 'monthly', priority: 0.6 },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -63,6 +63,12 @@ const LazyNutritionPage = lazy(() =>
 const LazyNutritionSetupPage = lazy(() =>
   import('./components/NutritionSetupPage.tsx').then((m) => ({ default: m.NutritionSetupPage })),
 );
+const LazyRecipeListPage = lazy(() =>
+  import('./components/recipes/RecipeListPage.tsx').then((m) => ({ default: m.RecipeListPage })),
+);
+const LazyRecipeDetailPage = lazy(() =>
+  import('./components/recipes/RecipeDetailPage.tsx').then((m) => ({ default: m.RecipeDetailPage })),
+);
 
 function Lazy({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<LoadingFallback />}>{children}</Suspense>;
@@ -118,6 +124,23 @@ export const router = createBrowserRouter([
         element: (
           <Lazy>
             <LazyExercisePage />
+          </Lazy>
+        ),
+      },
+      // Public recipes — accessible without auth, indexable by SEO
+      {
+        path: 'nutrition/recettes',
+        element: (
+          <Lazy>
+            <LazyRecipeListPage />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'nutrition/recettes/:slug',
+        element: (
+          <Lazy>
+            <LazyRecipeDetailPage />
           </Lazy>
         ),
       },


### PR DESCRIPTION
## Summary

Public `/nutrition/recettes` (listing with filters) and `/nutrition/recettes/:slug` (detail). Both are readable without auth — PR 3's RLS already allows anon SELECT on published recipes. Includes the EN translation of the 49 seed recipes.

## UI

- **RecipeListPage** — category chips + tag fieldset + search input + reset. Skeleton state while loading. AND semantics across filters.
- **RecipeDetailPage** — hero, prep stats (time/servings/difficulty/kcal), nutrition table, ingredients, numbered steps, tag pills. Graceful 404 if the slug isn't found.
- **RecipeCard** — category badge, difficulty pill, kcal, prep time.
- **RecipeFilters** — `<fieldset>`/`<legend>` for category, `<details>` for the tag cloud (deferred until needed), `aria-pressed` on every chip, reset button only when filters are active.

## Hooks

- `useRecipes(filters)` — one fetch per locale (10 min staleTime, content rarely changes). Filter logic kept client-side because the catalogue stays under 100 rows.
- `useRecipe(slug)` — `maybeSingle()` so a missing slug returns `null` instead of throwing.
- Both hooks read `i18n.language` and dispatch `fr`/`en` queries against the same `recipe_key`. The language toggle in `/parametres` swaps the rendered content.

## EN seed

- `scripts/data/recipes_en_seed.json` mirrors the FR file — same 49 IDs, same numeric values (`prepTime`, `servings`, `nutrition.*`), same `category` enum. `difficulty` stays in French (CHECK constraint accepts only `facile|moyen|difficile`); the UI translates the display via `t('difficulty.facile')` etc.
- `seed-recipes.ts` now takes an optional `fr|en` argument and defaults to seeding both. Per-locale slug-collision pre-flight is preserved.

## i18n

New `recipes` namespace in both FR and EN. The `check:i18n` script reports 17 namespaces and 2106 aligned keys.

## Routes & SEO

- Both routes added to `router.tsx` as public children of `PublicLayout` (no `RequireAuth` wrapper).
- `seoRoutes.ts` includes `/nutrition/recettes` so it's prerendered today (per-recipe pages land in PR 5 along with JSON-LD Recipe and the FR↔EN hreflang sitemap).

## Tests

- 9 new unit tests for `applyFilters` (category, tags AND-logic, search across name/desc/tags, blank-search guard, combined filters)
- Total: 380 passing

## PR plan reminder

This is **PR 4/6** of the autonomous nutrition + recipes batch. PR 5 wires the SEO (per-recipe prerender + JSON-LD + hreflang). PR 6 ships favourites UI.

## Manual rollout (post-merge)

```bash
npm run seed:recipes   # idempotent, seeds fr + en (98 rows)
```

## Test plan

- [ ] `/nutrition/recettes` loads as a visitor (not logged in), shows 49 cards
- [ ] Category chip filters narrow the results; clicking the same chip toggles off
- [ ] Tag chips combine with AND semantics
- [ ] Search matches name, description, and tags
- [ ] Reset clears every filter
- [ ] Click a card → `/nutrition/recettes/:slug` renders correctly
- [ ] Switch language to EN → recipes show in EN, URL stays at `/nutrition/recettes/...` (slug update + EN URL convention land in PR 5)
- [ ] 404 page on a bad slug
- [ ] Build prerender captures `/nutrition/recettes` (today's run shows 46/46 routes ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)