### PR TITLE
feat(recipes): favourites toggle and post-workout suggestion

### DIFF
--- a/src/components/EndScreen.tsx
+++ b/src/components/EndScreen.tsx
@@ -9,6 +9,7 @@ import { supabase } from '../lib/supabase.ts';
 import type { Session } from '../types/session.ts';
 import { computeDifficulty } from '../utils/sessionDifficulty.ts';
 import { shareSession } from '../utils/share.ts';
+import { NutritionSuggestion } from './recipes/NutritionSuggestion.tsx';
 
 interface Props {
   session: Session;
@@ -170,6 +171,7 @@ export function EndScreen({ session, amrapRounds, durationSeconds, onBack, progr
 
       {!user && supabase && <SignupNudge />}
       {user && !authLoading && profile && !isPremium && <PremiumTeaser />}
+      {user && <NutritionSuggestion seed={`${session.date}-${session.title}`} />}
 
       <div className="flex flex-col gap-3 mt-4 w-full max-w-xs">
         <button

--- a/src/components/nutrition/NutritionWidget7d.tsx
+++ b/src/components/nutrition/NutritionWidget7d.tsx
@@ -58,13 +58,15 @@ export function NutritionWidget7d() {
           {summary.days.map((d) => {
             const ratio = d.hasEntries ? Math.min(1, d.totals.calories / denom) : 0;
             const heightPct = Math.max(6, Math.round(ratio * 100));
+            // height: <pct>% on a flex child needs the parent to expose a
+            // resolved height — we set it on the bar directly (sibling of the
+            // h-16 row) instead of nesting an extra wrapper that drops it.
             return (
-              <div key={d.date} className="flex-1 flex items-end">
-                <div
-                  className={`w-full rounded-t ${d.hasEntries ? 'bg-brand/70' : 'bg-divider'}`}
-                  style={{ height: `${heightPct}%` }}
-                />
-              </div>
+              <div
+                key={d.date}
+                className={`flex-1 rounded-t ${d.hasEntries ? 'bg-brand/70' : 'bg-divider'}`}
+                style={{ height: `${heightPct}%` }}
+              />
             );
           })}
         </div>

--- a/src/components/recipes/FavoriteButton.tsx
+++ b/src/components/recipes/FavoriteButton.tsx
@@ -20,11 +20,12 @@ export interface FavoriteButtonProps {
 export function FavoriteButton({ recipeKey, compact = false }: FavoriteButtonProps) {
   const { t } = useTranslation('recipes');
   const { user } = useAuth();
-  const { favoriteKeys, toggle, pending } = useRecipeFavorites();
+  const { favoriteKeys, toggle, pendingKey } = useRecipeFavorites();
 
   if (!user) return null;
 
   const isFavorite = favoriteKeys.has(recipeKey);
+  const isPending = pendingKey === recipeKey;
   const label = isFavorite ? t('favorites.remove') : t('favorites.add');
 
   return (
@@ -35,7 +36,7 @@ export function FavoriteButton({ recipeKey, compact = false }: FavoriteButtonPro
         e.stopPropagation();
         void toggle(recipeKey);
       }}
-      disabled={pending}
+      disabled={isPending}
       aria-pressed={isFavorite}
       aria-label={label}
       title={label}

--- a/src/components/recipes/FavoriteButton.tsx
+++ b/src/components/recipes/FavoriteButton.tsx
@@ -1,0 +1,52 @@
+import { Heart } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { useRecipeFavorites } from '../../hooks/useRecipeFavorites.ts';
+
+export interface FavoriteButtonProps {
+  recipeKey: string;
+  /** Compact icon-only variant for cards; default is icon + label. */
+  compact?: boolean;
+}
+
+/**
+ * Heart toggle backed by `recipe_favorites`. Hidden for visitors — favouriting
+ * requires auth so we don't tease a feature we can't deliver. The heart fills
+ * when the recipe is favourited; click toggles with optimistic update.
+ *
+ * Prevents the parent <Link> from navigating: callers wrap recipe cards in a
+ * Link, and tapping the heart should not bounce the user to the detail page.
+ */
+export function FavoriteButton({ recipeKey, compact = false }: FavoriteButtonProps) {
+  const { t } = useTranslation('recipes');
+  const { user } = useAuth();
+  const { favoriteKeys, toggle, pending } = useRecipeFavorites();
+
+  if (!user) return null;
+
+  const isFavorite = favoriteKeys.has(recipeKey);
+  const label = isFavorite ? t('favorites.remove') : t('favorites.add');
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void toggle(recipeKey);
+      }}
+      disabled={pending}
+      aria-pressed={isFavorite}
+      aria-label={label}
+      title={label}
+      className={`inline-flex items-center gap-1.5 rounded-full transition-colors disabled:opacity-50 ${
+        compact
+          ? 'p-2 hover:bg-divider'
+          : 'px-3 py-1.5 border border-divider hover:border-brand/40 hover:bg-divider text-xs font-medium text-body'
+      }`}
+    >
+      <Heart className={`w-4 h-4 ${isFavorite ? 'fill-brand text-brand' : 'text-muted'}`} aria-hidden="true" />
+      {!compact && <span>{label}</span>}
+    </button>
+  );
+}

--- a/src/components/recipes/NutritionSuggestion.tsx
+++ b/src/components/recipes/NutritionSuggestion.tsx
@@ -1,0 +1,45 @@
+import { ChefHat, ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { useRecipeSuggestion } from '../../hooks/useRecipes.ts';
+import type { RecipeCategory } from '../../types/recipe.ts';
+import { recipeUrlForLocale } from '../../utils/localePath.ts';
+
+const POST_WORKOUT_CATEGORIES: RecipeCategory[] = ['post', 'recovery'];
+
+export interface NutritionSuggestionProps {
+  /** Stable seed so the suggestion doesn't shuffle on EndScreen rerenders. */
+  seed: string;
+}
+
+/**
+ * Discreet "pair this session with a recipe" CTA shown on EndScreen for
+ * authenticated users. Suggests a single post-workout or recovery recipe.
+ * Renders nothing while the catalogue is loading or empty — the CTA is
+ * additive, never blocking.
+ */
+export function NutritionSuggestion({ seed }: NutritionSuggestionProps) {
+  const { t, i18n } = useTranslation('recipes');
+  const { recipe, loading } = useRecipeSuggestion(POST_WORKOUT_CATEGORIES, seed);
+
+  if (loading || !recipe) return null;
+
+  const locale = i18n.language?.startsWith('en') ? 'en' : 'fr';
+  const href = recipeUrlForLocale(locale, recipe.slug);
+
+  return (
+    <Link
+      to={href}
+      className="w-full max-w-sm flex items-center gap-3 rounded-2xl bg-white/5 border border-white/10 px-4 py-3 hover:bg-white/10 transition-colors"
+    >
+      <ChefHat className="w-5 h-5 text-brand shrink-0" aria-hidden="true" />
+      <div className="flex-1 min-w-0 text-left">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-white/60">
+          {t('nutrition_suggestion.label')}
+        </p>
+        <p className="text-sm font-semibold text-white truncate">{recipe.name}</p>
+      </div>
+      <ChevronRight className="w-4 h-4 text-white/60 shrink-0" aria-hidden="true" />
+    </Link>
+  );
+}

--- a/src/components/recipes/NutritionSuggestion.tsx
+++ b/src/components/recipes/NutritionSuggestion.tsx
@@ -24,6 +24,10 @@ export function NutritionSuggestion({ seed }: NutritionSuggestionProps) {
 
   if (loading || !recipe) return null;
 
+  // Unlike RecipeListPage / RecipeDetailPage which derive locale from the URL,
+  // EndScreen lives at /seance/play (no /en/ prefix), so the locale must come
+  // from the user's i18n preference instead. Generates an /en/ recipe URL
+  // when the UI is in English even though the parent route is FR-pathed.
   const locale = i18n.language?.startsWith('en') ? 'en' : 'fr';
   const href = recipeUrlForLocale(locale, recipe.slug);
 

--- a/src/components/recipes/RecipeCard.tsx
+++ b/src/components/recipes/RecipeCard.tsx
@@ -2,6 +2,8 @@ import { Clock, Flame } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import type { Recipe } from '../../types/recipe.ts';
+import { recipeUrlForLocale } from '../../utils/localePath.ts';
+import { FavoriteButton } from './FavoriteButton.tsx';
 
 export interface RecipeCardProps {
   recipe: Recipe;
@@ -12,14 +14,17 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
 
   return (
     <Link
-      to={`/nutrition/recettes/${recipe.slug}`}
+      to={recipeUrlForLocale(recipe.locale, recipe.slug)}
       className="group flex flex-col gap-3 rounded-2xl border border-card-border bg-surface-card p-5 hover:border-brand/30 hover:shadow-lg hover:shadow-brand/10 transition-all"
     >
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-[10px] font-medium uppercase tracking-wider text-brand">
           {t(`category.${recipe.category}`)}
         </span>
-        {recipe.difficulty && <span className="text-[10px] text-muted">{t(`difficulty.${recipe.difficulty}`)}</span>}
+        <div className="flex items-center gap-2">
+          {recipe.difficulty && <span className="text-[10px] text-muted">{t(`difficulty.${recipe.difficulty}`)}</span>}
+          <FavoriteButton recipeKey={recipe.recipe_key} compact />
+        </div>
       </div>
       <h3 className="font-display text-lg font-bold text-heading leading-tight group-hover:text-brand transition-colors">
         {recipe.name}

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -6,6 +6,7 @@ import { useRecipe } from '../../hooks/useRecipes.ts';
 import { JsonLd } from '../../lib/JsonLd.tsx';
 import { breadcrumbJsonLd, minutesToISODuration, recipeJsonLd } from '../../lib/jsonld.ts';
 import { getRecipeLocaleFromPath, recipeListingUrlForLocale } from '../../utils/localePath.ts';
+import { FavoriteButton } from './FavoriteButton.tsx';
 
 export function RecipeDetailPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -97,9 +98,12 @@ export function RecipeDetailPage() {
         </Link>
 
         <header className="space-y-3">
-          <span className="inline-block text-[10px] font-medium uppercase tracking-wider text-brand">
-            {t(`category.${recipe.category}`)}
-          </span>
+          <div className="flex items-start justify-between gap-3">
+            <span className="inline-block text-[10px] font-medium uppercase tracking-wider text-brand pt-1">
+              {t(`category.${recipe.category}`)}
+            </span>
+            <FavoriteButton recipeKey={recipe.recipe_key} />
+          </div>
           <h1 className="font-display text-3xl sm:text-4xl font-black text-heading leading-tight">{recipe.name}</h1>
           <p className="text-base text-body">{recipe.description}</p>
         </header>

--- a/src/components/recipes/RecipeListPage.tsx
+++ b/src/components/recipes/RecipeListPage.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { useRecipeFavorites } from '../../hooks/useRecipeFavorites.ts';
 import { useRecipes } from '../../hooks/useRecipes.ts';
 import { JsonLd } from '../../lib/JsonLd.tsx';
 import { breadcrumbJsonLd, SITE_URL } from '../../lib/jsonld.ts';
@@ -35,6 +37,9 @@ export function RecipeListPage() {
     tags: selectedTags,
     search,
   });
+  const { user } = useAuth();
+  const { favoriteKeys } = useRecipeFavorites();
+  const favoriteRecipes = user ? allRecipes.filter((r) => favoriteKeys.has(r.recipe_key)) : [];
 
   const availableTags = useMemo(() => {
     const set = new Set<string>();
@@ -78,6 +83,19 @@ export function RecipeListPage() {
           <h1 className="font-display text-2xl sm:text-3xl font-black text-heading">{t('list.heading')}</h1>
           <p className="text-sm text-muted">{t('list.subtitle')}</p>
         </header>
+
+        {favoriteRecipes.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="font-display text-lg font-bold text-heading">
+              {t('favorites.section_heading', { count: favoriteRecipes.length })}
+            </h2>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {favoriteRecipes.map((r) => (
+                <RecipeCard key={`fav-${r.locale}-${r.recipe_key}`} recipe={r} />
+              ))}
+            </div>
+          </section>
+        )}
 
         <RecipeFilters
           category={category}

--- a/src/components/recipes/RecipeListPage.tsx
+++ b/src/components/recipes/RecipeListPage.tsx
@@ -39,6 +39,12 @@ export function RecipeListPage() {
   });
   const { user } = useAuth();
   const { favoriteKeys } = useRecipeFavorites();
+  // Favourites are locale-agnostic in the schema (recipe_key only), but the
+  // section here renders rows from the *current* locale's catalogue. As long
+  // as every recipe ships in both FR and EN (the seed enforces parity), every
+  // favourited recipe surfaces correctly under either URL. If one day a
+  // recipe shipped FR-only, it would silently disappear when the user views
+  // the EN listing — revisit when that happens.
   const favoriteRecipes = user ? allRecipes.filter((r) => favoriteKeys.has(r.recipe_key)) : [];
 
   const availableTags = useMemo(() => {

--- a/src/hooks/useRecipeFavorites.test.ts
+++ b/src/hooks/useRecipeFavorites.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { computeToggledFavorites } from './useRecipeFavorites.ts';
+
+describe('computeToggledFavorites', () => {
+  it('adds the key when absent', () => {
+    const next = computeToggledFavorites(new Set(['a']), 'b');
+    expect(next).toEqual(new Set(['a', 'b']));
+  });
+
+  it('removes the key when present', () => {
+    const next = computeToggledFavorites(new Set(['a', 'b']), 'a');
+    expect(next).toEqual(new Set(['b']));
+  });
+
+  it('returns a fresh Set (no mutation of input)', () => {
+    const original = new Set(['a']);
+    const next = computeToggledFavorites(original, 'b');
+    expect(original).toEqual(new Set(['a']));
+    expect(next).not.toBe(original);
+  });
+
+  it('idempotent: toggle twice equals start', () => {
+    const start = new Set(['a', 'b']);
+    const once = computeToggledFavorites(start, 'c');
+    const twice = computeToggledFavorites(once, 'c');
+    expect(twice).toEqual(start);
+  });
+});

--- a/src/hooks/useRecipeFavorites.ts
+++ b/src/hooks/useRecipeFavorites.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+import { computeToggledFavorites } from '../utils/recipeFavorites.ts';
 
 export interface UseRecipeFavoritesResult {
   /** Set of recipe_keys the current user has favorited. Empty for visitors. */
@@ -16,14 +17,6 @@ export interface UseRecipeFavoritesResult {
    * disable every other heart on the page during the round-trip.
    */
   pendingKey: string | null;
-}
-
-/** Pure: returns the new set after toggling `key`. Exported for unit tests. */
-export function computeToggledFavorites(current: ReadonlySet<string>, key: string): Set<string> {
-  const next = new Set(current);
-  if (next.has(key)) next.delete(key);
-  else next.add(key);
-  return next;
 }
 
 /**

--- a/src/hooks/useRecipeFavorites.ts
+++ b/src/hooks/useRecipeFavorites.ts
@@ -11,8 +11,11 @@ export interface UseRecipeFavoritesResult {
   error: string | null;
   /** Toggles a recipe's favourite state with optimistic update. No-op for visitors. */
   toggle: (recipeKey: string) => Promise<void>;
-  /** True when a mutation is in flight — used to disable the toggle button. */
-  pending: boolean;
+  /**
+   * recipe_key currently flipping. Per-key so toggling one heart doesn't
+   * disable every other heart on the page during the round-trip.
+   */
+  pendingKey: string | null;
 }
 
 /** Pure: returns the new set after toggling `key`. Exported for unit tests. */
@@ -110,6 +113,6 @@ export function useRecipeFavorites(): UseRecipeFavoritesResult {
     loading: query.isPending && !!userId,
     error: query.data?.error ?? (query.isError ? String(query.error ?? '') : null),
     toggle,
-    pending: mutation.isPending,
+    pendingKey: mutation.isPending ? (mutation.variables ?? null) : null,
   };
 }

--- a/src/hooks/useRecipeFavorites.ts
+++ b/src/hooks/useRecipeFavorites.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+
+export interface UseRecipeFavoritesResult {
+  /** Set of recipe_keys the current user has favorited. Empty for visitors. */
+  favoriteKeys: Set<string>;
+  loading: boolean;
+  error: string | null;
+  /** Toggles a recipe's favourite state with optimistic update. No-op for visitors. */
+  toggle: (recipeKey: string) => Promise<void>;
+  /** True when a mutation is in flight — used to disable the toggle button. */
+  pending: boolean;
+}
+
+/** Pure: returns the new set after toggling `key`. Exported for unit tests. */
+export function computeToggledFavorites(current: ReadonlySet<string>, key: string): Set<string> {
+  const next = new Set(current);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
+}
+
+/**
+ * Public API for the heart-toggle UI on RecipeCard / RecipeDetailPage and the
+ * "My favourites" section on the listing. Visitors get an empty set and a
+ * no-op toggle — the toggle button is hidden upstream so this is defensive.
+ */
+export function useRecipeFavorites(): UseRecipeFavoritesResult {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const userId = user?.id;
+  const queryKey: readonly unknown[] = ['recipeFavorites', userId ?? null];
+
+  interface FavoritesQueryData {
+    keys: string[];
+    error: string | null;
+  }
+
+  const query = useQuery<FavoritesQueryData>({
+    queryKey: [...queryKey],
+    queryFn: async () => {
+      if (!supabase || !userId) return { keys: [], error: null };
+      const { data, error, sessionExpired } = await supabaseQuery(() =>
+        supabase!.from('recipe_favorites').select('recipe_key').eq('user_id', userId),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return { keys: [], error: null };
+      }
+      if (error) return { keys: [], error: error.message ?? 'unknown error' };
+      return { keys: (data ?? []).map((row: { recipe_key: string }) => row.recipe_key), error: null };
+    },
+    enabled: !!userId && !!supabase,
+    staleTime: 60 * 1000,
+  });
+
+  const favoriteKeys = new Set<string>(query.data?.keys ?? []);
+
+  const mutation = useMutation<void, Error, string>({
+    mutationFn: async (recipeKey: string) => {
+      if (!supabase || !userId) return;
+      const isFavorite = favoriteKeys.has(recipeKey);
+      if (isFavorite) {
+        const { error: err } = await supabase
+          .from('recipe_favorites')
+          .delete()
+          .eq('user_id', userId)
+          .eq('recipe_key', recipeKey);
+        if (err) throw new Error(err.message);
+      } else {
+        const { error: err } = await supabase
+          .from('recipe_favorites')
+          .insert({ user_id: userId, recipe_key: recipeKey });
+        if (err) throw new Error(err.message);
+      }
+    },
+    // Optimistic update — flip immediately, rollback on error.
+    onMutate: async (recipeKey) => {
+      await queryClient.cancelQueries({ queryKey: [...queryKey] });
+      const previous = queryClient.getQueryData<FavoritesQueryData>([...queryKey]);
+      const next = computeToggledFavorites(new Set(previous?.keys ?? []), recipeKey);
+      queryClient.setQueryData<FavoritesQueryData>([...queryKey], { keys: Array.from(next), error: null });
+      return { previous };
+    },
+    onError: (_err, _key, context) => {
+      const ctx = context as { previous?: FavoritesQueryData } | undefined;
+      if (ctx?.previous) queryClient.setQueryData<FavoritesQueryData>([...queryKey], ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKey] });
+    },
+  });
+
+  const toggle = useCallback(
+    async (recipeKey: string) => {
+      if (!userId) return;
+      await mutation.mutateAsync(recipeKey).catch(() => {
+        // Error is surfaced via React Query state; the optimistic rollback
+        // already happened in `onError`.
+      });
+    },
+    [userId, mutation],
+  );
+
+  return {
+    favoriteKeys,
+    loading: query.isPending && !!userId,
+    error: query.data?.error ?? (query.isError ? String(query.error ?? '') : null),
+    toggle,
+    pending: mutation.isPending,
+  };
+}

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router';
 import { supabase } from '../lib/supabase.ts';
 import type { Recipe, RecipeCategory, RecipeLocale } from '../types/recipe.ts';
 import { getRecipeLocaleFromPath } from '../utils/localePath.ts';
+import { pickRecipeByCategory } from '../utils/pickRecipe.ts';
 
 export interface RecipesFilters {
   category?: RecipeCategory | null;
@@ -119,4 +120,20 @@ export function useRecipe(slug: string | undefined): {
     loading: query.isPending,
     error: query.data?.error ?? (query.isError ? String(query.error ?? '') : null),
   };
+}
+
+/**
+ * Returns one recipe deterministically picked from the visible catalogue
+ * whose category matches `categories`. Reuses the cached `useRecipes` query
+ * so this hook costs zero extra fetches when the catalogue is already
+ * loaded. The `seed` argument keeps the picked recipe stable across renders
+ * (e.g. on EndScreen, the suggestion shouldn't shuffle on every state flip).
+ */
+export function useRecipeSuggestion(
+  categories: readonly RecipeCategory[],
+  seed: string,
+): { recipe: Recipe | null; loading: boolean } {
+  const { recipes, loading } = useRecipes();
+  const recipe = pickRecipeByCategory(recipes, categories, seed);
+  return { recipe, loading };
 }

--- a/src/i18n/locales/en/recipes.json
+++ b/src/i18n/locales/en/recipes.json
@@ -56,5 +56,14 @@
   "card": {
     "kcal": "{{n}} kcal",
     "prep_min": "{{n}} min"
+  },
+  "favorites": {
+    "add": "Add to favourites",
+    "remove": "Remove from favourites",
+    "section_heading_one": "My favourite",
+    "section_heading_other": "My favourites ({{count}})"
+  },
+  "nutrition_suggestion": {
+    "label": "Pair this session with a recipe"
   }
 }

--- a/src/i18n/locales/fr/recipes.json
+++ b/src/i18n/locales/fr/recipes.json
@@ -56,5 +56,14 @@
   "card": {
     "kcal": "{{n}} kcal",
     "prep_min": "{{n}} min"
+  },
+  "favorites": {
+    "add": "Ajouter aux favoris",
+    "remove": "Retirer des favoris",
+    "section_heading_one": "Mon favori",
+    "section_heading_other": "Mes favoris ({{count}})"
+  },
+  "nutrition_suggestion": {
+    "label": "Idée recette pour récupérer"
   }
 }

--- a/src/utils/pickRecipe.test.ts
+++ b/src/utils/pickRecipe.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { Recipe } from '../types/recipe.ts';
+import { pickRecipeByCategory } from './pickRecipe.ts';
+
+function r(overrides: Partial<Recipe>): Recipe {
+  return {
+    recipe_key: 'k',
+    locale: 'fr',
+    slug: 's',
+    category: 'main',
+    name: 'n',
+    description: 'd',
+    prep_time_min: 10,
+    difficulty: 'facile',
+    servings: 1,
+    nutrition: { calories: 100, protein: 0, carbs: 0, fat: 0 },
+    ingredients: [],
+    steps: [],
+    tags: [],
+    is_published: true,
+    created_at: '2026-05-02T00:00:00Z',
+    updated_at: '2026-05-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('pickRecipeByCategory', () => {
+  const recipes = [
+    r({ recipe_key: 'p1', category: 'post' }),
+    r({ recipe_key: 'p2', category: 'post' }),
+    r({ recipe_key: 'p3', category: 'post' }),
+    r({ recipe_key: 'r1', category: 'recovery' }),
+    r({ recipe_key: 'm1', category: 'main' }),
+  ];
+
+  it('returns null when no recipe matches the categories', () => {
+    expect(pickRecipeByCategory(recipes, ['breakfast'], 'seed')).toBeNull();
+    expect(pickRecipeByCategory([], ['post'], 'seed')).toBeNull();
+  });
+
+  it('only picks from the matching subset', () => {
+    for (let i = 0; i < 20; i++) {
+      const picked = pickRecipeByCategory(recipes, ['post'], `seed-${i}`);
+      expect(picked).not.toBeNull();
+      expect(picked?.category).toBe('post');
+    }
+  });
+
+  it('honours multiple categories (union)', () => {
+    const picks = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const p = pickRecipeByCategory(recipes, ['post', 'recovery'], `seed-${i}`);
+      if (p) picks.add(p.recipe_key);
+    }
+    expect(picks).toEqual(new Set(['p1', 'p2', 'p3', 'r1']));
+  });
+
+  it('is deterministic for the same seed', () => {
+    const a = pickRecipeByCategory(recipes, ['post'], 'stable-seed');
+    const b = pickRecipeByCategory(recipes, ['post'], 'stable-seed');
+    expect(a).toBe(b);
+  });
+
+  it('different seeds explore different recipes', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      const p = pickRecipeByCategory(recipes, ['post'], `seed-${i}`);
+      if (p) seen.add(p.recipe_key);
+    }
+    // With 3 candidates and 50 seeds, we should hit at least 2 distinct picks.
+    expect(seen.size).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/utils/pickRecipe.ts
+++ b/src/utils/pickRecipe.ts
@@ -1,0 +1,31 @@
+import type { Recipe, RecipeCategory } from '../types/recipe.ts';
+
+/**
+ * Deterministically picks one recipe from `recipes` whose category is in
+ * `categories`. Determinism (via `seed`) keeps the suggestion stable through
+ * a render cycle so React Query rerenders don't shuffle the chosen recipe
+ * mid-view.
+ *
+ * Returns null when no recipe matches — callers render nothing.
+ */
+export function pickRecipeByCategory(
+  recipes: readonly Recipe[],
+  categories: readonly RecipeCategory[],
+  seed: string,
+): Recipe | null {
+  const set = new Set(categories);
+  const eligible = recipes.filter((r) => set.has(r.category));
+  if (eligible.length === 0) return null;
+  const idx = stringToIndex(seed, eligible.length);
+  return eligible[idx];
+}
+
+/** Tiny FNV-1a-style hash → bounded index. Stable, no crypto needed. */
+function stringToIndex(input: string, modulo: number): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash) % modulo;
+}

--- a/src/utils/recipeFavorites.test.ts
+++ b/src/utils/recipeFavorites.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeToggledFavorites } from './useRecipeFavorites.ts';
+import { computeToggledFavorites } from './recipeFavorites.ts';
 
 describe('computeToggledFavorites', () => {
   it('adds the key when absent', () => {

--- a/src/utils/recipeFavorites.ts
+++ b/src/utils/recipeFavorites.ts
@@ -1,0 +1,7 @@
+/** Pure: returns the new set after toggling `key`. */
+export function computeToggledFavorites(current: ReadonlySet<string>, key: string): Set<string> {
+  const next = new Set(current);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
+}


### PR DESCRIPTION
## Summary

Closes the recipe feature roadmap (final PR of the 6-PR batch). Two contextual surfaces:

- **Favourites toggle** on `RecipeCard` (compact heart) and `RecipeDetailPage` (with label), backed by `recipe_favorites` (PR 3 schema). Optimistic update with rollback on error. Hidden for visitors.
- **My favourites** section pinned at the top of the recipe listing for signed-in users with ≥1 favourite.
- **Post-workout suggestion** on `EndScreen`: a discrete CTA pointing to a deterministically-picked recipe from the `post` or `recovery` categories. Stable seed (session date + title) so the choice doesn't shuffle on rerenders.

## Architecture

- `useRecipeFavorites()` — React Query mutation with `onMutate`/`onError`/`onSettled` for true optimistic UX. Visitors get an empty `Set` and a no-op toggle.
- `useRecipeSuggestion(categories, seed)` — reuses the cached `useRecipes` query, **zero additional fetches** when the catalogue is already loaded.
- `pickRecipeByCategory(recipes, categories, seed)` — pure FNV-1a-seeded pick, exported and unit-tested.
- `computeToggledFavorites(set, key)` — pure `Set` toggle helper, unit-tested.

## Tests

- 5 cases on `pickRecipeByCategory` (empty match, category filter, multi-cat union, determinism, seed diversity)
- 4 cases on `computeToggledFavorites` (add / remove / idempotency / no-mutation)
- Total: 406 passing

## PR plan reminder

This is **PR 6/6** — the autonomous nutrition + recipes batch is complete after this merge. Manual rollout reminder: migration 023 + `npm run seed:recipes` must be applied on dev/prod for the recipe data to materialise.

## Test plan

- [ ] Visitor on `/nutrition/recettes`: no heart icons visible, no "My favourites" section
- [ ] Logged-in user clicks the heart on a card: heart fills immediately, navigation does not happen
- [ ] Network failure: heart reverts to its previous state
- [ ] "My favourites" section appears at the top of the listing once at least one recipe is favourited
- [ ] Finishing a session as a logged-in user: a "Pair this session with a recipe" card appears between the premium teaser and the share/back buttons
- [ ] Same session re-rendered: the suggested recipe stays the same (deterministic)
- [ ] Visitor finishing a session: no suggestion card shown
- [ ] Toggle the same heart twice: net state unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)