### PR TITLE
feat(landings): PR 5 — EN landing routes + hreflang

### DIFF
--- a/src/components/landings/FeatureLandingTemplate.tsx
+++ b/src/components/landings/FeatureLandingTemplate.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { type FeatureBenefit, FeatureBenefitGrid } from './FeatureBenefitGrid.tsx';
 import { FeatureCta } from './FeatureCta.tsx';
@@ -17,6 +20,18 @@ export interface FeatureLandingTemplateProps {
 }
 
 export function FeatureLandingTemplate({ meta, hero, benefits, finalCta }: FeatureLandingTemplateProps) {
+  const { i18n } = useTranslation();
+  const { pathname } = useLocation();
+
+  // Sync i18n locale with URL prefix so EN-mirrored landing URLs always render
+  // English content, even when navigated via SPA (no full reload).
+  useEffect(() => {
+    const targetLng = pathname.startsWith('/en/') ? 'en' : 'fr';
+    if (i18n.language !== targetLng) {
+      void i18n.changeLanguage(targetLng);
+    }
+  }, [pathname, i18n]);
+
   useDocumentHead({ title: meta.title, description: meta.description });
 
   return (

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -33,10 +33,6 @@ export interface SeoRoute {
 const STATIC_ROUTES: SeoRoute[] = [
   { path: '/', changefreq: 'daily', priority: 1.0 },
   { path: '/decouvrir', changefreq: 'monthly', priority: 0.5 },
-  { path: '/decouvrir/seances', changefreq: 'monthly', priority: 0.8 },
-  { path: '/decouvrir/programmes', changefreq: 'monthly', priority: 0.8 },
-  { path: '/decouvrir/nutrition', changefreq: 'monthly', priority: 0.8 },
-  { path: '/decouvrir/suivi', changefreq: 'monthly', priority: 0.7 },
   { path: '/formats', changefreq: 'monthly', priority: 0.8 },
   { path: '/exercices', changefreq: 'monthly', priority: 0.8 },
   { path: '/programmes', changefreq: 'monthly', priority: 0.8 },
@@ -72,6 +68,35 @@ function buildSlugIndex(seed: SeedFile): Map<string, string> {
 
 const FR_SLUGS = buildSlugIndex(FR_SEED);
 const EN_SLUGS = buildSlugIndex(EN_SEED);
+
+// Feature landing pages — public visitor-facing presentations of auth-only
+// sections. Each FR canonical URL has an EN mirror with translated path
+// segments so search engines can index and serve the right locale.
+const LANDING_PAIRS = [
+  { fr: '/decouvrir/seances', en: '/en/discover/sessions', priority: 0.8 },
+  { fr: '/decouvrir/programmes', en: '/en/discover/programs', priority: 0.8 },
+  { fr: '/decouvrir/nutrition', en: '/en/discover/nutrition', priority: 0.8 },
+  { fr: '/decouvrir/suivi', en: '/en/discover/tracking', priority: 0.7 },
+] as const;
+
+function buildLandingRoutes(): SeoRoute[] {
+  const routes: SeoRoute[] = [];
+  for (const pair of LANDING_PAIRS) {
+    const alternates: SeoAlternate[] = [
+      { hreflang: 'fr-FR', href: pair.fr },
+      { hreflang: 'en-US', href: pair.en },
+      { hreflang: 'x-default', href: pair.fr },
+    ];
+    routes.push({ path: pair.fr, changefreq: 'monthly', priority: pair.priority, alternates });
+    routes.push({
+      path: pair.en,
+      changefreq: 'monthly',
+      priority: pair.priority - 0.1,
+      alternates,
+    });
+  }
+  return routes;
+}
 
 export function getPublicRoutes(): SeoRoute[] {
   const formatRoutes: SeoRoute[] = FORMATS_DATA.map((f) => ({
@@ -130,6 +155,7 @@ export function getPublicRoutes(): SeoRoute[] {
 
   return [
     ...STATIC_ROUTES,
+    ...buildLandingRoutes(),
     recipeListingFr,
     recipeListingEn,
     ...formatRoutes,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -140,6 +140,40 @@ export const router = createBrowserRouter([
           </Lazy>
         ),
       },
+      // English mirrors of the feature landings — same components, locale forced
+      // by FeatureLandingTemplate based on the path. URLs are translated for SEO.
+      {
+        path: 'en/discover/sessions',
+        element: (
+          <Lazy>
+            <LazySeancesLanding />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'en/discover/programs',
+        element: (
+          <Lazy>
+            <LazyProgramsLanding />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'en/discover/nutrition',
+        element: (
+          <Lazy>
+            <LazyNutritionLanding />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'en/discover/tracking',
+        element: (
+          <Lazy>
+            <LazySuiviLanding />
+          </Lazy>
+        ),
+      },
       {
         path: 'formats',
         element: (


### PR DESCRIPTION
> Sub-PR of [#170 acquisition-overhaul umbrella](https://github.com/ErwanViot/wanshape/pull/170).

## Summary

- Added 4 EN-mirror routes: \`/en/discover/{sessions,programs,nutrition,tracking}\` reusing the same landing components
- \`FeatureLandingTemplate\`: \`useEffect\` syncs i18n locale with the URL prefix (\`/en/\` → \`en\`), so SPA navigation between locales always renders the matching language
- \`seoRoutes.ts\`: refactored landing entries into \`LANDING_PAIRS\` with cross-locale \`hreflang\` alternates (\`fr-FR\`, \`en-US\`, \`x-default\`), matching the recipe pattern
- Prerender: 153 routes (+4 EN landings), sitemap correctly emits \`<xhtml:link rel="alternate" hreflang="...">\` for all landing pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)