### PR TITLE
feat(mobile): paywall SSO via magic-link upgrade (Apple 3.1.3b)

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -112,6 +112,38 @@ npx cap update ios      # met à jour les pods CocoaPods
 npx cap update android  # met à jour les deps Gradle
 ```
 
+## Edge functions à déployer
+
+Les edge functions Supabase ne sont pas auto-déployées par CI. À chaque PR qui en touche une, déployer manuellement sur **dev** d'abord :
+
+```bash
+supabase functions deploy <name> --project-ref rgwwpkyuavhqdautpciu --no-verify-jwt
+```
+
+Fonctions à déployer dans le cadre de la migration mobile :
+- `create-web-upgrade-link` (PR #4) — génère un magic link Supabase pointant sur `/upgrade?priceId=…`. Env requis (Supabase dashboard → Edge Functions secrets) : `STRIPE_PRICE_MONTHLY`, `STRIPE_PRICE_YEARLY` (déjà présents puisque `create-checkout-session` les utilise déjà).
+
+Validation post-deploy :
+
+```bash
+curl -X POST 'https://<project-ref>.supabase.co/functions/v1/create-web-upgrade-link' \
+  -H 'Authorization: Bearer <user JWT>' \
+  -H 'Content-Type: application/json' \
+  -d '{"priceId":"price_xxx"}'
+```
+
+## Apple guideline 3.1.3(b) — Multiplatform Service
+
+Wan2Fit **ne peut pas** afficher de prix ni de bouton d'achat dans l'app native (iOS Apple ou Android Google Play). Le flow respecté est :
+
+1. Dans l'app, l'utilisateur tape sur un CTA "Voir les options premium" (sans prix).
+2. L'app appelle `useSubscription.checkout(priceId)` qui détecte natif et invoque `create-web-upgrade-link`.
+3. Le magic link est ouvert via `@capacitor/browser` (SafariViewController iOS / Chrome Custom Tab Android).
+4. La page `/upgrade?priceId=…` auto-déclenche `create-checkout-session` puis Stripe redirige sur sa page de paiement.
+5. Après succès, le user revient sur `https://wan2fit.fr/parametres?session=…` (le success_url Stripe sera transformé en Universal Link plus tard pour rebasculer dans l'app).
+
+**Règle interne stricte** : aucune chaîne `€/mois`, `9.99`, ou `Acheter` dans les composants montés en natif. Les pages `/tarifs` et `/premium` doivent rester accessibles uniquement via lien externe en natif (jamais via la nav primaire iOS/Android).
+
 ## Différences build web vs build natif
 
 | | `npm run build` (web) | `npm run build:native` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor-community/keep-awake": "^8.0.1",
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "^8.1.0",
+        "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.3.1",
         "@capacitor/ios": "^8.3.1",
         "@capacitor/keyboard": "^8.0.3",
@@ -1795,6 +1796,15 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
       "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@capacitor-community/keep-awake": "^8.0.1",
     "@capacitor/android": "^8.3.1",
     "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.3.1",
     "@capacitor/ios": "^8.3.1",
     "@capacitor/keyboard": "^8.0.3",

--- a/src/components/UpgradePage.tsx
+++ b/src/components/UpgradePage.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Navigate, useNavigate, useSearchParams } from 'react-router';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { useSubscription } from '../hooks/useSubscription.ts';
+import { LoadingFallback } from './LoadingFallback.tsx';
+
+// Landing page consumed by the native upgrade flow:
+//   1. Mobile app opens https://wan2fit.fr/upgrade?priceId=… via a one-shot
+//      magic link (the link auto-authenticates the user).
+//   2. This component checks the priceId, fires checkout(priceId), Stripe
+//      redirects the browser to the hosted checkout page.
+//   3. After Stripe success/cancel the user lands back on /tarifs (web).
+//
+// The page is also reachable from the web by an authenticated user — same
+// behaviour, just without the magic-link hop.
+export function UpgradePage() {
+  const { t } = useTranslation('common');
+  const { user, loading: authLoading } = useAuth();
+  const { checkout, isPremium } = useSubscription();
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [triggered, setTriggered] = useState(false);
+
+  const priceId = params.get('priceId');
+
+  useEffect(() => {
+    if (authLoading || triggered) return;
+    if (!user) {
+      // Magic link must have failed — punt to /login with returnTo.
+      const next = priceId ? `/upgrade?priceId=${encodeURIComponent(priceId)}` : '/upgrade';
+      navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
+      return;
+    }
+    if (!priceId) {
+      navigate('/tarifs', { replace: true });
+      return;
+    }
+    setTriggered(true);
+    void checkout(priceId).then((maybeError) => {
+      if (maybeError) setError(maybeError);
+    });
+  }, [authLoading, user, priceId, triggered, checkout, navigate]);
+
+  if (isPremium) return <Navigate to="/parametres" replace />;
+  if (error) {
+    return (
+      <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4 px-6 text-center">
+        <p className="text-strong">{error}</p>
+        <button
+          type="button"
+          onClick={() => navigate('/tarifs')}
+          className="px-4 py-2 rounded-lg bg-brand text-white text-sm font-medium"
+        >
+          {t('hook_errors.generic_retry')}
+        </button>
+      </div>
+    );
+  }
+
+  return <LoadingFallback />;
+}

--- a/src/components/UpgradePage.tsx
+++ b/src/components/UpgradePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useSubscription } from '../hooks/useSubscription.ts';
+import { isNative } from '../lib/capacitor.ts';
 import { LoadingFallback } from './LoadingFallback.tsx';
 
 // Landing page consumed by the native upgrade flow:
@@ -27,8 +28,15 @@ export function UpgradePage() {
 
   useEffect(() => {
     if (authLoading || triggered) return;
+    // Defense in depth: this page is the web target of a native magic
+    // link. If it ever renders inside the native shell (deep link bug,
+    // user shares the URL, etc.) we punt back to /tarifs to avoid a
+    // checkout → openWebUpgrade → magic link → … loop.
+    if (isNative()) {
+      navigate('/tarifs', { replace: true });
+      return;
+    }
     if (!user) {
-      // Magic link must have failed — punt to /login with returnTo.
       const next = priceId ? `/upgrade?priceId=${encodeURIComponent(priceId)}` : '/upgrade';
       navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
       return;
@@ -43,6 +51,7 @@ export function UpgradePage() {
     });
   }, [authLoading, user, priceId, triggered, checkout, navigate]);
 
+  // isPremium short-circuit lives below the hooks (rules of hooks).
   if (isPremium) return <Navigate to="/parametres" replace />;
   if (error) {
     return (

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,14 +1,24 @@
 import { type FormEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Navigate } from 'react-router';
+import { Link, Navigate, useSearchParams } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../../hooks/useDocumentHead.ts';
 import { BackLink } from './BackLink.tsx';
 import { FormInput } from './FormInput.tsx';
 
+// Whitelist for the ?next= post-login redirect to prevent open-redirect
+// abuse — only same-origin paths starting with '/' (and not '//') pass.
+function safeNextPath(raw: string | null): string {
+  if (!raw) return '/suivi';
+  if (!raw.startsWith('/') || raw.startsWith('//')) return '/suivi';
+  return raw;
+}
+
 export function LoginPage() {
   const { t } = useTranslation('auth');
   const { user, loading, signIn } = useAuth();
+  const [params] = useSearchParams();
+  const nextPath = safeNextPath(params.get('next'));
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -19,7 +29,7 @@ export function LoginPage() {
     description: t('login.page_description'),
   });
 
-  if (!loading && user) return <Navigate to="/suivi" replace />;
+  if (!loading && user) return <Navigate to={nextPath} replace />;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import i18n from '../i18n/index.ts';
@@ -16,6 +16,7 @@ const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' 
 
 export function useSubscription() {
   const { profile, user } = useAuth();
+  const queryClient = useQueryClient();
   const userId = user?.id;
 
   const tier = profile?.subscription_tier ?? 'free';
@@ -87,9 +88,16 @@ export function useSubscription() {
 
     if (data?.url) {
       // Native: SafariViewController / Chrome Custom Tab so the user stays
-      // inside the app shell and can dismiss with one tap.
+      // inside the app shell. We listen for the dismiss event and
+      // invalidate the subscription cache so the UI reflects whatever the
+      // user just did in the Stripe portal (cancel, switch plan, etc.).
       if (isNative()) {
         const { Browser } = await import('@capacitor/browser');
+        const finishedHandle = await Browser.addListener('browserFinished', () => {
+          void queryClient.invalidateQueries({ queryKey: ['subscription'] });
+          void queryClient.invalidateQueries({ queryKey: ['profile'] });
+          void finishedHandle.remove();
+        });
         await Browser.open({ url: data.url, presentationStyle: 'popover' });
         return null;
       }
@@ -97,7 +105,7 @@ export function useSubscription() {
       return null;
     }
     return data?.error || tHookError('portal_open_failed');
-  }, [user]);
+  }, [user, queryClient]);
 
   return {
     tier,

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import i18n from '../i18n/index.ts';
+import { isNative } from '../lib/capacitor.ts';
+import { openWebUpgrade } from '../lib/native-upgrade.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type { Subscription } from '../types/subscription.ts';
@@ -45,6 +47,13 @@ export function useSubscription() {
     async (priceId: string): Promise<string | null> => {
       if (!supabase || !user) return tHookError('not_signed_in');
 
+      // Native bypass: hand the user off to wan2fit.fr via a one-shot
+      // magic link so the Stripe checkout never runs inside the app
+      // WebView (Apple guideline 3.1.3(b) — no in-app price/purchase UI).
+      if (isNative()) {
+        return openWebUpgrade(priceId);
+      }
+
       const { data, error } = await supabase.functions.invoke('create-checkout-session', {
         body: { priceId },
       });
@@ -77,6 +86,13 @@ export function useSubscription() {
     }
 
     if (data?.url) {
+      // Native: SafariViewController / Chrome Custom Tab so the user stays
+      // inside the app shell and can dismiss with one tap.
+      if (isNative()) {
+        const { Browser } = await import('@capacitor/browser');
+        await Browser.open({ url: data.url, presentationStyle: 'popover' });
+        return null;
+      }
       window.location.href = data.url;
       return null;
     }

--- a/src/lib/native-upgrade.ts
+++ b/src/lib/native-upgrade.ts
@@ -1,0 +1,43 @@
+import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
+import { isNative } from './capacitor.ts';
+import { supabase } from './supabase.ts';
+
+// Native-side handoff for the Stripe checkout (Apple guideline 3.1.3(b)
+// Multiplatform Service: the app sends the user to wan2fit.fr to complete
+// the purchase, we never show a price or a buy button inside the app).
+//
+// Flow: invoke create-web-upgrade-link to get a single-use magic link
+// pointing to https://wan2fit.fr/upgrade?priceId=…, then open it with
+// @capacitor/browser. SafariViewController on iOS / Chrome Custom Tabs on
+// Android reuse the system cookies, so the user stays logged-in everywhere
+// the app trusts the same domain. The `presentationStyle: popover` keeps
+// the in-app feel — the user can dismiss with a single tap.
+export async function openWebUpgrade(priceId: string): Promise<string | null> {
+  if (!isNative()) {
+    return 'Native-only flow called from web — this should not happen';
+  }
+  if (!supabase) return 'Service indisponible';
+
+  const { data, error } = await supabase.functions.invoke('create-web-upgrade-link', {
+    body: { priceId },
+  });
+
+  if (error) {
+    return await extractEdgeFunctionError(
+      error as unknown as Record<string, unknown>,
+      "Échec de la génération du lien d'upgrade",
+    );
+  }
+
+  if (!data?.url) {
+    return data?.error || "Lien d'upgrade indisponible";
+  }
+
+  const { Browser } = await import('@capacitor/browser');
+  await Browser.open({
+    url: data.url,
+    presentationStyle: 'popover',
+    windowName: '_self',
+  });
+  return null;
+}

--- a/src/lib/native-upgrade.ts
+++ b/src/lib/native-upgrade.ts
@@ -34,10 +34,13 @@ export async function openWebUpgrade(priceId: string): Promise<string | null> {
   }
 
   const { Browser } = await import('@capacitor/browser');
+  // SafariViewController (iOS) / Chrome Custom Tab (Android) — programmatic
+  // open does NOT trigger Universal Links / App Links resolution, so the
+  // /upgrade* AASA pattern won't bounce the user back into the app and
+  // create a redirect loop.
   await Browser.open({
     url: data.url,
     presentationStyle: 'popover',
-    windowName: '_self',
   });
   return null;
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -20,6 +20,7 @@ const LazySignupPage = lazy(() => import('./components/auth/SignupPage.tsx').the
 const LazyAuthCallback = lazy(() =>
   import('./components/auth/AuthCallback.tsx').then((m) => ({ default: m.AuthCallback })),
 );
+const LazyUpgradePage = lazy(() => import('./components/UpgradePage.tsx').then((m) => ({ default: m.UpgradePage })));
 const LazyStatsPage = lazy(() => import('./components/auth/StatsPage.tsx').then((m) => ({ default: m.StatsPage })));
 const LazySettingsPage = lazy(() =>
   import('./components/auth/SettingsPage.tsx').then((m) => ({ default: m.SettingsPage })),
@@ -287,6 +288,14 @@ export const router = createBrowserRouter([
         element: (
           <Lazy>
             <LazyAuthCallback />
+          </Lazy>
+        ),
+      },
+      {
+        path: 'upgrade',
+        element: (
+          <Lazy>
+            <LazyUpgradePage />
           </Lazy>
         ),
       },

--- a/supabase/functions/create-web-upgrade-link/index.ts
+++ b/supabase/functions/create-web-upgrade-link/index.ts
@@ -1,0 +1,104 @@
+// Generate a one-shot magic link that lands the user on /upgrade?priceId=...
+// already authenticated. Used by the native iOS/Android app to bounce a
+// user out of an in-app paywall and into the web checkout (Apple guideline
+// 3.1.3(b) Multiplatform Service: an account-based service can let the
+// user upgrade outside the app, as long as no in-app purchase or pricing
+// is shown). The mobile app calls this endpoint, opens the returned URL
+// inside SafariViewController / Chrome Custom Tabs, and the user comes
+// back after the Stripe round-trip.
+//
+// Body: { priceId: 'price_xxx' }
+// Response: { url: 'https://wan2fit.fr/auth/v1/verify?...' }
+//
+// Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY
+// Required env (allow-list): STRIPE_PRICE_MONTHLY, STRIPE_PRICE_YEARLY
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { getCorsHeaders, resolveAllowedOrigin } from '../_shared/cors.ts';
+
+function jsonResponse(req: Request, data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(req: Request, message: string, status = 400) {
+  return jsonResponse(req, { error: message }, status);
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: getCorsHeaders(req) });
+  }
+
+  if (req.method !== 'POST') {
+    return errorResponse(req, 'Method not allowed', 405);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return errorResponse(req, 'Missing authorization', 401);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseServiceKey || !supabaseAnonKey) {
+    return errorResponse(req, 'Server misconfigured', 500);
+  }
+
+  const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+
+  if (authError || !user || !user.email) {
+    return errorResponse(req, 'Non autorisé', 401);
+  }
+
+  let body: { priceId?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(req, 'JSON invalide');
+  }
+
+  if (!body.priceId || typeof body.priceId !== 'string') {
+    return errorResponse(req, 'priceId requis');
+  }
+
+  // Validate priceId against the same allow-list as create-checkout-session
+  // so a malicious caller cannot redirect the user toward an unknown SKU.
+  const allowedPrices = [
+    Deno.env.get('STRIPE_PRICE_MONTHLY'),
+    Deno.env.get('STRIPE_PRICE_YEARLY'),
+  ].filter(Boolean);
+  if (allowedPrices.length === 0 || !allowedPrices.includes(body.priceId)) {
+    return errorResponse(req, 'Price non reconnu', 400);
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+  const targetOrigin = resolveAllowedOrigin(req);
+  const redirectTo = `${targetOrigin}/upgrade?priceId=${encodeURIComponent(body.priceId)}`;
+
+  // generateLink with type 'magiclink' returns an action_link the user can
+  // click to be auto-authenticated. The link is single-use and short-lived
+  // (default 1h) — perfect for this hand-off.
+  const { data, error } = await supabaseAdmin.auth.admin.generateLink({
+    type: 'magiclink',
+    email: user.email,
+    options: { redirectTo },
+  });
+
+  if (error || !data?.properties?.action_link) {
+    console.error('generateLink failed:', error);
+    return errorResponse(req, 'Magic link generation failed', 500);
+  }
+
+  return jsonResponse(req, { url: data.properties.action_link });
+});


### PR DESCRIPTION
## Summary
PR #4 du plan de migration mobile. Implémente le **modèle Spotify** : aucun prix ni bouton d'achat dans l'app native (Apple guideline 3.1.3(b) Multiplatform Service), upgrade via web.

**Flow natif** :
1. App appelle \`useSubscription.checkout(priceId)\`
2. Détection \`isNative()\` → \`openWebUpgrade()\` invoque \`create-web-upgrade-link\` (Supabase edge fn)
3. L'edge function génère un magic link Supabase \`auth.admin.generateLink\` redirect \`/upgrade?priceId=…\`
4. \`@capacitor/browser\` ouvre le link en SafariViewController (iOS) / Chrome Custom Tab (Android)
5. La page \`/upgrade\` consomme le magic link → auto-trigger le checkout existant → Stripe paiement
6. Stripe success → \`success_url\` Stripe (transformé en Universal Link plus tard)

**Flow web inchangé** : même \`checkout()\` → \`create-checkout-session\` → \`window.location.href\` Stripe.

- \`supabase/functions/create-web-upgrade-link\` : auth JWT, validation priceId allow-list (\`STRIPE_PRICE_MONTHLY\`/\`YEARLY\`), \`generateLink\`. Pas de nouveau secret nécessaire.
- \`src/lib/native-upgrade.ts\` : \`openWebUpgrade(priceId)\` helper (native-only).
- \`useSubscription.checkout/manageSubscription\` : routent via \`@capacitor/browser\` en natif.
- Route \`/upgrade\` : auto-checkout au mount.

## Deploy steps
- [ ] Déployer edge function en **dev** : \`supabase functions deploy create-web-upgrade-link --project-ref rgwwpkyuavhqdautpciu --no-verify-jwt\`
- [ ] Vérifier que \`STRIPE_PRICE_MONTHLY\`/\`STRIPE_PRICE_YEARLY\` sont dans Supabase Edge Functions secrets (dev) — déjà présents pour create-checkout-session.
- [ ] Smoke test : preview Vercel \`/upgrade?priceId=…\` après login → redirect Stripe checkout.
- [ ] Pas de deploy prod tant que le flow natif n'est pas validé E2E (post Xcode install).

## Test plan
- [x] \`npm run lint\` (293 fichiers)
- [x] \`npx vitest run\` (410 tests)
- [x] \`npm run check:i18n\`
- [x] \`npm run build\` (153 routes)
- [ ] Preview Vercel : \`/upgrade?priceId=<monthly>\` → redirect Stripe (post-merge)
- [ ] Tests natif via simulateur (post \`cap add ios\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)