### PR TITLE
feat(seo): per-recipe prerender + JSON-LD Recipe + bilingual hreflang

### DIFF
--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -3,13 +3,15 @@
  *
  * Usage: tsx scripts/prerender.ts
  *
- * Boots `vite preview`, drives a headless Chromium through every public route
- * with a French locale, captures the rendered DOM (including JSON-LD structured
- * data), and writes `dist/<route>/index.html`. Also regenerates `dist/sitemap.xml`.
+ * Boots `vite preview`, drives a headless Chromium through every public route,
+ * captures the rendered DOM (including JSON-LD structured data), and writes
+ * `dist/<route>/index.html`. Also regenerates `dist/sitemap.xml` with hreflang
+ * alternates for the bilingual recipe pages.
  *
- * Locale: pre-rendering is FR-only by design. The SPA hydrates client-side and
- * lets users toggle EN via i18next; a single FR snapshot is enough for the FR
- * audience and matches `<html lang="fr">` in `index.html`.
+ * For routes that declare `alternates` in seoRoutes, this script also injects
+ * the corresponding `<link rel="alternate" hreflang="...">` tags directly into
+ * the captured HTML's `<head>` so search engines can discover the FR↔EN pair
+ * even from a single page hit.
  *
  * Designed to run after `vite build`.
  */
@@ -50,25 +52,50 @@ try {
   const page = await context.newPage();
 
   const failed: string[] = [];
+  /** Routes intentionally skipped (e.g. recipe details without seed). */
+  const skipped: string[] = [];
   let captured = 0;
 
   for (const route of routes) {
     const url = `${BASE}${route.path}`;
+    // Bilingual pages render under their URL's locale (the components read it
+    // from the path). Setting the browser locale to en-US for /en/ routes also
+    // makes useTranslation honour `accept-language` on the captured tab.
+    const browserLocale = route.path.startsWith('/en/') ? 'en-US' : 'fr-FR';
     try {
-      await page.goto(url, { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS });
+      const context = browser.contexts()[0] ?? (await browser.newContext({ locale: browserLocale }));
+      // The page reuses the same context; switching locale per route would
+      // require a new context, but we only need the differentiation for
+      // useTranslation's initial detection — overriding via `?lng=` works.
+      await page.goto(`${url}${route.path.startsWith('/en/') ? `?lng=en` : ''}`, {
+        waitUntil: 'networkidle',
+        timeout: NAV_TIMEOUT_MS,
+      });
+      void context;
       await page.waitForTimeout(SETTLE_MS);
-      const html = await page.content();
+      const rawHtml = await page.content();
       // SPA fallback always returns HTTP 200, so detect the NotFoundPage marker
       // instead — guards against silently capturing a 404 for routes listed in
       // seoRoutes but missing from the router.
-      if (route.path !== '/' && /text-brand[^"]*">404</.test(html)) {
+      if (route.path !== '/' && /text-brand[^"]*">404</.test(rawHtml)) {
         throw new Error('route resolved to NotFoundPage (404)');
       }
+      // Recipe detail pages are data-bound: if Supabase hasn't been seeded for
+      // this build env, the component renders the recipe-not-found state. Skip
+      // those routes (no dist file, no sitemap entry) so we never ship hollow
+      // pages. They'll be picked up by the next rebuild after the seed is in
+      // place. This is *expected*, not an error — `skipped` is reported but
+      // doesn't fail the build.
+      if (isRecipeDetailPath(route.path) && !rawHtml.includes('"@type":"Recipe"')) {
+        skipped.push(route.path);
+        continue;
+      }
+      const html = injectHreflangs(rawHtml, route);
       const outDir = route.path === '/' ? DIST : join(DIST, route.path);
       mkdirSync(outDir, { recursive: true });
       writeFileSync(join(outDir, 'index.html'), html);
       captured++;
-      process.stdout.write(`\r[prerender] ${captured}/${routes.length} ${route.path.padEnd(40)}`);
+      process.stdout.write(`\r[prerender] ${captured}/${routes.length} ${route.path.padEnd(50)}`);
     } catch (err) {
       failed.push(route.path);
       console.error(`\n[prerender] FAILED ${route.path}: ${(err as Error).message}`);
@@ -79,12 +106,18 @@ try {
     console.error(`\n[prerender] ${failed.length} route(s) failed: ${failed.join(', ')}`);
     hadError = true;
   } else {
-    console.log('\n[prerender] all routes captured');
+    console.log(`\n[prerender] ${captured} route(s) captured${skipped.length ? `, ${skipped.length} skipped` : ''}`);
+  }
+  if (skipped.length > 0) {
+    console.warn(
+      `[prerender] ${skipped.length} recipe detail route(s) skipped (Supabase seed not yet applied for this build env)`,
+    );
   }
 
-  // Sitemap reflects only successfully captured routes — avoid pointing crawlers
-  // at URLs whose static HTML may be stale or missing.
-  const successful = routes.filter((r) => !failed.includes(r.path));
+  // Sitemap reflects only routes whose HTML was actually written to dist/ —
+  // skipped + failed are excluded so crawlers never see hollow URLs.
+  const written = new Set(routes.map((r) => r.path).filter((p) => !failed.includes(p) && !skipped.includes(p)));
+  const successful = routes.filter((r) => written.has(r.path));
   const today = new Date().toISOString().split('T')[0];
   writeFileSync(join(DIST, 'sitemap.xml'), buildSitemap(successful, today));
   console.log(`[prerender] sitemap.xml: ${successful.length} routes, lastmod=${today}`);
@@ -131,13 +164,41 @@ function buildSitemap(items: SeoRoute[], lastmod: string): string {
       ];
       if (r.changefreq) parts.push(`    <changefreq>${r.changefreq}</changefreq>`);
       if (r.priority != null) parts.push(`    <priority>${r.priority}</priority>`);
+      // hreflang alternates per https://developers.google.com/search/docs/specialty/international/localized-versions
+      if (r.alternates?.length) {
+        for (const alt of r.alternates) {
+          parts.push(
+            `    <xhtml:link rel="alternate" hreflang="${alt.hreflang}" href="${SITE_URL}${alt.href}" />`,
+          );
+        }
+      }
       parts.push('  </url>');
       return parts.join('\n');
     })
     .join('\n');
   return `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 ${urls}
 </urlset>
 `;
+}
+
+/**
+ * Injects `<link rel="alternate" hreflang="...">` and a self-canonical into the
+ * captured HTML's `<head>`. Pages that already have a <link rel="canonical">
+ * (set by useDocumentHead at runtime) keep it; we just append the hreflang
+ * siblings. No-op when the route declares no alternates.
+ */
+function isRecipeDetailPath(path: string): boolean {
+  return /^\/(en\/)?nutrition\/(recettes|recipes)\/.+/.test(path);
+}
+
+function injectHreflangs(html: string, route: SeoRoute): string {
+  if (!route.alternates?.length) return html;
+  const links = route.alternates
+    .map((a) => `<link rel="alternate" hreflang="${a.hreflang}" href="${SITE_URL}${a.href}">`)
+    .join('');
+  // Insert just before </head> — works for the prerendered Vite shell which
+  // always emits a single <head> closing tag.
+  return html.replace(/<\/head>/i, `${links}</head>`);
 }

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -57,21 +57,14 @@ try {
   let captured = 0;
 
   for (const route of routes) {
-    const url = `${BASE}${route.path}`;
-    // Bilingual pages render under their URL's locale (the components read it
-    // from the path). Setting the browser locale to en-US for /en/ routes also
-    // makes useTranslation honour `accept-language` on the captured tab.
-    const browserLocale = route.path.startsWith('/en/') ? 'en-US' : 'fr-FR';
+    const isEnRoute = route.path.startsWith('/en/');
+    // Bilingual pages render under their URL's locale (recipe components read
+    // it from the path). The `?lng=en` query param drives i18next's initial
+    // language detection so the chrome (header, nav) renders in English too,
+    // matching the URL.
+    const url = `${BASE}${route.path}${isEnRoute ? '?lng=en' : ''}`;
     try {
-      const context = browser.contexts()[0] ?? (await browser.newContext({ locale: browserLocale }));
-      // The page reuses the same context; switching locale per route would
-      // require a new context, but we only need the differentiation for
-      // useTranslation's initial detection — overriding via `?lng=` works.
-      await page.goto(`${url}${route.path.startsWith('/en/') ? `?lng=en` : ''}`, {
-        waitUntil: 'networkidle',
-        timeout: NAV_TIMEOUT_MS,
-      });
-      void context;
+      await page.goto(url, { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS });
       await page.waitForTimeout(SETTLE_MS);
       const rawHtml = await page.content();
       // SPA fallback always returns HTTP 200, so detect the NotFoundPage marker
@@ -90,7 +83,7 @@ try {
         skipped.push(route.path);
         continue;
       }
-      const html = injectHreflangs(rawHtml, route);
+      const html = postProcessHtml(rawHtml, route);
       const outDir = route.path === '/' ? DIST : join(DIST, route.path);
       mkdirSync(outDir, { recursive: true });
       writeFileSync(join(outDir, 'index.html'), html);
@@ -193,12 +186,24 @@ function isRecipeDetailPath(path: string): boolean {
   return /^\/(en\/)?nutrition\/(recettes|recipes)\/.+/.test(path);
 }
 
-function injectHreflangs(html: string, route: SeoRoute): string {
-  if (!route.alternates?.length) return html;
-  const links = route.alternates
-    .map((a) => `<link rel="alternate" hreflang="${a.hreflang}" href="${SITE_URL}${a.href}">`)
-    .join('');
-  // Insert just before </head> — works for the prerendered Vite shell which
-  // always emits a single <head> closing tag.
-  return html.replace(/<\/head>/i, `${links}</head>`);
+/**
+ * Post-rendering tweaks applied to every captured HTML before writing it:
+ * - Inject hreflang `<link>` siblings under `<head>` for routes that have
+ *   declared alternates in seoRoutes.
+ * - For EN routes, swap the shell's `<html lang="fr">` for `<html lang="en">`
+ *   so the document's primary language matches its URL and content.
+ */
+function postProcessHtml(html: string, route: SeoRoute): string {
+  let next = html;
+  if (route.path.startsWith('/en/')) {
+    next = next.replace(/<html(\s[^>]*)?\slang="fr"/i, '<html$1 lang="en"');
+  }
+  if (route.alternates?.length) {
+    const links = route.alternates
+      .map((a) => `<link rel="alternate" hreflang="${a.hreflang}" href="${SITE_URL}${a.href}">`)
+      .join('');
+    // Insert just before </head> — works for the Vite shell which emits one.
+    next = next.replace(/<\/head>/i, `${links}</head>`);
+  }
+  return next;
 }

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -1,18 +1,25 @@
 import { ArrowLeft, ChefHat, Clock, Flame, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router';
+import { Link, useLocation, useParams } from 'react-router';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { useRecipe } from '../../hooks/useRecipes.ts';
+import { JsonLd } from '../../lib/JsonLd.tsx';
+import { breadcrumbJsonLd, minutesToISODuration, recipeJsonLd } from '../../lib/jsonld.ts';
+import { getRecipeLocaleFromPath, recipeListingUrlForLocale } from '../../utils/localePath.ts';
 
 export function RecipeDetailPage() {
   const { slug } = useParams<{ slug: string }>();
   const { t } = useTranslation('recipes');
+  const { pathname } = useLocation();
+  const locale = getRecipeLocaleFromPath(pathname);
   const { recipe, loading, error } = useRecipe(slug);
 
   useDocumentHead({
     title: recipe ? `${recipe.name} · Wan2Fit` : t('detail.title_fallback'),
     description: recipe?.description ?? t('detail.description_fallback'),
   });
+
+  const listingUrl = recipeListingUrlForLocale(locale);
 
   if (loading) {
     return (
@@ -33,7 +40,7 @@ export function RecipeDetailPage() {
         <div className="max-w-2xl mx-auto text-center space-y-4">
           <h1 className="font-display text-2xl font-bold text-heading">{t('detail.not_found_title')}</h1>
           <p className="text-sm text-muted">{error ?? t('detail.not_found_body')}</p>
-          <Link to="/nutrition/recettes" className="inline-block text-sm text-brand hover:underline">
+          <Link to={listingUrl} className="inline-block text-sm text-brand hover:underline">
             {t('detail.back_to_list')}
           </Link>
         </div>
@@ -48,11 +55,41 @@ export function RecipeDetailPage() {
     { label: t('macro.fat'), value: recipe.nutrition.fat, unit: 'g' },
   ];
 
+  // Schema.org Recipe payload — drives Google Rich Results and gives LLMs a
+  // structured view of the recipe (ingredients, steps, nutrition).
+  const recipeSchema = recipeJsonLd({
+    name: recipe.name,
+    description: recipe.description,
+    url: pathname,
+    inLanguage: locale === 'en' ? 'en-US' : 'fr-FR',
+    recipeCategory: t(`category.${recipe.category}`),
+    recipeYield: recipe.servings,
+    totalTime: minutesToISODuration(recipe.prep_time_min ?? null),
+    recipeIngredient: recipe.ingredients.map((ing) => `${ing.qty ? `${ing.qty} ` : ''}${ing.item}`.trim()),
+    recipeInstructions: recipe.steps,
+    nutrition: {
+      calories: recipe.nutrition.calories,
+      protein_g: recipe.nutrition.protein,
+      carbs_g: recipe.nutrition.carbs,
+      fat_g: recipe.nutrition.fat,
+      fiber_g: recipe.nutrition.fiber,
+      servings: recipe.servings,
+    },
+    keywords: recipe.tags,
+  });
+  const breadcrumbsSchema = breadcrumbJsonLd([
+    { name: t('breadcrumb.home', { ns: 'common' }), url: '/' },
+    { name: t('list.heading'), url: listingUrl },
+    { name: recipe.name, url: pathname },
+  ]);
+
   return (
     <article className="px-6 md:px-10 py-8">
+      <JsonLd data={breadcrumbsSchema} />
+      <JsonLd data={recipeSchema} />
       <div className="max-w-3xl mx-auto space-y-8">
         <Link
-          to="/nutrition/recettes"
+          to={listingUrl}
           className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-body transition-colors"
         >
           <ArrowLeft className="w-4 h-4" aria-hidden="true" />

--- a/src/components/recipes/RecipeListPage.tsx
+++ b/src/components/recipes/RecipeListPage.tsx
@@ -1,13 +1,19 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { useRecipes } from '../../hooks/useRecipes.ts';
+import { JsonLd } from '../../lib/JsonLd.tsx';
+import { breadcrumbJsonLd, SITE_URL } from '../../lib/jsonld.ts';
 import type { RecipeCategory } from '../../types/recipe.ts';
+import { getRecipeLocaleFromPath, recipeUrlForLocale } from '../../utils/localePath.ts';
 import { RecipeCard } from './RecipeCard.tsx';
 import { RecipeFilters } from './RecipeFilters.tsx';
 
 export function RecipeListPage() {
   const { t } = useTranslation('recipes');
+  const { pathname } = useLocation();
+  const locale = getRecipeLocaleFromPath(pathname);
   useDocumentHead({
     title: t('list.title'),
     description: t('list.description'),
@@ -46,8 +52,27 @@ export function RecipeListPage() {
     setSelectedTags([]);
   }
 
+  // ItemList schema for the listing helps Google understand the page structure
+  // and surface individual recipes as separate results.
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: recipes.slice(0, 30).map((r, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `${SITE_URL}${recipeUrlForLocale(locale, r.slug)}`,
+      name: r.name,
+    })),
+  };
+  const breadcrumbsJsonLd = breadcrumbJsonLd([
+    { name: t('breadcrumb.home', { ns: 'common' }), url: '/' },
+    { name: t('list.heading'), url: pathname },
+  ]);
+
   return (
     <div className="px-6 md:px-10 lg:px-14 py-8">
+      <JsonLd data={breadcrumbsJsonLd} />
+      <JsonLd data={itemListJsonLd} />
       <div className="max-w-5xl mx-auto space-y-8">
         <header className="space-y-2">
           <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">{t('list.heading')}</h1>

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
 import { supabase } from '../lib/supabase.ts';
 import type { Recipe, RecipeCategory, RecipeLocale } from '../types/recipe.ts';
+import { getRecipeLocaleFromPath } from '../utils/localePath.ts';
 
 export interface RecipesFilters {
   category?: RecipeCategory | null;
@@ -15,19 +16,19 @@ export interface UseRecipesResult {
   error: string | null;
 }
 
-function detectLocale(language: string): RecipeLocale {
-  return language?.startsWith('en') ? 'en' : 'fr';
-}
-
 /**
  * Public listing — no auth required (recipes RLS allows anon SELECT when
  * is_published = TRUE). Filters apply on the result set client-side because
  * the catalogue is small (≤ 100 rows per locale) and avoids index-juggling
  * on every filter combo.
+ *
+ * Locale is derived from the URL (`/en/...` ⇒ en, otherwise fr) rather than
+ * `i18n.language` so the rendered locale matches the indexed URL. The user's
+ * preference toggle in /parametres switches the URL itself.
  */
 export function useRecipes(filters: RecipesFilters = {}): UseRecipesResult {
-  const { i18n } = useTranslation();
-  const locale = detectLocale(i18n.language);
+  const { pathname } = useLocation();
+  const locale: RecipeLocale = getRecipeLocaleFromPath(pathname);
 
   const query = useQuery<{ recipes: Recipe[]; error: string | null }>({
     queryKey: ['recipes', locale],
@@ -82,18 +83,17 @@ export function applyFilters(recipes: Recipe[], filters: RecipesFilters): Recipe
 }
 
 /**
- * Slug↔locale invariant: each (recipe_key, locale) row has its own slug.
- * If the user switches language while sitting on a FR slug, this hook will
- * legitimately return `recipe: null` because the EN row has a different slug.
- * Per-recipe URL rewrite/redirect on locale toggle lands in PR 5.
+ * Locale comes from the URL (`/en/...` is en, anything else is fr). This way
+ * a deep-linked French slug under `/nutrition/recettes/...` keeps querying
+ * FR rows even if the user has set their UI preference to English.
  */
 export function useRecipe(slug: string | undefined): {
   recipe: Recipe | null;
   loading: boolean;
   error: string | null;
 } {
-  const { i18n } = useTranslation();
-  const locale = detectLocale(i18n.language);
+  const { pathname } = useLocation();
+  const locale: RecipeLocale = getRecipeLocaleFromPath(pathname);
 
   const query = useQuery<{ recipe: Recipe | null; error: string | null }>({
     queryKey: ['recipe', locale, slug ?? null],

--- a/src/lib/jsonld.test.ts
+++ b/src/lib/jsonld.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { minutesToISODuration, recipeJsonLd, stepName } from './jsonld.ts';
+
+describe('minutesToISODuration', () => {
+  it('formats positive minutes as ISO 8601', () => {
+    expect(minutesToISODuration(15)).toBe('PT15M');
+    expect(minutesToISODuration(90)).toBe('PT90M');
+  });
+
+  it('rounds fractional minutes', () => {
+    expect(minutesToISODuration(15.4)).toBe('PT15M');
+    expect(minutesToISODuration(15.6)).toBe('PT16M');
+  });
+
+  it('returns undefined for null/undefined/non-positive values', () => {
+    expect(minutesToISODuration(null)).toBeUndefined();
+    expect(minutesToISODuration(undefined)).toBeUndefined();
+    expect(minutesToISODuration(0)).toBeUndefined();
+    expect(minutesToISODuration(-5)).toBeUndefined();
+  });
+});
+
+describe('stepName', () => {
+  it('returns the full step text when short enough', () => {
+    expect(stepName('Toaster les tranches.', 1)).toBe('Toaster les tranches');
+  });
+
+  it('extracts the first sentence when text contains multiple sentences', () => {
+    expect(stepName('Toaster les tranches. Réserver.', 1)).toBe('Toaster les tranches');
+    expect(stepName('Mélanger ! Cuire à feu doux.', 1)).toBe('Mélanger');
+  });
+
+  it('truncates long single sentences with an ellipsis', () => {
+    const long = 'a'.repeat(80);
+    const out = stepName(long, 1);
+    expect(out.length).toBeLessThanOrEqual(60);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to an indexed placeholder for empty/whitespace input', () => {
+    expect(stepName('', 1)).toBe('Étape 1');
+    expect(stepName('   ', 3)).toBe('Étape 3');
+  });
+});
+
+describe('recipeJsonLd', () => {
+  const baseInput = {
+    name: 'Toast & œuf',
+    description: 'Toast complet avec un œuf mollet.',
+    url: '/nutrition/recettes/toast-oeuf',
+    recipeIngredient: ['2 tranches Pain complet', '1 Œuf'],
+    recipeInstructions: ['Toaster le pain.', 'Cuire l’œuf 6 min.'],
+  };
+
+  it('emits the canonical schema.org Recipe envelope', () => {
+    const out = recipeJsonLd(baseInput);
+    expect(out['@context']).toBe('https://schema.org');
+    expect(out['@type']).toBe('Recipe');
+    expect(out.name).toBe(baseInput.name);
+    expect(out.url).toMatch(/^https:\/\/.*\/nutrition\/recettes\/toast-oeuf$/);
+    expect(out.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': expect.stringMatching(/\/nutrition\/recettes\/toast-oeuf$/),
+    });
+  });
+
+  it('defaults inLanguage to fr-FR', () => {
+    expect(recipeJsonLd(baseInput).inLanguage).toBe('fr-FR');
+  });
+
+  it('honours an explicit inLanguage', () => {
+    expect(recipeJsonLd({ ...baseInput, inLanguage: 'en-US' }).inLanguage).toBe('en-US');
+  });
+
+  it('expands recipeInstructions into HowToStep with name + position + text', () => {
+    const out = recipeJsonLd(baseInput);
+    expect(out.recipeInstructions).toEqual([
+      { '@type': 'HowToStep', position: 1, name: 'Toaster le pain', text: 'Toaster le pain.' },
+      { '@type': 'HowToStep', position: 2, name: 'Cuire l’œuf 6 min', text: 'Cuire l’œuf 6 min.' },
+    ]);
+  });
+
+  it('emits NutritionInformation with the canonical "1 serving" servingSize', () => {
+    const out = recipeJsonLd({
+      ...baseInput,
+      nutrition: { calories: 320, protein_g: 18, carbs_g: 30, fat_g: 12, fiber_g: 4, servings: 2 },
+    });
+    expect(out.nutrition).toEqual({
+      '@type': 'NutritionInformation',
+      calories: '320 kcal',
+      proteinContent: '18 g',
+      carbohydrateContent: '30 g',
+      fatContent: '12 g',
+      fiberContent: '4 g',
+      servingSize: '1 serving',
+    });
+  });
+
+  it('omits fiberContent when fiber is missing', () => {
+    const out = recipeJsonLd({
+      ...baseInput,
+      nutrition: { calories: 320, protein_g: 18, carbs_g: 30, fat_g: 12, servings: 1 },
+    });
+    expect(out.nutrition?.fiberContent).toBeUndefined();
+  });
+
+  it('joins keywords with commas (omits when empty)', () => {
+    expect(recipeJsonLd({ ...baseInput, keywords: ['quick', 'high-protein'] }).keywords).toBe('quick, high-protein');
+    expect(recipeJsonLd({ ...baseInput, keywords: [] }).keywords).toBeUndefined();
+    expect(recipeJsonLd(baseInput).keywords).toBeUndefined();
+  });
+});

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -139,6 +139,26 @@ export function minutesToISODuration(minutes: number | null | undefined): string
   return `PT${Math.round(minutes)}M`;
 }
 
+const STEP_NAME_MAX_CHARS = 60;
+
+/**
+ * Derives a short HowToStep `name` from the full step text. Splits on the first
+ * sentence terminator and truncates to keep the name digestible in rich-result
+ * cards. Falls back to an indexed placeholder for unusable input.
+ */
+export function stepName(text: string, index: number): string {
+  const trimmed = text.trim();
+  if (!trimmed) return `Étape ${index}`;
+  // First sentence — split on a terminator followed by whitespace OR end of
+  // string, then strip any trailing terminator + whitespace.
+  const firstSentence = trimmed
+    .split(/(?<=[.!?])(?:\s|$)/, 1)[0]
+    .replace(/[.!?\s]+$/, '')
+    .trim();
+  if (firstSentence.length <= STEP_NAME_MAX_CHARS) return firstSentence;
+  return `${firstSentence.slice(0, STEP_NAME_MAX_CHARS - 1).trimEnd()}…`;
+}
+
 export function recipeJsonLd(input: RecipeJsonLdInput) {
   return {
     '@context': 'https://schema.org',
@@ -154,6 +174,10 @@ export function recipeJsonLd(input: RecipeJsonLdInput) {
     recipeInstructions: input.recipeInstructions.map((step, i) => ({
       '@type': 'HowToStep',
       position: i + 1,
+      // Google's Recipe rich-results validator wants a non-empty `name` per
+      // step. Use the first sentence (truncated to 60 chars) so the value is
+      // descriptive without duplicating the whole step text.
+      name: stepName(step, i + 1),
       text: step,
     })),
     nutrition: input.nutrition
@@ -164,7 +188,10 @@ export function recipeJsonLd(input: RecipeJsonLdInput) {
           carbohydrateContent: `${input.nutrition.carbs_g} g`,
           fatContent: `${input.nutrition.fat_g} g`,
           fiberContent: input.nutrition.fiber_g != null ? `${input.nutrition.fiber_g} g` : undefined,
-          servingSize: `1 of ${input.nutrition.servings}`,
+          // Schema.org expects a measurable description, not a fraction. Our
+          // recipes don't expose grams-per-serving, so we use the canonical
+          // "1 serving" string which the rich-results tester accepts.
+          servingSize: '1 serving',
         }
       : undefined,
     keywords: input.keywords?.length ? input.keywords.join(', ') : undefined,

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -108,3 +108,67 @@ function absoluteUrl(path: string): string {
   if (path.startsWith('http')) return path;
   return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
 }
+
+export interface RecipeJsonLdInput {
+  name: string;
+  description: string;
+  url: string;
+  image?: string;
+  inLanguage?: string;
+  recipeCategory?: string;
+  recipeYield?: number;
+  /** ISO 8601 duration, e.g. "PT15M". Built by `minutesToISODuration` below. */
+  totalTime?: string;
+  recipeIngredient: string[];
+  recipeInstructions: string[];
+  nutrition?: {
+    calories: number;
+    protein_g: number;
+    carbs_g: number;
+    fat_g: number;
+    fiber_g?: number;
+    /** Servings the nutrition values reference, used to fill `servingSize`. */
+    servings: number;
+  };
+  keywords?: string[];
+}
+
+/** Convert a positive minute count to an ISO 8601 duration ("PT15M"). */
+export function minutesToISODuration(minutes: number | null | undefined): string | undefined {
+  if (minutes == null || minutes <= 0) return undefined;
+  return `PT${Math.round(minutes)}M`;
+}
+
+export function recipeJsonLd(input: RecipeJsonLdInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Recipe',
+    name: input.name,
+    description: input.description,
+    image: input.image ? absoluteUrl(input.image) : undefined,
+    inLanguage: input.inLanguage ?? 'fr-FR',
+    recipeCategory: input.recipeCategory,
+    recipeYield: input.recipeYield,
+    totalTime: input.totalTime,
+    recipeIngredient: input.recipeIngredient,
+    recipeInstructions: input.recipeInstructions.map((step, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      text: step,
+    })),
+    nutrition: input.nutrition
+      ? {
+          '@type': 'NutritionInformation',
+          calories: `${input.nutrition.calories} kcal`,
+          proteinContent: `${input.nutrition.protein_g} g`,
+          carbohydrateContent: `${input.nutrition.carbs_g} g`,
+          fatContent: `${input.nutrition.fat_g} g`,
+          fiberContent: input.nutrition.fiber_g != null ? `${input.nutrition.fiber_g} g` : undefined,
+          servingSize: `1 of ${input.nutrition.servings}`,
+        }
+      : undefined,
+    keywords: input.keywords?.length ? input.keywords.join(', ') : undefined,
+    url: `${SITE_URL}${input.url}`,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': `${SITE_URL}${input.url}` },
+  };
+}

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -1,10 +1,27 @@
+import enRecipes from '../../scripts/data/recipes_en_seed.json' with { type: 'json' };
+import frRecipes from '../../scripts/data/recipes_fr_seed.json' with { type: 'json' };
 import { EXERCISES_DATA } from '../data/exercises.ts';
 import { FORMATS_DATA } from '../data/formats.ts';
+import { slugify } from '../utils/slug.ts';
+
+export type Hreflang = 'fr-FR' | 'en-US' | 'x-default';
+
+export interface SeoAlternate {
+  hreflang: Hreflang;
+  /** Absolute path on this site, e.g. /en/nutrition/recipes/sweet-potato-toast. */
+  href: string;
+}
 
 export interface SeoRoute {
   path: string;
   changefreq?: 'daily' | 'weekly' | 'monthly' | 'yearly';
   priority?: number;
+  /**
+   * Alternate translations of this page. Emitted as `<xhtml:link rel="alternate"
+   * hreflang="...">` in the sitemap so search engines can index both locales
+   * and serve the right one to each user.
+   */
+  alternates?: SeoAlternate[];
 }
 
 const STATIC_ROUTES: SeoRoute[] = [
@@ -13,9 +30,6 @@ const STATIC_ROUTES: SeoRoute[] = [
   { path: '/formats', changefreq: 'monthly', priority: 0.8 },
   { path: '/exercices', changefreq: 'monthly', priority: 0.8 },
   { path: '/programmes', changefreq: 'monthly', priority: 0.8 },
-  // Recipe listing — public, indexable. Per-recipe pages are emitted by PR 5
-  // (Supabase fetch at build time + sitemap entries with hreflang).
-  { path: '/nutrition/recettes', changefreq: 'weekly', priority: 0.8 },
   { path: '/tarifs', changefreq: 'monthly', priority: 0.8 },
   { path: '/premium', changefreq: 'monthly', priority: 0.7 },
   { path: '/a-propos', changefreq: 'monthly', priority: 0.6 },
@@ -26,6 +40,28 @@ const STATIC_ROUTES: SeoRoute[] = [
 ];
 
 export const FIXED_PROGRAM_SLUGS = ['debutant-4-semaines', 'remise-en-forme', 'cardio-express'] as const;
+
+interface SeedRecipeMinimal {
+  id: string;
+  name: string;
+}
+
+interface SeedFile {
+  recipes: SeedRecipeMinimal[];
+}
+
+const FR_SEED = frRecipes as SeedFile;
+const EN_SEED = enRecipes as SeedFile;
+
+/** Build a recipe_key → slug index per locale once at module load. */
+function buildSlugIndex(seed: SeedFile): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const r of seed.recipes) map.set(r.id, slugify(r.name));
+  return map;
+}
+
+const FR_SLUGS = buildSlugIndex(FR_SEED);
+const EN_SLUGS = buildSlugIndex(EN_SEED);
 
 export function getPublicRoutes(): SeoRoute[] {
   const formatRoutes: SeoRoute[] = FORMATS_DATA.map((f) => ({
@@ -46,5 +82,49 @@ export function getPublicRoutes(): SeoRoute[] {
     priority: 0.7,
   }));
 
-  return [...STATIC_ROUTES, ...formatRoutes, ...exerciseRoutes, ...programRoutes];
+  // Recipe listings (FR + EN) cross-link via hreflang.
+  const recipeListingFr: SeoRoute = {
+    path: '/nutrition/recettes',
+    changefreq: 'weekly',
+    priority: 0.8,
+    alternates: [
+      { hreflang: 'fr-FR', href: '/nutrition/recettes' },
+      { hreflang: 'en-US', href: '/en/nutrition/recipes' },
+      { hreflang: 'x-default', href: '/nutrition/recettes' },
+    ],
+  };
+  const recipeListingEn: SeoRoute = {
+    path: '/en/nutrition/recipes',
+    changefreq: 'weekly',
+    priority: 0.7,
+    alternates: recipeListingFr.alternates,
+  };
+
+  // Per-recipe pages: one route per (recipe_key, locale). Each pair shares a
+  // recipe_key so we can build the alternates link group across locales.
+  const recipeDetailRoutes: SeoRoute[] = [];
+  for (const [recipeKey, frSlug] of FR_SLUGS) {
+    const enSlug = EN_SLUGS.get(recipeKey);
+    const frPath = `/nutrition/recettes/${frSlug}`;
+    const enPath = enSlug ? `/en/nutrition/recipes/${enSlug}` : null;
+    const alternates: SeoAlternate[] = [
+      { hreflang: 'fr-FR', href: frPath },
+      ...(enPath ? [{ hreflang: 'en-US' as const, href: enPath }] : []),
+      { hreflang: 'x-default', href: frPath },
+    ];
+    recipeDetailRoutes.push({ path: frPath, changefreq: 'monthly', priority: 0.6, alternates });
+    if (enPath) {
+      recipeDetailRoutes.push({ path: enPath, changefreq: 'monthly', priority: 0.5, alternates });
+    }
+  }
+
+  return [
+    ...STATIC_ROUTES,
+    recipeListingFr,
+    recipeListingEn,
+    ...formatRoutes,
+    ...exerciseRoutes,
+    ...programRoutes,
+    ...recipeDetailRoutes,
+  ];
 }

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -1,3 +1,9 @@
+/**
+ * BUILD-TIME ONLY — do not import from any module shipped to the browser.
+ * This file pulls in the recipe seed JSONs (~150 KB combined) to enumerate
+ * sitemap entries; importing it client-side would bundle that payload.
+ * The only legitimate consumer is `scripts/prerender.ts`.
+ */
 import enRecipes from '../../scripts/data/recipes_en_seed.json' with { type: 'json' };
 import frRecipes from '../../scripts/data/recipes_fr_seed.json' with { type: 'json' };
 import { EXERCISES_DATA } from '../data/exercises.ts';

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -127,7 +127,9 @@ export const router = createBrowserRouter([
           </Lazy>
         ),
       },
-      // Public recipes — accessible without auth, indexable by SEO
+      // Public recipes — accessible without auth, indexable by SEO.
+      // FR is the canonical namespace; EN lives under `/en/` with localised
+      // path segments so the URLs themselves are translated for SEO.
       {
         path: 'nutrition/recettes',
         element: (
@@ -138,6 +140,22 @@ export const router = createBrowserRouter([
       },
       {
         path: 'nutrition/recettes/:slug',
+        element: (
+          <Lazy>
+            <LazyRecipeDetailPage />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'en/nutrition/recipes',
+        element: (
+          <Lazy>
+            <LazyRecipeListPage />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'en/nutrition/recipes/:slug',
         element: (
           <Lazy>
             <LazyRecipeDetailPage />

--- a/src/utils/localePath.test.ts
+++ b/src/utils/localePath.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getRecipeLocaleFromPath, recipeListingUrlForLocale, recipeUrlForLocale } from './localePath.ts';
+
+describe('getRecipeLocaleFromPath', () => {
+  it('returns en when path is under /en/', () => {
+    expect(getRecipeLocaleFromPath('/en/nutrition/recipes')).toBe('en');
+    expect(getRecipeLocaleFromPath('/en/nutrition/recipes/sweet-potato-toast')).toBe('en');
+  });
+
+  it('returns fr for canonical FR paths', () => {
+    expect(getRecipeLocaleFromPath('/nutrition/recettes')).toBe('fr');
+    expect(getRecipeLocaleFromPath('/nutrition/recettes/toast-patate-douce')).toBe('fr');
+    expect(getRecipeLocaleFromPath('/')).toBe('fr');
+  });
+
+  it('does not match a path that merely contains "en/"', () => {
+    expect(getRecipeLocaleFromPath('/contenu/en/something')).toBe('fr');
+    expect(getRecipeLocaleFromPath('/en')).toBe('fr');
+  });
+});
+
+describe('recipeUrlForLocale', () => {
+  it('builds the canonical FR URL', () => {
+    expect(recipeUrlForLocale('fr', 'porridge-banane-miel')).toBe('/nutrition/recettes/porridge-banane-miel');
+  });
+
+  it('builds the EN URL with the /en/ prefix and the English path', () => {
+    expect(recipeUrlForLocale('en', 'porridge-banana-honey')).toBe('/en/nutrition/recipes/porridge-banana-honey');
+  });
+});
+
+describe('recipeListingUrlForLocale', () => {
+  it('points to the FR listing by default', () => {
+    expect(recipeListingUrlForLocale('fr')).toBe('/nutrition/recettes');
+  });
+
+  it('points to the EN listing under /en/', () => {
+    expect(recipeListingUrlForLocale('en')).toBe('/en/nutrition/recipes');
+  });
+});

--- a/src/utils/localePath.ts
+++ b/src/utils/localePath.ts
@@ -1,0 +1,28 @@
+import type { RecipeLocale } from '../types/recipe.ts';
+
+/**
+ * Returns the locale of a Wan2Fit URL by inspecting the path prefix.
+ *
+ * - `/en/...` is the EN namespace
+ * - everything else is the canonical FR namespace
+ *
+ * Used by recipe components so the locale rendered in the page is bound to
+ * the URL the crawler indexed, not to the user's i18n preference. Without
+ * this, switching the language toggle would mis-render a prerendered page.
+ */
+export function getRecipeLocaleFromPath(pathname: string): RecipeLocale {
+  return pathname.startsWith('/en/') ? 'en' : 'fr';
+}
+
+/**
+ * Builds the URL of the same recipe in the alternate locale, given the
+ * current path's locale and the alternate slug. Returns null when there is
+ * no alternate (single-locale recipe).
+ */
+export function recipeUrlForLocale(locale: RecipeLocale, slug: string): string {
+  return locale === 'en' ? `/en/nutrition/recipes/${slug}` : `/nutrition/recettes/${slug}`;
+}
+
+export function recipeListingUrlForLocale(locale: RecipeLocale): string {
+  return locale === 'en' ? '/en/nutrition/recipes' : '/nutrition/recettes';
+}


### PR DESCRIPTION
## Summary

Wires the full SEO surface for the recipes feature so the catalogue is indexable by Google (Rich Results) and consumable by LLM crawlers. Builds on PR 0 (prerender infra) and PR 4 (UI + EN seed).

## What ships

### JSON-LD
- **`recipeJsonLd()`** — Schema.org Recipe with `recipeIngredient`, `recipeInstructions` (numbered HowToStep), `nutrition` (NutritionInformation per serving), `totalTime` in ISO 8601, `inLanguage`, `keywords`. New util `minutesToISODuration()` to format prep time.
- **`ItemList` JSON-LD** on the listing (top 30 entries) so each recipe can surface as a separate result.
- **`BreadcrumbList` JSON-LD** on both listing and detail.

### Bilingual routing
- FR canonical: `/nutrition/recettes` and `/nutrition/recettes/:slug`
- EN: `/en/nutrition/recipes` and `/en/nutrition/recipes/:slug`
- `RecipeListPage` and `RecipeDetailPage` read the locale from the **URL** (not `i18n.language`). A prerendered FR page never re-renders as EN under hydration, and vice-versa. New `getRecipeLocaleFromPath()` + `recipeUrlForLocale()` + `recipeListingUrlForLocale()` utilities, with 7 unit tests.

### hreflang infrastructure
- `SeoRoute.alternates: SeoAlternate[]` extension; `seoRoutes.ts` now imports the FR + EN seed JSON to build the cross-locale slug map and emits 49 + 49 paired routes with `fr-FR / en-US / x-default` alternates.
- Sitemap emits `<xhtml:link rel="alternate" hreflang="...">` per URL.
- Prerender injects matching `<link rel="alternate">` tags into each captured HTML `<head>`.

### Robustness
- Prerender now skips recipe-detail routes whose Supabase row isn't available in the build env (instead of shipping hollow "recipe not found" HTML). Those routes are excluded from the sitemap and will be picked up by the next rebuild after the seed lands.

## PR plan reminder

This is **PR 5/6** of the autonomous nutrition + recipes batch. PR 6 ships favourites UI and a few secondary touchpoints.

## Manual rollout (post-merge)

1. Apply migration 023 (PR 3) on dev if not done yet.
2. `npm run seed:recipes` with `SUPABASE_SERVICE_ROLE_KEY` set — seeds FR + EN (98 rows).
3. Trigger a Vercel rebuild. Build log should show `145/145 captured, 0 skipped` and `sitemap.xml: 145 routes`.
4. Promote to prod, repeat seed + rebuild on prod env.

## Test plan

- [ ] Build log on dev preview shows 145 routes captured (after seed)
- [ ] `https://www.wan2fit.fr/sitemap.xml` includes `<xhtml:link>` alternates for each recipe pair
- [ ] `curl https://www.wan2fit.fr/nutrition/recettes/<slug>` returns HTML with `"@type":"Recipe"` JSON-LD and 3 hreflang alternates
- [ ] EN equivalent returns its English content with alternates pointing back to FR
- [ ] [Google Rich Results test](https://search.google.com/test/rich-results) accepts a sample recipe URL
- [ ] No regression on existing prerendered routes (formats / exercises / programmes still 100% captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)