### PR TITLE
feat(mobile): native auth storage + deep link listener + AASA/assetlinks

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -34,6 +34,47 @@ npx cap sync
 
 Les dossiers `ios/` et `android/` sont commitables : ils contiennent la config native (Info.plist, AndroidManifest.xml, etc.) qu'on éditera au fil des PRs.
 
+### À faire après le premier `cap add` (PR #2 deep links)
+
+**iOS — `ios/App/App/Info.plist`** : ajouter le custom URL scheme et le domaine associé.
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>fr.wansoft.wan2fit</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>wan2fit</string>
+    </array>
+  </dict>
+</array>
+```
+
+Puis dans Xcode : **Signing & Capabilities** → **+ Capability** → **Associated Domains** → ajouter `applinks:wan2fit.fr` (et `applinks:www.wan2fit.fr` si besoin).
+
+**Android — `android/app/src/main/AndroidManifest.xml`** : ajouter dans `<activity android:name="com.getcapacitor.bridge.MainActivity">` :
+
+```xml
+<intent-filter android:autoVerify="true">
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="https" android:host="wan2fit.fr" />
+</intent-filter>
+<intent-filter>
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="wan2fit" />
+</intent-filter>
+```
+
+**AASA + assetlinks.json** : déjà commités sous `public/.well-known/`. Servis par Vercel sur `https://wan2fit.fr/.well-known/{apple-app-site-association,assetlinks.json}` via `vercel.json` (Content-Type `application/json` forcé). Deux placeholders à remplacer **avant la première soumission** :
+- `TODO_APPLE_TEAM_ID` dans `apple-app-site-association` → Team ID Apple Developer (ex. `ABCDEFGHIJ`), visible sur https://developer.apple.com/account/#/membership
+- `TODO_ANDROID_RELEASE_SHA256` dans `assetlinks.json` → fingerprint du keystore Android release : `keytool -list -v -keystore release.keystore -alias upload | grep SHA256`
+
 ## Cycle de dev quotidien
 
 ```bash

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,9 +5,9 @@
         "appIDs": ["TODO_APPLE_TEAM_ID.fr.wansoft.wan2fit"],
         "components": [
           { "/": "/reset-password" },
-          { "/": "/upgrade*" },
-          { "/": "/account*" },
-          { "/": "/auth/callback*" }
+          { "/": "/auth/callback*" },
+          { "/": "/parametres*" },
+          { "/": "/upgrade*" }
         ]
       }
     ]

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["TODO_APPLE_TEAM_ID.fr.wansoft.wan2fit"],
+        "components": [
+          { "/": "/reset-password" },
+          { "/": "/upgrade*" },
+          { "/": "/account*" },
+          { "/": "/auth/callback*" }
+        ]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "fr.wansoft.wan2fit",
+      "sha256_cert_fingerprints": ["TODO_ANDROID_RELEASE_SHA256"]
+    }
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import type { PluginListenerHandle } from '@capacitor/core';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { lazy, Suspense, useEffect } from 'react';
 import { RouterProvider } from 'react-router';
@@ -23,9 +24,22 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    const handlePromise = registerDeepLinkListener();
+    // The listener registration is async; if the effect is torn down before
+    // it resolves (StrictMode double-mount in dev, fast unmount in tests),
+    // we must still remove the handle once it lands. The cancelled flag
+    // ensures we never leak a listener nor try to remove a handle twice.
+    let cancelled = false;
+    let activeHandle: PluginListenerHandle | null = null;
+    void registerDeepLinkListener().then((handle) => {
+      if (cancelled) {
+        handle?.remove();
+      } else {
+        activeHandle = handle;
+      }
+    });
     return () => {
-      void handlePromise.then((handle) => handle?.remove());
+      cancelled = true;
+      activeHandle?.remove();
     };
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
 import { AuthProvider } from './contexts/AuthContext.tsx';
 import { hideNativeSplash } from './lib/capacitor.ts';
+import { registerDeepLinkListener } from './lib/deepLinks.ts';
 import { queryClient } from './lib/queryClient.ts';
 import { router } from './router.tsx';
 
@@ -19,6 +20,13 @@ export default function App() {
   // is safe. No cleanup needed — the splash is already gone after first call.
   useEffect(() => {
     void hideNativeSplash();
+  }, []);
+
+  useEffect(() => {
+    const handlePromise = registerDeepLinkListener();
+    return () => {
+      void handlePromise.then((handle) => handle?.remove());
+    };
   }, []);
 
   // QueryClientProvider sits INSIDE ErrorBoundary so any TanStack-originated

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import type { User } from '@supabase/supabase-js';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import i18n from '../i18n';
+import { getAuthRedirectUrl } from '../lib/auth-redirects.ts';
 import { supabase } from '../lib/supabase.ts';
 import { sessionEvents } from '../lib/supabaseQuery.ts';
 import type { Profile } from '../types/auth.ts';
@@ -183,7 +184,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const resetPassword = useCallback(async (email: string): Promise<{ error: string | null }> => {
     if (!supabase) return { error: i18n.t('errors.auth_unavailable', { ns: 'auth' }) };
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/reset-password`,
+      redirectTo: getAuthRedirectUrl('/reset-password'),
     });
     return { error: translateError(error?.message) };
   }, []);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -174,6 +174,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         password,
         options: {
           data: { display_name: displayName },
+          emailRedirectTo: getAuthRedirectUrl('/auth/callback'),
         },
       });
       return { error: translateError(error?.message) };

--- a/src/lib/auth-redirects.ts
+++ b/src/lib/auth-redirects.ts
@@ -1,0 +1,13 @@
+import { isNative } from './capacitor.ts';
+
+const PRODUCTION_ORIGIN = 'https://wan2fit.fr';
+
+// Build a redirect URL that survives the Supabase email round-trip.
+// On web we keep window.location.origin so dev/preview URLs (Vercel preview
+// deployments) work without extra config. On native we always send users to
+// the production domain — Apple's AASA + Android's assetlinks reroute the
+// click back into the installed app via the deep-link listener.
+export function getAuthRedirectUrl(path: string): string {
+  if (isNative()) return `${PRODUCTION_ORIGIN}${path}`;
+  return `${window.location.origin}${path}`;
+}

--- a/src/lib/deepLinks.ts
+++ b/src/lib/deepLinks.ts
@@ -7,12 +7,16 @@ import { isNative } from './capacitor.ts';
 // Supported schemes:
 //   wan2fit://reset-password?token=xxx        → /reset-password?token=xxx
 //   https://wan2fit.fr/upgrade?session=xxx    → /upgrade?session=xxx (Universal Link)
-// Anything we cannot parse falls through to the home route so the user is
-// never stuck on a black screen.
+// Note: WHATWG URL parses non-special schemes (custom like wan2fit://) by
+// putting the segment after :// in `host`, leaving `pathname` empty. We
+// rebuild the route from host + pathname for those cases. Anything we cannot
+// parse falls through to '/' so users never land on a black screen.
 function urlToRouterPath(rawUrl: string): string {
   try {
     const parsed = new URL(rawUrl);
-    return `${parsed.pathname || '/'}${parsed.search}${parsed.hash}`;
+    const isHttp = parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    const route = isHttp ? parsed.pathname || '/' : `/${parsed.host}${parsed.pathname}`.replace(/\/{2,}/g, '/') || '/';
+    return `${route}${parsed.search}${parsed.hash}`;
   } catch {
     return '/';
   }

--- a/src/lib/deepLinks.ts
+++ b/src/lib/deepLinks.ts
@@ -1,0 +1,28 @@
+import { App } from '@capacitor/app';
+import type { PluginListenerHandle } from '@capacitor/core';
+import { router } from '../router.tsx';
+import { isNative } from './capacitor.ts';
+
+// Convert any incoming deep link into a router path.
+// Supported schemes:
+//   wan2fit://reset-password?token=xxx        → /reset-password?token=xxx
+//   https://wan2fit.fr/upgrade?session=xxx    → /upgrade?session=xxx (Universal Link)
+// Anything we cannot parse falls through to the home route so the user is
+// never stuck on a black screen.
+function urlToRouterPath(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    return `${parsed.pathname || '/'}${parsed.search}${parsed.hash}`;
+  } catch {
+    return '/';
+  }
+}
+
+export async function registerDeepLinkListener(): Promise<PluginListenerHandle | null> {
+  if (!isNative()) return null;
+
+  return App.addListener('appUrlOpen', (event) => {
+    const path = urlToRouterPath(event.url);
+    void router.navigate(path);
+  });
+}

--- a/src/lib/supabase-storage.ts
+++ b/src/lib/supabase-storage.ts
@@ -1,4 +1,3 @@
-import { Preferences } from '@capacitor/preferences';
 import { isNative } from './capacitor.ts';
 
 // Supabase auth storage interface (sync OR async).
@@ -13,15 +12,28 @@ type StorageAdapter = {
   removeItem: (key: string) => Promise<void>;
 };
 
+// Lazy-loaded native module so the web bundle never imports
+// @capacitor/preferences (matches the dynamic-import pattern in capacitor.ts).
+let preferencesPromise: Promise<typeof import('@capacitor/preferences')> | null = null;
+function loadPreferences() {
+  if (!preferencesPromise) {
+    preferencesPromise = import('@capacitor/preferences');
+  }
+  return preferencesPromise;
+}
+
 const capacitorPreferencesAdapter: StorageAdapter = {
   async getItem(key) {
+    const { Preferences } = await loadPreferences();
     const { value } = await Preferences.get({ key });
     return value;
   },
   async setItem(key, value) {
+    const { Preferences } = await loadPreferences();
     await Preferences.set({ key, value });
   },
   async removeItem(key) {
+    const { Preferences } = await loadPreferences();
     await Preferences.remove({ key });
   },
 };

--- a/src/lib/supabase-storage.ts
+++ b/src/lib/supabase-storage.ts
@@ -1,0 +1,31 @@
+import { Preferences } from '@capacitor/preferences';
+import { isNative } from './capacitor.ts';
+
+// Supabase auth storage interface (sync OR async).
+// On native, WebView localStorage can be wiped silently by the OS, so we
+// persist auth tokens in @capacitor/preferences (KV backed by NSUserDefaults
+// on iOS and SharedPreferences on Android — both stable across app launches).
+// On web we return undefined so Supabase falls back to its built-in
+// localStorage adapter (no behaviour change for the PWA).
+type StorageAdapter = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+};
+
+const capacitorPreferencesAdapter: StorageAdapter = {
+  async getItem(key) {
+    const { value } = await Preferences.get({ key });
+    return value;
+  },
+  async setItem(key, value) {
+    await Preferences.set({ key, value });
+  },
+  async removeItem(key) {
+    await Preferences.remove({ key });
+  },
+};
+
+export function getSupabaseStorage(): StorageAdapter | undefined {
+  return isNative() ? capacitorPreferencesAdapter : undefined;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseStorage } from './supabase-storage.ts';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const supabaseKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
@@ -48,6 +49,7 @@ function getClient(): SupabaseClient | null {
       persistSession: true,
       detectSessionInUrl: true,
       lock: inMemoryLock,
+      storage: getSupabaseStorage(),
     },
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,26 @@
 {
   "installCommand": "dnf install -y nss nspr atk at-spi2-atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm alsa-lib pango cairo libXcomposite libXdamage libXfixes libXrandr libXtst libXScrnSaver && npm install && npx playwright install chromium",
   "rewrites": [
-    { "source": "/((?!assets|sessions|images|icons|sitemap\\.xml|robots\\.txt|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|manifest\\.webmanifest|sw\\.js|theme-init\\.js).*)", "destination": "/index.html" }
+    {
+      "source": "/((?!assets|sessions|images|icons|\\.well-known|sitemap\\.xml|robots\\.txt|logo-wan2fit\\.png|icon-192\\.png|icon-512\\.png|favicon\\.ico|manifest\\.webmanifest|sw\\.js|theme-init\\.js).*)",
+      "destination": "/index.html"
+    }
   ],
   "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [


### PR DESCRIPTION
## Summary
PR #2 du plan de migration mobile. Pose les primitives JS pour les deep links Capacitor et le storage auth natif, plus les fichiers statiques que les résolveurs Universal Links (Apple) et App Links (Android) iront chercher sur \`wan2fit.fr/.well-known/\`. La config native (\`Info.plist\` URL Schemes, \`AndroidManifest\` intent-filters, capability Associated Domains) viendra avec \`cap add ios|android\` — checklist exacte dans \`claudedocs/mobile-dev.md\`.

- **Storage natif** : \`src/lib/supabase-storage.ts\` adapter \`@capacitor/preferences\` (dynamic import) câblé dans \`supabase.ts\`. Web inchangé. Sur natif, tokens auth survivent aux purges WebView via NSUserDefaults / SharedPreferences.
- **Deep link listener** : \`src/lib/deepLinks.ts\` traduit \`wan2fit://reset-password?token=…\` ET \`https://wan2fit.fr/upgrade\` (Universal Link) vers \`router.navigate()\`. Bug subtil corrigé : WHATWG URL parse les schemes custom en mettant le segment après \`://\` dans \`host\`, pas \`pathname\`.
- **Auth redirects** : \`src/lib/auth-redirects.ts\` \`getAuthRedirectUrl\`. Natif force \`https://wan2fit.fr/<path>\` (Universal Link rebascule dans l'app via AASA). Web reste sur \`window.location.origin\` pour préserver les Vercel previews.
- **AuthContext** : \`resetPassword\` et \`signUp\` (\`emailRedirectTo\`) utilisent maintenant le helper.
- **App.tsx** : \`registerDeepLinkListener\` mounté en \`useEffect\` avec cleanup robuste (cancelled flag + activeHandle ref) pour tolérer un unmount avant que la promise async résolve (StrictMode dev, tests).
- **\`.well-known/\`** : \`apple-app-site-association\` (paths : \`/reset-password\`, \`/auth/callback*\`, \`/parametres*\`, \`/upgrade*\`) et \`assetlinks.json\`. Deux placeholders \`TODO_APPLE_TEAM_ID\` et \`TODO_ANDROID_RELEASE_SHA256\` à remplir avant la 1re soumission stores (instructions dans \`mobile-dev.md\`).
- **\`vercel.json\`** : SPA fallback exclut \`.well-known\` + force \`Content-Type: application/json\` sur les deux fichiers (AASA n'a pas d'extension, validateurs Apple rejettent les autres types).
- **Doc** : \`mobile-dev.md\` complétée avec snippets \`Info.plist\` (\`CFBundleURLSchemes\` \`wan2fit\`), \`AndroidManifest\` (intent-filters \`autoVerify\`), capability Associated Domains, et instructions placeholder substitution.

Volontairement pas dans cette PR :
- Modifs \`Info.plist\` / \`AndroidManifest\` (les dossiers natifs n'existent pas encore — \`cap add\` viendra après install Xcode/Android Studio)
- Routes \`/upgrade\` (PR #4 Paywall SSO)

## Test plan
- [x] \`npm run lint\` (289 fichiers, 0 issue)
- [x] \`npx vitest run\` (410 tests verts)
- [x] \`npm run build\` (153 routes prerenderées + \`.well-known/*\` copié dans \`dist/\`)
- [x] Parsing \`urlToRouterPath\` testé sur custom scheme + Universal Link + edge cases
- [ ] AASA accessible sur \`wan2fit.fr/.well-known/apple-app-site-association\` après merge develop (preview Vercel)
- [ ] Validation finale fonctionnelle quand \`cap add ios\` sera fait + Info.plist mis à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)