### PR TITLE
feat(mobile): in-app account deletion (Apple 5.1.1.v)

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -122,6 +122,7 @@ supabase functions deploy <name> --project-ref rgwwpkyuavhqdautpciu --no-verify-
 
 Fonctions à déployer dans le cadre de la migration mobile :
 - `create-web-upgrade-link` (PR #4) — génère un magic link Supabase pointant sur `/upgrade?priceId=…`. Env requis (Supabase dashboard → Edge Functions secrets) : `STRIPE_PRICE_MONTHLY`, `STRIPE_PRICE_YEARLY` (déjà présents puisque `create-checkout-session` les utilise déjà).
+- `delete-account` (PR #5) — annule la subscription Stripe active puis appelle `auth.admin.deleteUser`. Env requis : `STRIPE_SECRET_KEY` (déjà présent). Apple guideline 5.1.1(v) : la suppression in-app est **obligatoire** pour les apps qui permettent la création de compte — sans cette feature, soumission App Store auto-rejetée.
 
 Validation post-deploy :
 

--- a/src/components/auth/DeleteAccountDialog.tsx
+++ b/src/components/auth/DeleteAccountDialog.tsx
@@ -1,0 +1,127 @@
+import { AlertTriangle, X } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDeleteAccount } from '../../hooks/useDeleteAccount.ts';
+
+const CONFIRMATION_WORD = 'SUPPRIMER';
+
+interface DeleteAccountDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Modal that gates account deletion behind a typed confirmation word so
+// the user cannot wipe their account by tapping a button twice in a row.
+// Backed by useDeleteAccount which calls the delete-account edge function.
+export function DeleteAccountDialog({ open, onClose }: DeleteAccountDialogProps) {
+  const { t } = useTranslation('settings');
+  const { deleteAccount, pending } = useDeleteAccount();
+  const [confirmation, setConfirmation] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setConfirmation('');
+      setError(null);
+      return;
+    }
+    inputRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  const canSubmit = confirmation === CONFIRMATION_WORD && !pending;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setError(null);
+    const err = await deleteAccount();
+    if (err) {
+      setError(err);
+      return;
+    }
+    onClose();
+    // signOut already cleared local state; redirect to home.
+    window.location.href = '/';
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8 bg-black/70 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`${inputId}-title`}
+    >
+      <div className="w-full max-w-md rounded-2xl bg-surface-card border border-card-border shadow-xl p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <span className="w-10 h-10 rounded-full bg-red-500/15 flex items-center justify-center shrink-0">
+              <AlertTriangle className="w-5 h-5 text-red-400" aria-hidden="true" />
+            </span>
+            <h2 id={`${inputId}-title`} className="text-lg font-bold text-heading">
+              {t('danger_zone.confirm_title')}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={pending}
+            aria-label={t('danger_zone.cancel')}
+            className="p-1 -m-1 text-muted hover:text-heading transition-colors"
+          >
+            <X className="w-5 h-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <p className="text-sm text-body">{t('danger_zone.confirm_body')}</p>
+        <ul className="text-xs text-muted list-disc pl-5 space-y-1">
+          <li>{t('danger_zone.bullet_data')}</li>
+          <li>{t('danger_zone.bullet_subscription')}</li>
+          <li>{t('danger_zone.bullet_irreversible')}</li>
+        </ul>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <label htmlFor={inputId} className="block text-xs font-medium text-strong">
+            {t('danger_zone.confirm_label', { word: CONFIRMATION_WORD })}
+          </label>
+          <input
+            id={inputId}
+            ref={inputRef}
+            type="text"
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            disabled={pending}
+            autoComplete="off"
+            autoCapitalize="characters"
+            spellCheck={false}
+            placeholder={CONFIRMATION_WORD}
+            className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-heading placeholder:text-muted focus:border-red-400 focus:outline-none transition-colors"
+          />
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={pending}
+              className="flex-1 py-2.5 rounded-xl border border-divider text-sm font-semibold text-body hover:bg-surface transition-colors disabled:opacity-50"
+            >
+              {t('danger_zone.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="flex-1 py-2.5 rounded-xl bg-red-500 text-white text-sm font-semibold hover:bg-red-500/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {pending ? t('danger_zone.deleting') : t('danger_zone.confirm_action')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/DeleteAccountDialog.tsx
+++ b/src/components/auth/DeleteAccountDialog.tsx
@@ -3,8 +3,6 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeleteAccount } from '../../hooks/useDeleteAccount.ts';
 
-const CONFIRMATION_WORD = 'SUPPRIMER';
-
 interface DeleteAccountDialogProps {
   open: boolean;
   onClose: () => void;
@@ -15,6 +13,7 @@ interface DeleteAccountDialogProps {
 // Backed by useDeleteAccount which calls the delete-account edge function.
 export function DeleteAccountDialog({ open, onClose }: DeleteAccountDialogProps) {
   const { t } = useTranslation('settings');
+  const confirmationWord = t('danger_zone.confirmation_word');
   const { deleteAccount, pending } = useDeleteAccount();
   const [confirmation, setConfirmation] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -32,7 +31,7 @@ export function DeleteAccountDialog({ open, onClose }: DeleteAccountDialogProps)
 
   if (!open) return null;
 
-  const canSubmit = confirmation === CONFIRMATION_WORD && !pending;
+  const canSubmit = confirmation === confirmationWord && !pending;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,9 +42,10 @@ export function DeleteAccountDialog({ open, onClose }: DeleteAccountDialogProps)
       setError(err);
       return;
     }
+    // RequireAuth will now bounce the user to /login because signOut() in
+    // useDeleteAccount has already cleared the auth state. Just close the
+    // dialog and let the router do its job — no manual window.location.
     onClose();
-    // signOut already cleared local state; redirect to home.
-    window.location.href = '/';
   };
 
   return (
@@ -85,19 +85,22 @@ export function DeleteAccountDialog({ open, onClose }: DeleteAccountDialogProps)
 
         <form onSubmit={handleSubmit} className="space-y-3">
           <label htmlFor={inputId} className="block text-xs font-medium text-strong">
-            {t('danger_zone.confirm_label', { word: CONFIRMATION_WORD })}
+            {t('danger_zone.confirm_label', { word: confirmationWord })}
           </label>
           <input
             id={inputId}
             ref={inputRef}
             type="text"
             value={confirmation}
-            onChange={(e) => setConfirmation(e.target.value)}
+            // .toUpperCase() makes the comparison robust regardless of the
+            // user's keyboard auto-capitalize setting (some third-party iOS
+            // keyboards ignore the HTML hint).
+            onChange={(e) => setConfirmation(e.target.value.toUpperCase())}
             disabled={pending}
             autoComplete="off"
             autoCapitalize="characters"
             spellCheck={false}
-            placeholder={CONFIRMATION_WORD}
+            placeholder={confirmationWord}
             className="w-full px-4 py-3 rounded-xl bg-surface border border-divider text-heading placeholder:text-muted focus:border-red-400 focus:outline-none transition-colors"
           />
 

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { Camera, Crown, Monitor, Moon, Sparkles, Sun } from 'lucide-react';
+import { Camera, Crown, Monitor, Moon, Sparkles, Sun, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router';
@@ -11,6 +11,7 @@ import { supabase } from '../../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../../lib/supabaseQuery.ts';
 import { formatDate } from '../../utils/date.ts';
 import { getInitials } from '../../utils/getInitials.ts';
+import { DeleteAccountDialog } from './DeleteAccountDialog.tsx';
 
 const MAX_AVATAR_SIZE = 2 * 1024 * 1024; // 2 Mo
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -27,6 +28,7 @@ export function SettingsPage() {
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
   const [portalError, setPortalError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   useDocumentHead({
     title: t('page_title'),
@@ -281,7 +283,22 @@ export function SettingsPage() {
         >
           {t('sign_out')}
         </button>
+
+        {/* Danger zone — Apple guideline 5.1.1(v) requires in-app account deletion. */}
+        <section className="space-y-3 pt-4 border-t border-divider">
+          <h2 className="text-sm font-bold uppercase tracking-wider text-red-400">{t('danger_zone.heading')}</h2>
+          <p className="text-xs text-muted">{t('danger_zone.description')}</p>
+          <button
+            type="button"
+            onClick={() => setDeleteOpen(true)}
+            className="flex items-center justify-center gap-2 w-full py-3 rounded-xl bg-red-500/10 text-red-400 font-semibold border border-red-500/30 hover:bg-red-500/20 transition-colors cursor-pointer"
+          >
+            <Trash2 className="w-4 h-4" aria-hidden="true" />
+            {t('danger_zone.delete_button')}
+          </button>
+        </section>
       </div>
+      <DeleteAccountDialog open={deleteOpen} onClose={() => setDeleteOpen(false)} />
     </div>
   );
 }

--- a/src/hooks/useDeleteAccount.ts
+++ b/src/hooks/useDeleteAccount.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import i18n from '../i18n/index.ts';
+import { supabase } from '../lib/supabase.ts';
+import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
+
+const tHookError = (key: string) => i18n.t(`hook_errors.${key}`, { ns: 'common' });
+
+// Permanent account deletion. Calls the delete-account edge function which
+// cancels any active Stripe subscription, then auth.admin.deleteUser. After
+// success we sign the user out locally so the UI flips back to the public
+// surface — the auth row is already gone server-side.
+export function useDeleteAccount() {
+  const { signOut } = useAuth();
+  const [pending, setPending] = useState(false);
+
+  const deleteAccount = useCallback(async (): Promise<string | null> => {
+    if (!supabase) return tHookError('service_unavailable');
+    setPending(true);
+    try {
+      const { data, error } = await supabase.functions.invoke('delete-account');
+      if (error) {
+        return await extractEdgeFunctionError(error as unknown as Record<string, unknown>, tHookError('generic_retry'));
+      }
+      if (!data?.ok) {
+        return data?.error || tHookError('generic_retry');
+      }
+      await signOut();
+      return null;
+    } finally {
+      setPending(false);
+    }
+  }, [signOut]);
+
+  return { deleteAccount, pending };
+}

--- a/src/hooks/useDeleteAccount.ts
+++ b/src/hooks/useDeleteAccount.ts
@@ -18,12 +18,12 @@ export function useDeleteAccount() {
     if (!supabase) return tHookError('service_unavailable');
     setPending(true);
     try {
-      const { data, error } = await supabase.functions.invoke('delete-account');
+      const { error } = await supabase.functions.invoke('delete-account');
       if (error) {
+        // supabase.functions.invoke surfaces non-2xx HTTP responses through
+        // `error` (FunctionsHttpError), not `data` — so checking `data.ok`
+        // here would be dead code.
         return await extractEdgeFunctionError(error as unknown as Record<string, unknown>, tHookError('generic_retry'));
-      }
-      if (!data?.ok) {
-        return data?.error || tHookError('generic_retry');
       }
       await signOut();
       return null;

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -40,6 +40,7 @@
     "bullet_data": "Your profile, sessions, and programs will be erased.",
     "bullet_subscription": "Your Premium subscription will be cancelled on Stripe.",
     "bullet_irreversible": "There is no way to recover the data afterwards.",
+    "confirmation_word": "DELETE",
     "confirm_label": "Type {{word}} to confirm",
     "confirm_action": "Delete permanently",
     "deleting": "Deleting…",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -31,6 +31,20 @@
     "cgv_link": "General Terms of Sale"
   },
   "sign_out": "Log out",
+  "danger_zone": {
+    "heading": "Danger zone",
+    "description": "Deleting your account permanently removes your profile, history, and personal data. This cannot be undone.",
+    "delete_button": "Delete my account",
+    "confirm_title": "Delete your account?",
+    "confirm_body": "This action is immediate and irreversible. Type the word below to confirm.",
+    "bullet_data": "Your profile, sessions, and programs will be erased.",
+    "bullet_subscription": "Your Premium subscription will be cancelled on Stripe.",
+    "bullet_irreversible": "There is no way to recover the data afterwards.",
+    "confirm_label": "Type {{word}} to confirm",
+    "confirm_action": "Delete permanently",
+    "deleting": "Deleting…",
+    "cancel": "Cancel"
+  },
   "cgu_modal": {
     "title": "Terms update",
     "body": "Our Terms of Service and Privacy Policy have been updated (version {{version}}). Access to the app is suspended until you accept them.",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -31,6 +31,20 @@
     "cgv_link": "Conditions Générales de Vente"
   },
   "sign_out": "Se déconnecter",
+  "danger_zone": {
+    "heading": "Zone dangereuse",
+    "description": "La suppression efface définitivement ton compte, ton historique et tes données personnelles. Aucun retour en arrière possible.",
+    "delete_button": "Supprimer mon compte",
+    "confirm_title": "Supprimer ton compte ?",
+    "confirm_body": "Cette action est immédiate et définitive. Pour la confirmer, saisis le mot ci-dessous.",
+    "bullet_data": "Ton profil, tes séances et tes programmes seront effacés.",
+    "bullet_subscription": "Ton abonnement Premium sera annulé chez Stripe.",
+    "bullet_irreversible": "Aucun retour en arrière possible.",
+    "confirm_label": "Tape {{word}} pour confirmer",
+    "confirm_action": "Supprimer définitivement",
+    "deleting": "Suppression…",
+    "cancel": "Annuler"
+  },
   "cgu_modal": {
     "title": "Mise à jour des conditions",
     "body": "Nos Conditions Générales d'Utilisation et notre Politique de Confidentialité ont été mises à jour (version {{version}}). L'accès à l'app est suspendu le temps que tu les acceptes.",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -40,6 +40,7 @@
     "bullet_data": "Ton profil, tes séances et tes programmes seront effacés.",
     "bullet_subscription": "Ton abonnement Premium sera annulé chez Stripe.",
     "bullet_irreversible": "Aucun retour en arrière possible.",
+    "confirmation_word": "SUPPRIMER",
     "confirm_label": "Tape {{word}} pour confirmer",
     "confirm_action": "Supprimer définitivement",
     "deleting": "Suppression…",

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,108 @@
+// Permanent account deletion. Required for App Store compliance — Apple
+// guideline 5.1.1(v) demands an in-app option to delete the account, not
+// just deactivate. The function:
+//   1. Verifies the caller's JWT.
+//   2. If a Stripe subscription is active, cancels it immediately so we
+//      stop billing the user we are about to remove. Skipped if no active
+//      sub or if the sub is already canceled.
+//   3. Deletes the auth user via auth.admin.deleteUser. Every domain table
+//      (profiles, subscriptions, sessions, programs, custom sessions,
+//      nutrition, recipes, …) cascades on auth.users.id, so a single
+//      delete unwinds the whole graph.
+//
+// Body: none. Response: { ok: true } or { error: string }.
+// Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY,
+// STRIPE_SECRET_KEY (only used when a subscription needs to be canceled).
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/cors.ts';
+
+function jsonResponse(req: Request, data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(req: Request, message: string, status = 400) {
+  return jsonResponse(req, { error: message }, status);
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: getCorsHeaders(req) });
+  }
+
+  if (req.method !== 'POST') {
+    return errorResponse(req, 'Method not allowed', 405);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return errorResponse(req, 'Missing authorization', 401);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseServiceKey || !supabaseAnonKey) {
+    return errorResponse(req, 'Server misconfigured', 500);
+  }
+
+  const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+
+  if (authError || !user) {
+    return errorResponse(req, 'Non autorisé', 401);
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Cancel the user's active Stripe subscription before we lose the
+  // mapping. We only cancel if the local row is active/trialing/past_due —
+  // canceled or incomplete subs are no-ops.
+  const { data: activeSub } = await supabaseAdmin
+    .from('subscriptions')
+    .select('stripe_subscription_id, status')
+    .eq('user_id', user.id)
+    .in('status', ['active', 'trialing', 'past_due'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (activeSub?.stripe_subscription_id) {
+    const stripeSecretKey = Deno.env.get('STRIPE_SECRET_KEY');
+    if (!stripeSecretKey) {
+      return errorResponse(req, 'STRIPE_SECRET_KEY not configured', 500);
+    }
+    const stripeRes = await fetch(
+      `https://api.stripe.com/v1/subscriptions/${activeSub.stripe_subscription_id}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${stripeSecretKey}` },
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    // We tolerate 404 (already deleted on Stripe side) but bail on real
+    // errors — better to keep the account and let the user retry than to
+    // delete the auth row while billing keeps running.
+    if (!stripeRes.ok && stripeRes.status !== 404) {
+      console.error('Stripe cancel failed:', stripeRes.status, await stripeRes.text());
+      return errorResponse(req, 'Échec annulation Stripe — réessayez', 500);
+    }
+  }
+
+  const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(user.id);
+  if (deleteError) {
+    console.error('auth.admin.deleteUser failed:', deleteError);
+    return errorResponse(req, 'Suppression du compte échouée', 500);
+  }
+
+  return jsonResponse(req, { ok: true });
+});


### PR DESCRIPTION
## Summary
PR #5 du plan de migration mobile. **Bloqueur App Store** : Apple guideline 5.1.1(v) impose qu'une app permettant la création de compte permette aussi sa suppression in-app — sans cette feature, soumission auto-rejetée.

- **Edge function** \`delete-account\` :
  - Auth JWT
  - Cancel \`active|trialing|past_due\` Stripe subscription via API (\`DELETE /v1/subscriptions/<id>\`), tolère 404, fail-closed sur autre erreur
  - \`auth.admin.deleteUser\` — toutes les tables ont \`ON DELETE CASCADE\` sur \`auth.users.id\` (audit migrations 001/002/003/004/005/014/015/016/020/023), donc un seul delete nettoie tout
- **Hook** \`useDeleteAccount\` : invoke + signOut local
- **Composant** \`DeleteAccountDialog\` : modal avec confirmation typée (\"SUPPRIMER\"), \`aria-modal\` + \`role=dialog\`, auto-focus input, désactive submit pendant pending
- **SettingsPage** : section \"Zone dangereuse\" en bas, sous Sign out
- **i18n** : 14 clés FR+EN sous \`settings.danger_zone\` (21 namespaces, 2209 clés alignées)

## Deploy steps
- [ ] Déployer edge function en **dev** : \`supabase functions deploy delete-account --project-ref rgwwpkyuavhqdautpciu --no-verify-jwt\`
- [ ] Vérifier que \`STRIPE_SECRET_KEY\` est présent dans Edge Functions secrets (déjà là pour les autres edge fn).
- [ ] Smoke test sur dev : créer un compte test, abonner via Stripe test mode, supprimer → vérifier subscription canceled chez Stripe + user gone de auth.users + profiles vide.
- [ ] Pas de deploy prod tant que QA dev validée.

## Test plan
- [x] \`npm run lint\` (295 fichiers)
- [x] \`npx vitest run\` (410 tests)
- [x] \`npm run check:i18n\` (2209 keys)
- [x] \`npm run build\` (153 routes)
- [ ] Smoke test web preview Vercel : flow complet suppression
- [ ] Smoke test Stripe test mode : subscription canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)