### PR TITLE
feat(nav): expose Recipes in the desktop header and mobile bottom nav

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -119,6 +119,25 @@ function UtensilsIcon() {
   );
 }
 
+function ChefHatIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" />
+      <line x1="6" y1="17" x2="18" y2="17" />
+    </svg>
+  );
+}
+
 function ChartIcon() {
   return (
     <svg
@@ -174,7 +193,10 @@ export function BottomNav() {
   const isPrograms = pathname.startsWith('/programme');
   const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
   const isSuivi = pathname === '/suivi';
-  const isNutrition = pathname.startsWith('/nutrition');
+  const isRecipes = pathname.startsWith('/nutrition/recettes') || pathname.startsWith('/en/nutrition/recipes');
+  // Match the exact /nutrition page (and its setup sub-page) only — recipes
+  // own their own bottom-nav slot.
+  const isNutrition = (pathname === '/nutrition' || pathname.startsWith('/nutrition/setup')) && !isRecipes;
   const isLogin = pathname === '/login' || pathname === '/signup';
 
   return (
@@ -195,6 +217,9 @@ export function BottomNav() {
             <NavItem to="/nutrition" label={t('nutrition')} active={isNutrition}>
               <UtensilsIcon />
             </NavItem>
+            <NavItem to="/nutrition/recettes" label={t('recipes')} active={isRecipes}>
+              <ChefHatIcon />
+            </NavItem>
             <NavItem to="/suivi" label={t('tracking')} active={isSuivi}>
               <ChartIcon />
             </NavItem>
@@ -209,6 +234,9 @@ export function BottomNav() {
             </NavItem>
             <NavItem to="/decouvrir" label={t('explore')} active={isDiscover}>
               <DiscoverIcon />
+            </NavItem>
+            <NavItem to="/nutrition/recettes" label={t('recipes')} active={isRecipes}>
+              <ChefHatIcon />
             </NavItem>
             <NavItem to="/login" label={t('login')} active={isLogin}>
               <UserIcon />

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -18,8 +18,22 @@ const NAV_ITEMS = [
     match: (p: string) => p === '/decouvrir' || p.startsWith('/formats') || p.startsWith('/exercices'),
   },
   { to: '/programmes', labelKey: 'programs', match: (p: string) => p.startsWith('/programme') },
+  // Recipes are public — exposed before the auth-only Nutrition entry so a
+  // visitor can still find them. Match both FR and EN URLs.
+  {
+    to: '/nutrition/recettes',
+    labelKey: 'recipes',
+    match: (p: string) => p.startsWith('/nutrition/recettes') || p.startsWith('/en/nutrition/recipes'),
+  },
   { to: '/tarifs', labelKey: 'pricing', match: (p: string) => p === '/tarifs' },
-  { to: '/nutrition', labelKey: 'nutrition', match: (p: string) => p.startsWith('/nutrition'), requiresAuth: true },
+  // Nutrition stays auth-only and matches only its own pages, not the
+  // public recipe sub-tree (which has its own entry above).
+  {
+    to: '/nutrition',
+    labelKey: 'nutrition',
+    match: (p: string) => p === '/nutrition' || p.startsWith('/nutrition/setup'),
+    requiresAuth: true,
+  },
   { to: '/suivi', labelKey: 'tracking', match: (p: string) => p === '/suivi', requiresAuth: true },
 ] as const;
 

--- a/src/i18n/locales/en/nav.json
+++ b/src/i18n/locales/en/nav.json
@@ -6,6 +6,7 @@
   "programs": "Programs",
   "pricing": "Pricing",
   "nutrition": "Nutrition",
+  "recipes": "Recipes",
   "tracking": "Tracking",
   "login": "Log in",
   "bottom_label": "Secondary navigation"

--- a/src/i18n/locales/fr/nav.json
+++ b/src/i18n/locales/fr/nav.json
@@ -6,6 +6,7 @@
   "programs": "Programmes",
   "pricing": "Tarifs",
   "nutrition": "Nutrition",
+  "recipes": "Recettes",
   "tracking": "Suivi",
   "login": "Connexion",
   "bottom_label": "Navigation secondaire"


### PR DESCRIPTION
## Summary

Recipes shipped in PRs 4-6 but had no global nav entry point — fix that. Visible for both visitors and authenticated users.

## Changes

- **BrandHeader** (desktop): public `Recipes` item between Programs and Pricing. Matches `/nutrition/recettes/*` and `/en/nutrition/recipes/*`.
- **BottomNav** (mobile): dedicated 5th slot for Recipes with a chef-hat icon, in both auth and visitor states.
- **Nutrition** entry restricted to its own page (`/nutrition` exact + `/nutrition/setup`) so it doesn't double-highlight when on a recipe page.
- i18n: `nav.recipes` (FR + EN).

## Test plan

- [ ] Logged-in: header has Recipes link, click → /nutrition/recettes
- [ ] Visitor: header has Recipes link, click → /nutrition/recettes (no auth wall)
- [ ] Mobile (<768px): bottom nav has 5 slots including Recipes (chef-hat icon)
- [ ] On a recipe page: Recipes is highlighted, Nutrition is not (and vice-versa on /nutrition)
- [ ] On /en/nutrition/recipes/...: Recipes still highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)