### PR TITLE
feat(landings): PR 3 — Suivi landing + visitor BottomNav refactor

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -21,25 +21,6 @@ function DumbbellIcon() {
   );
 }
 
-function DiscoverIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="11" cy="11" r="8" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </svg>
-  );
-}
-
 function ProgramsIcon() {
   return (
     <svg
@@ -57,44 +38,6 @@ function ProgramsIcon() {
       <rect x="14" y="3" width="7" height="7" />
       <rect x="3" y="14" width="7" height="7" />
       <rect x="14" y="14" width="7" height="7" />
-    </svg>
-  );
-}
-
-function HomeIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
-    </svg>
-  );
-}
-
-function UserIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-      <circle cx="12" cy="7" r="4" />
     </svg>
   );
 }
@@ -188,16 +131,15 @@ export function BottomNav() {
   const { user } = useAuth();
   const { t } = useTranslation('nav');
 
-  const isHome = pathname === '/';
-  const isSeances = pathname === '/seances' || pathname.startsWith('/seance');
-  const isPrograms = pathname.startsWith('/programme');
-  const isDiscover = pathname === '/decouvrir' || pathname.startsWith('/formats') || pathname.startsWith('/exercices');
-  const isSuivi = pathname === '/suivi';
+  const isSeances = pathname === '/seances' || pathname.startsWith('/seance') || pathname === '/decouvrir/seances';
+  const isPrograms = pathname.startsWith('/programme') || pathname === '/decouvrir/programmes';
+  const isSuivi = pathname === '/suivi' || pathname === '/decouvrir/suivi';
   const isRecipes = pathname.startsWith('/nutrition/recettes') || pathname.startsWith('/en/nutrition/recipes');
   // Match the exact /nutrition page (and its setup sub-page) only — recipes
   // own their own bottom-nav slot.
-  const isNutrition = (pathname === '/nutrition' || pathname.startsWith('/nutrition/setup')) && !isRecipes;
-  const isLogin = pathname === '/login' || pathname === '/signup';
+  const isNutrition =
+    (pathname === '/nutrition' || pathname.startsWith('/nutrition/setup') || pathname === '/decouvrir/nutrition') &&
+    !isRecipes;
 
   return (
     <nav
@@ -225,21 +167,23 @@ export function BottomNav() {
             </NavItem>
           </>
         ) : (
+          // Visitor mirrors the logged-in 5 slots, but each auth-only destination
+          // routes to its public landing (/decouvrir/*) instead.
           <>
-            <NavItem to="/" label={t('home')} active={isHome}>
-              <HomeIcon />
+            <NavItem to="/decouvrir/seances" label={t('sessions')} active={isSeances}>
+              <DumbbellIcon />
             </NavItem>
-            <NavItem to="/programmes" label={t('programs')} active={isPrograms}>
+            <NavItem to="/decouvrir/programmes" label={t('programs')} active={isPrograms}>
               <ProgramsIcon />
             </NavItem>
-            <NavItem to="/decouvrir" label={t('explore')} active={isDiscover}>
-              <DiscoverIcon />
+            <NavItem to="/decouvrir/nutrition" label={t('nutrition')} active={isNutrition}>
+              <UtensilsIcon />
             </NavItem>
             <NavItem to="/nutrition/recettes" label={t('recipes')} active={isRecipes}>
               <ChefHatIcon />
             </NavItem>
-            <NavItem to="/login" label={t('login')} active={isLogin}>
-              <UserIcon />
+            <NavItem to="/decouvrir/suivi" label={t('tracking')} active={isSuivi}>
+              <ChartIcon />
             </NavItem>
           </>
         )}

--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -60,7 +60,7 @@ export function BrandHeader() {
   const showPricing = !loading && !isPremium;
   const isPricingActive = pathname === '/tarifs';
   const isExploreActive = matchExplore(pathname);
-  const isTrackingActive = pathname === '/suivi';
+  const isTrackingActive = pathname === '/suivi' || pathname === '/decouvrir/suivi';
 
   return (
     <header className="px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
@@ -83,6 +83,7 @@ export function BrandHeader() {
               <NavDropdown triggerLabelKey="train" items={VISITOR_TRAIN_ITEMS} />
               <NavLink to="/decouvrir" labelKey="explore" active={isExploreActive} />
               <NavDropdown triggerLabelKey="nutrition" items={VISITOR_NUTRITION_ITEMS} />
+              <NavLink to="/decouvrir/suivi" labelKey="tracking" active={isTrackingActive} />
             </>
           )}
         </nav>

--- a/src/components/landings/SuiviLanding.tsx
+++ b/src/components/landings/SuiviLanding.tsx
@@ -1,0 +1,126 @@
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { FeatureLandingTemplate } from './FeatureLandingTemplate.tsx';
+
+function NetworkIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="5" r="3" />
+      <circle cx="5" cy="19" r="3" />
+      <circle cx="19" cy="19" r="3" />
+      <path d="M12 8v6M5.5 17l5-5M18.5 17l-5-5" />
+    </svg>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+function RulerIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21.3 8.7l-12.6 12.6a1 1 0 0 1-1.4 0L2.7 16.7a1 1 0 0 1 0-1.4L15.3 2.7a1 1 0 0 1 1.4 0l4.6 4.6a1 1 0 0 1 0 1.4z" />
+      <path d="M7 17l-2-2M11 13l-2-2M15 9l-2-2" />
+    </svg>
+  );
+}
+
+function TrendIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+      <polyline points="17 6 23 6 23 12" />
+    </svg>
+  );
+}
+
+export function SuiviLanding() {
+  const { t } = useTranslation('landing_suivi');
+  const { user } = useAuth();
+
+  const primaryTarget = user ? '/suivi' : '/signup';
+
+  return (
+    <FeatureLandingTemplate
+      meta={{ title: t('meta.title'), description: t('meta.description') }}
+      hero={{
+        eyebrow: t('hero.eyebrow'),
+        title: t('hero.title'),
+        subtitle: t('hero.subtitle'),
+        ctas: [
+          { label: t('hero.cta_primary'), to: primaryTarget },
+          { label: t('hero.cta_secondary'), to: '/programmes', variant: 'secondary' },
+        ],
+      }}
+      benefits={{
+        sectionLabel: t('benefits.section_label'),
+        items: [
+          {
+            icon: <NetworkIcon />,
+            title: t('benefits.correlation_title'),
+            body: t('benefits.correlation_body'),
+          },
+          { icon: <CalendarIcon />, title: t('benefits.history_title'), body: t('benefits.history_body') },
+          { icon: <RulerIcon />, title: t('benefits.body_title'), body: t('benefits.body_body') },
+          { icon: <TrendIcon />, title: t('benefits.signal_title'), body: t('benefits.signal_body') },
+        ],
+      }}
+      finalCta={{
+        title: t('final_cta.title'),
+        subtitle: t('final_cta.subtitle'),
+        ctas: [
+          { label: t('final_cta.cta_primary'), to: primaryTarget },
+          { label: t('final_cta.cta_secondary'), to: '/programmes', variant: 'secondary' },
+        ],
+      }}
+    />
+  );
+}

--- a/src/i18n/locales/en/landing_suivi.json
+++ b/src/i18n/locales/en/landing_suivi.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "title": "Tracking — finally see it's working, beyond the scale",
+    "description": "Workouts, measurements, weight, nutrition in one dashboard. See the correlation, not just raw numbers."
+  },
+  "hero": {
+    "eyebrow": "Tracking",
+    "title": "Finally see it's working — beyond the scale.",
+    "subtitle": "Your workouts, your measurements, your weight, what you eat. All connected in one dashboard — see the correlation, not just isolated numbers.",
+    "cta_primary": "Create a free account",
+    "cta_secondary": "Browse the standard programs"
+  },
+  "benefits": {
+    "section_label": "Why our tracking",
+    "correlation_title": "Correlation, not juxtaposition",
+    "correlation_body": "Strava shows your GPS. MyFitnessPal shows your calories. Here you see how one acts on the other — the gap between effort and result.",
+    "history_title": "Workout history",
+    "history_body": "Every completed session is saved. You see your regularity, your favorite formats, your weekly volume.",
+    "body_title": "Measurements and weight",
+    "body_body": "Beyond the weekly scale: waist, hips, arms. The real transformation indicator, without falling into obsession.",
+    "signal_title": "The signal to keep going",
+    "signal_body": "People quit when they can't see it's working. Tracking is designed to make that signal visible — week after week."
+  },
+  "final_cta": {
+    "title": "Finally see your effort pay off.",
+    "subtitle": "Create a free account, start tracking, and watch the curve take shape.",
+    "cta_primary": "Create a free account",
+    "cta_secondary": "Browse the programs"
+  }
+}

--- a/src/i18n/locales/fr/landing_suivi.json
+++ b/src/i18n/locales/fr/landing_suivi.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "title": "Suivi — vois enfin si ça marche, au-delà de la balance",
+    "description": "Séances, mensurations, poids, nutrition dans un seul tableau de bord. Vois la corrélation, pas juste les chiffres bruts."
+  },
+  "hero": {
+    "eyebrow": "Suivi",
+    "title": "Vois enfin si ça marche — au-delà de la balance.",
+    "subtitle": "Tes séances, tes mensurations, ton poids, ce que tu manges. Tout connecté dans un même tableau de bord — pour voir la corrélation, pas juste des chiffres isolés.",
+    "cta_primary": "Créer un compte gratuit",
+    "cta_secondary": "Voir les programmes types"
+  },
+  "benefits": {
+    "section_label": "Pourquoi notre suivi",
+    "correlation_title": "Corrélation, pas juxtaposition",
+    "correlation_body": "Strava te dit ton GPS. MyFitnessPal te dit tes calories. Ici tu vois comment l'un agit sur l'autre — l'écart entre l'effort et le résultat.",
+    "history_title": "Historique des séances",
+    "history_body": "Chaque séance terminée est sauvegardée. Tu vois ta régularité, tes formats préférés, ton volume hebdomadaire.",
+    "body_title": "Mensurations + poids",
+    "body_body": "Hors balance hebdomadaire : tour de taille, hanches, bras. Le vrai indicateur de transformation, sans tomber dans l'obsession.",
+    "signal_title": "Le signal pour ne pas lâcher",
+    "signal_body": "Le moment où on abandonne, c'est quand on ne voit pas que ça marche. Le suivi est conçu pour rendre ce signal visible — semaine après semaine."
+  },
+  "final_cta": {
+    "title": "Vois enfin que ton effort paie.",
+    "subtitle": "Crée ton compte gratuit, commence à suivre, et regarde la courbe se dessiner.",
+    "cta_primary": "Créer un compte gratuit",
+    "cta_secondary": "Découvrir les programmes"
+  }
+}

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -36,6 +36,7 @@ const STATIC_ROUTES: SeoRoute[] = [
   { path: '/decouvrir/seances', changefreq: 'monthly', priority: 0.8 },
   { path: '/decouvrir/programmes', changefreq: 'monthly', priority: 0.8 },
   { path: '/decouvrir/nutrition', changefreq: 'monthly', priority: 0.8 },
+  { path: '/decouvrir/suivi', changefreq: 'monthly', priority: 0.7 },
   { path: '/formats', changefreq: 'monthly', priority: 0.8 },
   { path: '/exercices', changefreq: 'monthly', priority: 0.8 },
   { path: '/programmes', changefreq: 'monthly', priority: 0.8 },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -34,6 +34,9 @@ const LazyProgramsLanding = lazy(() =>
 const LazyNutritionLanding = lazy(() =>
   import('./components/landings/NutritionLanding.tsx').then((m) => ({ default: m.NutritionLanding })),
 );
+const LazySuiviLanding = lazy(() =>
+  import('./components/landings/SuiviLanding.tsx').then((m) => ({ default: m.SuiviLanding })),
+);
 const LazyProgramList = lazy(() => import('./components/ProgramList.tsx').then((m) => ({ default: m.ProgramList })));
 const LazyProgramContentPage = lazy(() =>
   import('./components/ProgramContentPage.tsx').then((m) => ({ default: m.ProgramContentPage })),
@@ -126,6 +129,14 @@ export const router = createBrowserRouter([
         element: (
           <Lazy>
             <LazyNutritionLanding />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'decouvrir/suivi',
+        element: (
+          <Lazy>
+            <LazySuiviLanding />
           </Lazy>
         ),
       },


### PR DESCRIPTION
> Sub-PR of [#170 acquisition-overhaul umbrella](https://github.com/ErwanViot/wanshape/pull/170).

## Summary

- \`SuiviLanding\` at \`/decouvrir/suivi\` — *"Vois enfin si ça marche — au-delà de la balance"* (correlation between sessions × nutrition × body, vs Strava-style isolated metrics)
- \`BrandHeader\`: Suivi added to visitor nav → visitor now sees the full 4-entry mirror \`M'entraîner ▾ · Explorer · Nutrition ▾ · Suivi\`
- \`BottomNav\` refactor: visitor's 5 slots now mirror the logged-in 5 slots, with auth-only destinations routed to \`/decouvrir/*\` landings. Dropped unused Home/Discover/User icons.
- i18n: \`landing_suivi\` (FR + EN)
- Prerender: 149 routes (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)