### PR TITLE
feat(mobile): native wake lock + network status + offline banner

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -71,6 +71,16 @@ Puis dans Xcode : **Signing & Capabilities** → **+ Capability** → **Associat
 </intent-filter>
 ```
 
+**iOS — désactiver le rubber-band bounce du WKWebView** : Capacitor 8 n'expose pas d'option typée pour ça. Éditer `ios/App/App/AppDelegate.swift` (ou créer un `ViewController` custom) pour ajouter, après le chargement initial du WebView :
+
+```swift
+// In AppDelegate.swift, after WebView creation, or via a custom ViewController:
+webView.scrollView.bounces = false
+webView.scrollView.alwaysBounceVertical = false
+```
+
+Le but : empêcher le surface sombre du fond de l'app d'apparaître quand l'utilisateur tire trop bas/haut. Pas de modif côté Android (WebView Android n'a pas de bounce par défaut).
+
 **AASA + assetlinks.json** : déjà commités sous `public/.well-known/`. Servis par Vercel sur `https://wan2fit.fr/.well-known/{apple-app-site-association,assetlinks.json}` via `vercel.json` (Content-Type `application/json` forcé). Deux placeholders à remplacer **avant la première soumission** :
 - `TODO_APPLE_TEAM_ID` dans `apple-app-site-association` → Team ID Apple Developer (ex. `ABCDEFGHIJ`), visible sur https://developer.apple.com/account/#/membership
 - `TODO_ANDROID_RELEASE_SHA256` dans `assetlinks.json` → fingerprint du keystore Android release : `keytool -list -v -keystore release.keystore -alias upload | grep SHA256`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "wan2fit",
       "version": "1.1.1",
       "dependencies": {
+        "@capacitor-community/keep-awake": "^8.0.1",
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.3.1",
         "@capacitor/ios": "^8.3.1",
         "@capacitor/keyboard": "^8.0.3",
+        "@capacitor/network": "^8.0.1",
         "@capacitor/preferences": "^8.0.1",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
@@ -1771,6 +1773,15 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@capacitor-community/keep-awake": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/keep-awake/-/keep-awake-8.0.1.tgz",
+      "integrity": "sha512-wTI5A6FWl5gWoMduzJ5euuJ1P73SO+rea0jV6vNdmz5TLbwIDhufelFe/GowNvU9gog6kDYbFhJ2pOp9ua1f3w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/android": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.1.tgz",
@@ -1882,6 +1893,15 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.3.tgz",
       "integrity": "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "seed:recipes": "tsx scripts/seed-recipes.ts"
   },
   "dependencies": {
+    "@capacitor-community/keep-awake": "^8.0.1",
     "@capacitor/android": "^8.3.1",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.1",
     "@capacitor/ios": "^8.3.1",
     "@capacitor/keyboard": "^8.0.3",
+    "@capacitor/network": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -11,13 +11,17 @@ export function OfflineBanner() {
 
   if (isOnline) return null;
 
+  // aria-live alone is enough for screen readers — no role="status" (would
+  // trigger Biome's useSemanticElements) and no <output> (form-result
+  // semantics, awkward for a generic notification). "polite" instead of
+  // "assertive" because losing connectivity is not an emergency.
   return (
-    <output
+    <div
       aria-live="polite"
       className="pt-safe sticky top-0 z-50 w-full bg-amber-500/95 text-amber-950 text-sm font-medium px-4 py-2 flex items-center justify-center gap-2 shadow"
     >
       <WifiOff className="w-4 h-4" aria-hidden="true" />
       <span>{t('offline.banner')}</span>
-    </output>
+    </div>
   );
 }

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,0 +1,23 @@
+import { WifiOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNetworkStatus } from '../hooks/useNetworkStatus.ts';
+
+// Thin banner shown only when the device drops offline. Lives at the very
+// top of the viewport above any header so it doesn't collide with native
+// notch / status bar (it sits inside the safe area via pt-safe).
+export function OfflineBanner() {
+  const isOnline = useNetworkStatus();
+  const { t } = useTranslation('common');
+
+  if (isOnline) return null;
+
+  return (
+    <output
+      aria-live="polite"
+      className="pt-safe sticky top-0 z-50 w-full bg-amber-500/95 text-amber-950 text-sm font-medium px-4 py-2 flex items-center justify-center gap-2 shadow"
+    >
+      <WifiOff className="w-4 h-4" aria-hidden="true" />
+      <span>{t('offline.banner')}</span>
+    </output>
+  );
+}

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -5,6 +5,7 @@ import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
 import { Footer } from './Footer.tsx';
 import { CguRevalidationModal } from './legal/CguRevalidationModal.tsx';
+import { OfflineBanner } from './OfflineBanner.tsx';
 import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 
 export function PublicLayout() {
@@ -24,6 +25,7 @@ export function PublicLayout() {
       <a href="#main-content" className="skip-to-content">
         {t('layout.skip_to_content')}
       </a>
+      <OfflineBanner />
       <BrandHeader />
       <SessionExpiredBanner />
       <main id="main-content" className="flex-1 pb-16 md:pb-0">

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { isNative } from '../lib/capacitor.ts';
+
+// Subscribe to online/offline transitions.
+// Native: @capacitor/network gives a richer status (cellular vs wifi) but
+// we only surface a boolean here — the OfflineBanner is a single state.
+// Web: navigator.onLine + the online/offline events. Reliable in modern
+// browsers; the rare false positive (online === true but no DNS) degrades
+// gracefully because TanStack Query retries failed requests.
+export function useNetworkStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(() => (typeof navigator !== 'undefined' ? navigator.onLine : true));
+
+  useEffect(() => {
+    if (isNative()) {
+      let cancelled = false;
+      let removeListener: (() => void) | null = null;
+
+      void import('@capacitor/network').then(({ Network }) => {
+        if (cancelled) return;
+        void Network.getStatus().then((status) => {
+          if (!cancelled) setIsOnline(status.connected);
+        });
+        void Network.addListener('networkStatusChange', (status) => {
+          setIsOnline(status.connected);
+        }).then((handle) => {
+          if (cancelled) {
+            handle.remove();
+          } else {
+            removeListener = () => handle.remove();
+          }
+        });
+      });
+
+      return () => {
+        cancelled = true;
+        removeListener?.();
+      };
+    }
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -8,7 +8,10 @@ import { isNative } from '../lib/capacitor.ts';
 // browsers; the rare false positive (online === true but no DNS) degrades
 // gracefully because TanStack Query retries failed requests.
 export function useNetworkStatus(): boolean {
-  const [isOnline, setIsOnline] = useState<boolean>(() => (typeof navigator !== 'undefined' ? navigator.onLine : true));
+  // Optimistic initial state: assume online so the OfflineBanner doesn't
+  // flash on boot. The effect below corrects it on the first tick via
+  // Network.getStatus() (native) or navigator.onLine (web).
+  const [isOnline, setIsOnline] = useState<boolean>(true);
 
   useEffect(() => {
     if (isNative()) {
@@ -17,6 +20,10 @@ export function useNetworkStatus(): boolean {
 
       void import('@capacitor/network').then(({ Network }) => {
         if (cancelled) return;
+        // Best-effort sync. There's a tiny window between getStatus() and
+        // addListener() where a network change could be missed, but the
+        // listener catches every transition after that — acceptable for a
+        // banner whose only role is to inform the user.
         void Network.getStatus().then((status) => {
           if (!cancelled) setIsOnline(status.connected);
         });
@@ -37,6 +44,7 @@ export function useNetworkStatus(): boolean {
       };
     }
 
+    setIsOnline(navigator.onLine);
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);
     window.addEventListener('online', handleOnline);

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,30 +1,56 @@
 import { useEffect, useRef } from 'react';
+import { isNative } from '../lib/capacitor.ts';
 
+// Keep the screen on while the active flag is true.
+// Native: @capacitor-community/keep-awake bridges to UIApplication
+// idleTimerDisabled (iOS) and FLAG_KEEP_SCREEN_ON (Android). The Web Wake
+// Lock API is unsupported in iOS WKWebView, so we route everything through
+// the plugin once we run inside Capacitor.
+// Web: navigator.wakeLock.request('screen') with graceful no-op when the
+// API is missing or denied.
 export function useWakeLock(active: boolean) {
-  const wakeLock = useRef<WakeLockSentinel | null>(null);
+  const webSentinel = useRef<WakeLockSentinel | null>(null);
 
   useEffect(() => {
-    if (!active || !('wakeLock' in navigator)) return;
+    if (!active) return;
 
-    let released = false;
+    let cancelled = false;
+
+    if (isNative()) {
+      void import('@capacitor-community/keep-awake')
+        .then(({ KeepAwake }) => {
+          if (cancelled) return;
+          return KeepAwake.keepAwake();
+        })
+        .catch(() => {
+          // Plugin missing or platform refused — degrade silently.
+        });
+
+      return () => {
+        cancelled = true;
+        void import('@capacitor-community/keep-awake').then(({ KeepAwake }) => KeepAwake.allowSleep()).catch(() => {});
+      };
+    }
+
+    if (!('wakeLock' in navigator)) return;
 
     navigator.wakeLock
       .request('screen')
       .then((sentinel) => {
-        if (released) {
+        if (cancelled) {
           sentinel.release();
           return;
         }
-        wakeLock.current = sentinel;
+        webSentinel.current = sentinel;
       })
       .catch(() => {
         // Wake Lock not available (e.g. low battery, background tab)
       });
 
     return () => {
-      released = true;
-      wakeLock.current?.release();
-      wakeLock.current = null;
+      cancelled = true;
+      webSentinel.current?.release();
+      webSentinel.current = null;
     };
   }, [active]);
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -55,6 +55,9 @@
     "exercises": "Exercises",
     "programs": "Programs"
   },
+  "offline": {
+    "banner": "Offline — some features are unavailable."
+  },
   "hook_errors": {
     "service_unavailable": "Service unavailable",
     "not_signed_in": "Not signed in",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -55,6 +55,9 @@
     "exercises": "Exercices",
     "programs": "Programmes"
   },
+  "offline": {
+    "banner": "Hors ligne — certaines fonctionnalités sont indisponibles."
+  },
   "hook_errors": {
     "service_unavailable": "Service indisponible",
     "not_signed_in": "Non connecté",


### PR DESCRIPTION
## Summary
PR #3 du plan de migration mobile. Adapte les features WebView qui ne marchent pas en natif et ajoute la détection offline.

- **useWakeLock natif** : utilise \`@capacitor-community/keep-awake\` (UIApplication.idleTimerDisabled iOS / FLAG_KEEP_SCREEN_ON Android) sur natif, fallback Web Wake Lock API en web. **Fix bug iOS WebView** où la Web Wake Lock API est non supportée → l'écran s'éteignait pendant les séances.
- **useNetworkStatus + OfflineBanner** : hook \`@capacitor/network\` en natif + \`navigator.onLine\` en web. Bandeau jaune sticky au top de PublicLayout (avec \`pt-safe\` pour respecter le notch iOS), affiché uniquement quand offline. Volontairement absent du PlayerLayout — perdre la connectivité pendant une séance n'est pas bloquant.
- **i18n** : 1 nouvelle clé \`common.offline.banner\` (FR + EN), 21 namespaces / 2197 clés alignées.
- **Doc** : \`mobile-dev.md\` documente le snippet Swift à appliquer après \`cap add ios\` pour désactiver le rubber-band bounce du WKWebView (Capacitor 8 n'expose pas d'option typée pour ça).

Volontairement pas dans cette PR (à reporter en PR ciblée si besoin) :
- Refacto scanner code-barres vers \`@capacitor-mlkit/barcode-scanning\` — \`BarcodeScanner.tsx\` actuel (~250 lignes ponyfill zxing) marche partout, le swap mérite sa propre PR avec recette QA dédiée.

## Test plan
- [x] \`npm run lint\` (291 fichiers, 0 issue après fix a11y \`role=status\` → \`<output>\`)
- [x] \`npx vitest run\` (410 tests verts)
- [x] \`npm run check:i18n\` (21 namespaces, 2197 clés alignées)
- [x] \`npm run build\` (153 routes prerenderées)
- [ ] Smoke test web : couper la connexion → bandeau apparaît (post-merge sur preview Vercel)
- [ ] Test natif : à valider quand \`cap add ios\` sera fait + Xcode installé (\`KeepAwake.keepAwake()\` actif pendant une séance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)