### PR TITLE
feat(landings): PR 1 — Sessions feature landing + visitor nav mirror

### DIFF
--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -7,7 +7,7 @@ import { NavDropdown } from './NavDropdown.tsx';
 
 const matchExplore = (p: string) => p === '/decouvrir' || p.startsWith('/formats') || p.startsWith('/exercices');
 const matchPrograms = (p: string) => p.startsWith('/programme');
-const matchSessions = (p: string) => p === '/seances' || p.startsWith('/seance');
+const matchSessions = (p: string) => p === '/seances' || p.startsWith('/seance') || p === '/decouvrir/seances';
 const matchRecipes = (p: string) => p.startsWith('/nutrition/recettes') || p.startsWith('/en/nutrition/recipes');
 const matchPlate = (p: string) => p === '/nutrition' || p.startsWith('/nutrition/setup');
 
@@ -21,10 +21,11 @@ const NUTRITION_ITEMS = [
   { to: '/nutrition/recettes', labelKey: 'recipes', match: matchRecipes },
 ] as const;
 
-const VISITOR_ITEMS = [
-  { to: '/decouvrir', labelKey: 'explore', match: matchExplore },
-  { to: '/programmes', labelKey: 'programs', match: matchPrograms },
-  { to: '/nutrition/recettes', labelKey: 'recipes', match: matchRecipes },
+// Visitor sees mirror of the logged-in nav. Auth-only destinations
+// route to public landings (/decouvrir/*); the rest reuses public listings.
+const VISITOR_TRAIN_ITEMS = [
+  { to: '/decouvrir/seances', labelKey: 'my_sessions', match: matchSessions },
+  { to: '/programmes', labelKey: 'my_programs', match: matchPrograms },
 ] as const;
 
 function NavLink({ to, labelKey, active }: { to: string; labelKey: string; active: boolean }) {
@@ -54,6 +55,7 @@ export function BrandHeader() {
   const isPricingActive = pathname === '/tarifs';
   const isExploreActive = matchExplore(pathname);
   const isTrackingActive = pathname === '/suivi';
+  const isRecipesActive = matchRecipes(pathname);
 
   return (
     <header className="px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
@@ -72,9 +74,11 @@ export function BrandHeader() {
               <NavLink to="/suivi" labelKey="tracking" active={isTrackingActive} />
             </>
           ) : (
-            VISITOR_ITEMS.map((item) => (
-              <NavLink key={item.to} to={item.to} labelKey={item.labelKey} active={item.match(pathname)} />
-            ))
+            <>
+              <NavDropdown triggerLabelKey="train" items={VISITOR_TRAIN_ITEMS} />
+              <NavLink to="/decouvrir" labelKey="explore" active={isExploreActive} />
+              <NavLink to="/nutrition/recettes" labelKey="recipes" active={isRecipesActive} />
+            </>
           )}
         </nav>
 

--- a/src/components/landings/FeatureBenefitGrid.tsx
+++ b/src/components/landings/FeatureBenefitGrid.tsx
@@ -1,0 +1,33 @@
+export interface FeatureBenefit {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}
+
+interface FeatureBenefitGridProps {
+  sectionLabel: string;
+  benefits: FeatureBenefit[];
+}
+
+export function FeatureBenefitGrid({ sectionLabel, benefits }: FeatureBenefitGridProps) {
+  return (
+    <section aria-label={sectionLabel} className="px-6 md:px-10 lg:px-14 py-16 md:py-20 bg-surface-2/50">
+      <div className="max-w-7xl mx-auto">
+        <div className={`grid gap-6 ${benefits.length === 4 ? 'md:grid-cols-2 lg:grid-cols-4' : 'md:grid-cols-3'}`}>
+          {benefits.map((benefit) => (
+            <div
+              key={benefit.title}
+              className="rounded-2xl bg-card-bg border border-card-border p-6 flex flex-col gap-3"
+            >
+              <div className="w-11 h-11 rounded-xl bg-brand/10 text-brand flex items-center justify-center">
+                {benefit.icon}
+              </div>
+              <h3 className="font-display text-lg font-bold text-heading">{benefit.title}</h3>
+              <p className="text-body text-sm leading-relaxed">{benefit.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landings/FeatureCta.tsx
+++ b/src/components/landings/FeatureCta.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router';
+import type { FeatureHeroCta } from './FeatureHero.tsx';
+
+interface FeatureCtaProps {
+  title: string;
+  subtitle?: string;
+  ctas: FeatureHeroCta[];
+}
+
+export function FeatureCta({ title, subtitle, ctas }: FeatureCtaProps) {
+  return (
+    <section className="px-6 md:px-10 lg:px-14 py-16 md:py-24">
+      <div className="max-w-3xl mx-auto text-center flex flex-col items-center gap-5">
+        <h2 className="font-display text-3xl md:text-4xl font-black text-heading tracking-tight">{title}</h2>
+        {subtitle ? <p className="text-lg text-body">{subtitle}</p> : null}
+        <div className="flex flex-wrap justify-center gap-3 mt-2">
+          {ctas.map((cta) => (
+            <Link
+              key={cta.to}
+              to={cta.to}
+              className={
+                cta.variant === 'secondary'
+                  ? 'inline-flex items-center justify-center px-6 py-3 rounded-full text-base font-semibold border border-divider-strong text-heading hover:bg-divider transition-colors'
+                  : 'cta-gradient inline-flex items-center justify-center px-6 py-3 rounded-full text-base font-bold text-white shadow-lg hover:shadow-xl transition-shadow'
+              }
+            >
+              {cta.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landings/FeatureHero.tsx
+++ b/src/components/landings/FeatureHero.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router';
+
+export interface FeatureHeroCta {
+  label: string;
+  to: string;
+  variant?: 'primary' | 'secondary';
+}
+
+interface FeatureHeroProps {
+  eyebrow?: string;
+  title: string;
+  subtitle: string;
+  ctas: FeatureHeroCta[];
+  visual?: React.ReactNode;
+}
+
+export function FeatureHero({ eyebrow, title, subtitle, ctas, visual }: FeatureHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-brand/15 via-surface to-accent/10 px-6 md:px-10 lg:px-14 py-16 md:py-24">
+      <div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+        <div className="flex flex-col gap-5">
+          {eyebrow ? (
+            <span className="inline-flex items-center self-start gap-2 px-3 py-1 rounded-full bg-brand/10 border border-brand/20 text-brand text-xs font-semibold uppercase tracking-wide">
+              {eyebrow}
+            </span>
+          ) : null}
+          <h1 className="font-display text-4xl md:text-5xl lg:text-6xl font-black tracking-tight text-heading leading-[1.05]">
+            {title}
+          </h1>
+          <p className="text-lg md:text-xl text-body max-w-xl">{subtitle}</p>
+          <div className="flex flex-wrap gap-3 mt-3">
+            {ctas.map((cta) => (
+              <Link
+                key={cta.to}
+                to={cta.to}
+                className={
+                  cta.variant === 'secondary'
+                    ? 'inline-flex items-center justify-center px-6 py-3 rounded-full text-base font-semibold border border-divider-strong text-heading hover:bg-divider transition-colors'
+                    : 'cta-gradient inline-flex items-center justify-center px-6 py-3 rounded-full text-base font-bold text-white shadow-lg hover:shadow-xl transition-shadow'
+                }
+              >
+                {cta.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        {visual ? <div className="flex justify-center lg:justify-end">{visual}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landings/FeatureLandingTemplate.tsx
+++ b/src/components/landings/FeatureLandingTemplate.tsx
@@ -1,0 +1,29 @@
+import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
+import { type FeatureBenefit, FeatureBenefitGrid } from './FeatureBenefitGrid.tsx';
+import { FeatureCta } from './FeatureCta.tsx';
+import { FeatureHero, type FeatureHeroCta } from './FeatureHero.tsx';
+
+export interface FeatureLandingTemplateProps {
+  meta: { title: string; description: string };
+  hero: {
+    eyebrow?: string;
+    title: string;
+    subtitle: string;
+    ctas: FeatureHeroCta[];
+    visual?: React.ReactNode;
+  };
+  benefits: { sectionLabel: string; items: FeatureBenefit[] };
+  finalCta: { title: string; subtitle?: string; ctas: FeatureHeroCta[] };
+}
+
+export function FeatureLandingTemplate({ meta, hero, benefits, finalCta }: FeatureLandingTemplateProps) {
+  useDocumentHead({ title: meta.title, description: meta.description });
+
+  return (
+    <div className="flex flex-col">
+      <FeatureHero {...hero} />
+      <FeatureBenefitGrid sectionLabel={benefits.sectionLabel} benefits={benefits.items} />
+      <FeatureCta {...finalCta} />
+    </div>
+  );
+}

--- a/src/components/landings/SeancesLanding.tsx
+++ b/src/components/landings/SeancesLanding.tsx
@@ -1,0 +1,121 @@
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { FeatureLandingTemplate } from './FeatureLandingTemplate.tsx';
+
+function ZapIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+    </svg>
+  );
+}
+
+function HomeIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </svg>
+  );
+}
+
+function GridIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+    </svg>
+  );
+}
+
+function ClockIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}
+
+export function SeancesLanding() {
+  const { t } = useTranslation('landing_sessions');
+  const { user } = useAuth();
+
+  const primaryTarget = user ? '/seances' : '/signup';
+  const primaryLabel = t('hero.cta_primary');
+  const formatsLabel = t('hero.cta_secondary');
+
+  return (
+    <FeatureLandingTemplate
+      meta={{ title: t('meta.title'), description: t('meta.description') }}
+      hero={{
+        eyebrow: t('hero.eyebrow'),
+        title: t('hero.title'),
+        subtitle: t('hero.subtitle'),
+        ctas: [
+          { label: primaryLabel, to: primaryTarget },
+          { label: formatsLabel, to: '/formats', variant: 'secondary' },
+        ],
+      }}
+      benefits={{
+        sectionLabel: t('benefits.section_label'),
+        items: [
+          { icon: <ZapIcon />, title: t('benefits.no_decision_title'), body: t('benefits.no_decision_body') },
+          { icon: <HomeIcon />, title: t('benefits.no_gear_title'), body: t('benefits.no_gear_body') },
+          { icon: <GridIcon />, title: t('benefits.formats_title'), body: t('benefits.formats_body') },
+          { icon: <ClockIcon />, title: t('benefits.duration_title'), body: t('benefits.duration_body') },
+        ],
+      }}
+      finalCta={{
+        title: t('final_cta.title'),
+        subtitle: t('final_cta.subtitle'),
+        ctas: [
+          { label: primaryLabel, to: primaryTarget },
+          { label: t('final_cta.cta_secondary'), to: '/formats', variant: 'secondary' },
+        ],
+      }}
+    />
+  );
+}

--- a/src/i18n/locales/en/landing_sessions.json
+++ b/src/i18n/locales/en/landing_sessions.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "title": "My sessions — a guided workout every day",
+    "description": "A guided workout every day, ready to launch. 8 varied formats, no equipment, from 5 to 40 minutes."
+  },
+  "hero": {
+    "eyebrow": "Today's session",
+    "title": "Your workout for today is already waiting.",
+    "subtitle": "No decision to make, no equipment needed. Show up, hit play, sweat. Today's session is calibrated and ready.",
+    "cta_primary": "Create a free account",
+    "cta_secondary": "Browse the formats"
+  },
+  "benefits": {
+    "section_label": "Why Wan2Fit for your workouts",
+    "no_decision_title": "Zero decisions",
+    "no_decision_body": "No program to pick, no level to set. Today's workout is already there, calibrated, ready to launch.",
+    "no_gear_title": "No equipment",
+    "no_gear_body": "Designed for your living room, bedroom, a park. Bodyweight only — effective and proven.",
+    "formats_title": "8 varied formats",
+    "formats_body": "HIIT, Tabata, EMOM, AMRAP, Pyramid, Superset, Circuit, Strength. Your body never adapts.",
+    "duration_title": "5 to 40 minutes",
+    "duration_body": "You decide what you can give today. Short or long — effort counts as much as duration."
+  },
+  "final_cta": {
+    "title": "Ready to sweat?",
+    "subtitle": "Create a free account. Your first workout is already programmed.",
+    "cta_primary": "Create a free account",
+    "cta_secondary": "Browse the formats"
+  }
+}

--- a/src/i18n/locales/fr/landing_sessions.json
+++ b/src/i18n/locales/fr/landing_sessions.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "title": "Mes séances — une séance guidée chaque jour",
+    "description": "Une séance de sport guidée chaque jour, prête à lancer. 8 formats variés, sans matériel, de 5 à 40 min."
+  },
+  "hero": {
+    "eyebrow": "Séance du jour",
+    "title": "Ta séance de ce matin t'attend déjà.",
+    "subtitle": "Aucune décision à prendre, aucun matériel requis. Tu arrives, tu lances, tu transpires. La séance du jour est calibrée et prête.",
+    "cta_primary": "Créer un compte gratuit",
+    "cta_secondary": "Voir les formats disponibles"
+  },
+  "benefits": {
+    "section_label": "Pourquoi Wan2Fit pour vos séances",
+    "no_decision_title": "0 décision à prendre",
+    "no_decision_body": "Pas de programme à choisir, pas de niveau à régler. La séance du jour est déjà là, calibrée, prête à lancer.",
+    "no_gear_title": "Sans matériel",
+    "no_gear_body": "Tout est conçu pour ton salon, ta chambre, un parc. Poids du corps uniquement — efficace et prouvé.",
+    "formats_title": "8 formats variés",
+    "formats_body": "HIIT, Tabata, EMOM, AMRAP, Pyramide, Superset, Circuit, Renforcement. Ton corps ne s'habitue jamais.",
+    "duration_title": "5 à 40 min",
+    "duration_body": "Tu choisis ce que tu peux donner aujourd'hui. Court ou long, l'effort compte autant que la durée."
+  },
+  "final_cta": {
+    "title": "Prête à transpirer ?",
+    "subtitle": "Crée ton compte gratuitement. Ta première séance est déjà programmée.",
+    "cta_primary": "Créer un compte gratuit",
+    "cta_secondary": "Découvrir les formats"
+  }
+}

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -33,6 +33,7 @@ export interface SeoRoute {
 const STATIC_ROUTES: SeoRoute[] = [
   { path: '/', changefreq: 'daily', priority: 1.0 },
   { path: '/decouvrir', changefreq: 'monthly', priority: 0.5 },
+  { path: '/decouvrir/seances', changefreq: 'monthly', priority: 0.8 },
   { path: '/formats', changefreq: 'monthly', priority: 0.8 },
   { path: '/exercices', changefreq: 'monthly', priority: 0.8 },
   { path: '/programmes', changefreq: 'monthly', priority: 0.8 },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -25,6 +25,9 @@ const LazySettingsPage = lazy(() =>
   import('./components/auth/SettingsPage.tsx').then((m) => ({ default: m.SettingsPage })),
 );
 const LazyDiscover = lazy(() => import('./components/Discover.tsx').then((m) => ({ default: m.Discover })));
+const LazySeancesLanding = lazy(() =>
+  import('./components/landings/SeancesLanding.tsx').then((m) => ({ default: m.SeancesLanding })),
+);
 const LazyProgramList = lazy(() => import('./components/ProgramList.tsx').then((m) => ({ default: m.ProgramList })));
 const LazyProgramContentPage = lazy(() =>
   import('./components/ProgramContentPage.tsx').then((m) => ({ default: m.ProgramContentPage })),
@@ -92,6 +95,15 @@ export const router = createBrowserRouter([
         element: (
           <Lazy>
             <LazyDiscover />
+          </Lazy>
+        ),
+      },
+      // Public feature landings — visitor-facing presentation of auth-only sections
+      {
+        path: 'decouvrir/seances',
+        element: (
+          <Lazy>
+            <LazySeancesLanding />
           </Lazy>
         ),
       },


### PR DESCRIPTION
> Sub-PR of [#170 acquisition-overhaul umbrella](https://github.com/ErwanViot/wanshape/pull/170). Targets the umbrella branch, **NOT develop**.

## Summary

PR 1 of the acquisition-overhaul POC — pilots the FeatureLanding pattern on the Sessions feature.

**What's delivered:**
- Reusable \`FeatureLandingTemplate\` + atoms (\`FeatureHero\`, \`FeatureBenefitGrid\`, \`FeatureCta\`) — designed to host all 4 future landings
- \`SeancesLanding\` instance (the pilot) at \`/decouvrir/seances\`
- Visitor nav now mirrors the logged-in nav structure: \`M'entraîner ▾\` (with sub-items \`Mes séances\` → landing + \`Mes programmes\` → existing public listing) + \`Explorer\` + \`Recettes\` + \`Tarifs\` (still on the right, hidden if premium)
- i18n namespace \`landing_sessions\` (FR + EN), copywriting based on the JTBD validated by the business panel: *"Ta séance de ce matin t'attend déjà."*
- Prerender-enabled (route added to \`seoRoutes.ts\` → \`/decouvrir/seances\` is now in the sitemap and pre-rendered as static HTML for SEO)

## Out of scope (other sub-PRs)

- PR 2 — Programmes + Nutrition landings (and visitor Nutrition dropdown)
- PR 3 — Suivi landing + visitor BottomNav refactor
- PR 4 — Home redesign
- PR 5 — EN variants of the other landings

## Test plan

- [ ] Visit http://localhost:5173/decouvrir/seances as a visitor (use a private window) → landing renders
- [ ] As a visitor, click \`M'entraîner\` in the nav → dropdown shows \`Mes séances\` (→ landing) + \`Mes programmes\` (→ public listing)
- [ ] As a logged-in user → nav unchanged, the landing is also accessible (CTAs route to \`/seances\` instead of \`/signup\`)
- [ ] FR ↔ EN copy works on the landing
- [ ] Theme dark/light: hero gradient + benefit cards both readable
- [ ] Build OK, 146 routes prerendered, sitemap includes \`/decouvrir/seances\`
- [ ] Lint clean, 410 tests pass

## Validation

Local validation done via Chrome MCP — hero + benefits + CTA all render as expected on desktop. See screenshots in PR thread (incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)