### PR TITLE
feat(mobile): native push notifications with opt-in categories

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -123,6 +123,23 @@ supabase functions deploy <name> --project-ref rgwwpkyuavhqdautpciu --no-verify-
 Fonctions à déployer dans le cadre de la migration mobile :
 - `create-web-upgrade-link` (PR #4) — génère un magic link Supabase pointant sur `/upgrade?priceId=…`. Env requis (Supabase dashboard → Edge Functions secrets) : `STRIPE_PRICE_MONTHLY`, `STRIPE_PRICE_YEARLY` (déjà présents puisque `create-checkout-session` les utilise déjà).
 - `delete-account` (PR #5) — annule la subscription Stripe active puis appelle `auth.admin.deleteUser`. Env requis : `STRIPE_SECRET_KEY` (déjà présent). Apple guideline 5.1.1(v) : la suppression in-app est **obligatoire** pour les apps qui permettent la création de compte — sans cette feature, soumission App Store auto-rejetée.
+- `register-push-device` (PR #6) — upsert (user, token, platform) dans `user_devices`. Aucun secret nouveau. Appelé par `usePushNotifications` à chaque launch après acceptation de la permission.
+- `send-push` (PR #6) — envoie une notification FCM HTTP v1 à toutes les devices d'un user. Server-to-server uniquement (header `x-internal-secret` requis). Env nouveaux à provisionner :
+  - `INTERNAL_PUSH_SECRET` — chaîne aléatoire 32+ char (ex : `openssl rand -hex 32`)
+  - `FCM_SERVICE_ACCOUNT_JSON` — JSON brut du Firebase Admin SDK service account (Console Firebase → Project settings → Service accounts → Generate new private key). Doit contenir `client_email`, `private_key`, `project_id`.
+
+## Push notifications philosophy
+
+Wan2Fit interdit les notifications coercitives. Catégories acceptées :
+- `info` — Information transactionnelle (default ON, attendu par les users)
+- `progression` — Célébration d'un palier atteint (default OFF, opt-in)
+- `new_content` — Nouvelle recette / nouveau programme (default OFF, opt-in)
+
+**Catégories proscrites** (à ne JAMAIS introduire) : daily reminder, streak, missed-day prompt, "tu n'as pas fait de séance depuis X jours". Ces patterns poussent au surentraînement et créent du shame, ce qui contredit la philosophie produit (cf. `MEMORY.md`).
+
+Côté natif (post `cap add ios` + `cap add android`) :
+- iOS : capability **Push Notifications** + APNs key (.p8) liée au Bundle ID dans le Firebase project (Cloud Messaging → Apple app configuration). Capability dans Xcode : Signing & Capabilities → +Capability → Push Notifications + Background Modes → Remote notifications.
+- Android : pas de modif manifest (le plugin Capacitor s'en charge), mais le `google-services.json` doit être placé dans `android/app/`.
 
 Validation post-deploy :
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/network": "^8.0.1",
         "@capacitor/preferences": "^8.0.1",
+        "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@sentry/react": "^10.45.0",
@@ -1921,6 +1922,15 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-8.0.1.tgz",
       "integrity": "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/push-notifications": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-8.0.3.tgz",
+      "integrity": "sha512-jmBBoJvOzmzem8YoO9dQJBPFiM1bksTNAoV7yksCBN10BybAOtmBF19vFPt/jr2KGAirnPZz0ne2X0OH/rRGtg==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/network": "^8.0.1",
     "@capacitor/preferences": "^8.0.1",
+    "@capacitor/push-notifications": "^8.0.3",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@sentry/react": "^10.45.0",

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation } from 'react-router';
+import { usePushNotifications } from '../hooks/usePushNotifications.ts';
 import { BottomNav } from './BottomNav.tsx';
 import { BrandHeader } from './BrandHeader.tsx';
 import { Footer } from './Footer.tsx';
@@ -11,6 +12,8 @@ import { SessionExpiredBanner } from './SessionExpiredBanner.tsx';
 export function PublicLayout() {
   const { t } = useTranslation('common');
   const { pathname } = useLocation();
+  // Native-only push registration. No-op on web (hook short-circuits).
+  usePushNotifications();
 
   // Scroll top on route change. Data freshness is no longer tied to
   // navigation — every hook is on TanStack Query and relies on its

--- a/src/components/auth/NotificationsSection.tsx
+++ b/src/components/auth/NotificationsSection.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { useNotificationPreferences } from '../../hooks/useNotificationPreferences.ts';
+
+interface ToggleRowProps {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+}
+
+function ToggleRow({ id, label, description, checked, disabled, onChange }: ToggleRowProps) {
+  return (
+    <label htmlFor={id} className="flex items-start gap-3 py-2.5 cursor-pointer">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-strong">{label}</p>
+        <p className="text-xs text-muted">{description}</p>
+      </div>
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-1 w-5 h-5 rounded accent-brand cursor-pointer disabled:opacity-50"
+      />
+    </label>
+  );
+}
+
+// Notification preferences UI in SettingsPage. The wan2fit philosophy is
+// reflected in the categories on offer: info (transactional), progression
+// (celebrative), new_content (announcements). No daily reminder, no streak,
+// no missed-day prompt — those would push users toward overtraining and
+// shame, which the product explicitly refuses.
+export function NotificationsSection() {
+  const { t } = useTranslation('settings');
+  const { preferences, setPreference, isPending } = useNotificationPreferences();
+
+  return (
+    <section className="space-y-1">
+      <h2 className="text-sm font-bold uppercase tracking-wider text-subtle mb-2">{t('notifications.heading')}</h2>
+      <p className="text-xs text-muted mb-2">{t('notifications.description')}</p>
+      <div className="rounded-xl border border-divider bg-surface-card divide-y divide-divider/60 px-4">
+        <ToggleRow
+          id="notif-info"
+          label={t('notifications.info_label')}
+          description={t('notifications.info_description')}
+          checked={preferences.info}
+          disabled={isPending}
+          onChange={(next) => setPreference('info', next)}
+        />
+        <ToggleRow
+          id="notif-progression"
+          label={t('notifications.progression_label')}
+          description={t('notifications.progression_description')}
+          checked={preferences.progression}
+          disabled={isPending}
+          onChange={(next) => setPreference('progression', next)}
+        />
+        <ToggleRow
+          id="notif-new-content"
+          label={t('notifications.new_content_label')}
+          description={t('notifications.new_content_description')}
+          checked={preferences.new_content}
+          disabled={isPending}
+          onChange={(next) => setPreference('new_content', next)}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { notifySessionExpired, supabaseQuery } from '../../lib/supabaseQuery.ts'
 import { formatDate } from '../../utils/date.ts';
 import { getInitials } from '../../utils/getInitials.ts';
 import { DeleteAccountDialog } from './DeleteAccountDialog.tsx';
+import { NotificationsSection } from './NotificationsSection.tsx';
 
 const MAX_AVATAR_SIZE = 2 * 1024 * 1024; // 2 Mo
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -258,6 +259,9 @@ export function SettingsPage() {
             </div>
           )}
         </section>
+
+        {/* Notifications */}
+        <NotificationsSection />
 
         {/* Legal */}
         <section className="space-y-3">

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { supabase } from '../lib/supabase.ts';
+import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
+
+export interface NotificationPreferences {
+  info: boolean;
+  progression: boolean;
+  new_content: boolean;
+}
+
+const DEFAULTS: NotificationPreferences = {
+  info: true,
+  progression: false,
+  new_content: false,
+};
+
+// Read + update opt-in flags. The migration trigger seeds a row at signup
+// so we always have defaults to read; the upsert is defensive in case the
+// row is ever missing.
+export function useNotificationPreferences() {
+  const { user } = useAuth();
+  const userId = user?.id;
+  const queryClient = useQueryClient();
+
+  const query = useQuery<NotificationPreferences>({
+    queryKey: ['notification-preferences', userId ?? null],
+    queryFn: async () => {
+      if (!supabase || !userId) return DEFAULTS;
+      const { data, sessionExpired } = await supabaseQuery(() =>
+        supabase!
+          .from('notification_preferences')
+          .select('info, progression, new_content')
+          .eq('user_id', userId)
+          .maybeSingle(),
+      );
+      if (sessionExpired) {
+        notifySessionExpired();
+        return DEFAULTS;
+      }
+      return (data as NotificationPreferences | null) ?? DEFAULTS;
+    },
+    enabled: !!userId && !!supabase,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (patch: Partial<NotificationPreferences>) => {
+      if (!supabase || !userId) throw new Error('Not signed in');
+      const next = { ...DEFAULTS, ...query.data, ...patch };
+      const { error } = await supabase
+        .from('notification_preferences')
+        .upsert({ user_id: userId, ...next, updated_at: new Date().toISOString() });
+      if (error) throw error;
+      return next;
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(['notification-preferences', userId ?? null], next);
+    },
+  });
+
+  return {
+    preferences: query.data ?? DEFAULTS,
+    loading: query.isPending,
+    setPreference: (key: keyof NotificationPreferences, value: boolean) => mutation.mutateAsync({ [key]: value }),
+    isPending: mutation.isPending,
+  };
+}

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -43,11 +43,12 @@ export function usePushNotifications() {
         // we already pushed during this session.
         if (registeredToken.current === token.value) return;
         registeredToken.current = token.value;
+        // Migration 025 enforces platform IN ('ios','android','web') —
+        // fall back to 'web' (instead of 'unknown') so a Capacitor build
+        // running on an unrecognised host doesn't fail the CHECK.
+        const platform = isIOS() ? 'ios' : isAndroid() ? 'android' : 'web';
         const { error } = await supabase!.functions.invoke('register-push-device', {
-          body: {
-            token: token.value,
-            platform: isIOS() ? 'ios' : isAndroid() ? 'android' : 'unknown',
-          },
+          body: { token: token.value, platform },
         });
         if (error) console.warn('register-push-device failed', error);
       });

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { isAndroid, isIOS, isNative } from '../lib/capacitor.ts';
+import { supabase } from '../lib/supabase.ts';
+
+// Bootstrap the FCM device registration on native launch:
+//   1. Ask the OS for notification permission (no-op if already decided).
+//   2. Subscribe to the registration event so we receive the FCM token.
+//   3. POST that token to register-push-device so the server-side fan-out
+//      (send-push edge function) can target this device.
+//
+// Re-runs on every user change. We intentionally do NOT prompt for
+// permission until the user is signed in — Apple flags pre-auth prompts
+// as friction during App Review.
+//
+// Web is a no-op: Capacitor.isNativePlatform() returns false and the hook
+// short-circuits before any plugin import.
+export function usePushNotifications() {
+  const { user } = useAuth();
+  const userId = user?.id;
+  const registeredToken = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isNative() || !userId || !supabase) return;
+
+    let cancelled = false;
+    const removers: Array<() => void> = [];
+
+    const setup = async () => {
+      const { PushNotifications } = await import('@capacitor/push-notifications');
+
+      const permission = await PushNotifications.checkPermissions();
+      if (permission.receive === 'prompt' || permission.receive === 'prompt-with-rationale') {
+        const result = await PushNotifications.requestPermissions();
+        if (cancelled || result.receive !== 'granted') return;
+      } else if (permission.receive !== 'granted') {
+        return;
+      }
+
+      const regHandle = await PushNotifications.addListener('registration', async (token) => {
+        if (cancelled) return;
+        // Avoid an extra round-trip if the OS hands us back the same token
+        // we already pushed during this session.
+        if (registeredToken.current === token.value) return;
+        registeredToken.current = token.value;
+        const { error } = await supabase!.functions.invoke('register-push-device', {
+          body: {
+            token: token.value,
+            platform: isIOS() ? 'ios' : isAndroid() ? 'android' : 'unknown',
+          },
+        });
+        if (error) console.warn('register-push-device failed', error);
+      });
+      removers.push(() => regHandle.remove());
+
+      const errHandle = await PushNotifications.addListener('registrationError', (err) => {
+        console.warn('PushNotifications registrationError', err);
+      });
+      removers.push(() => errHandle.remove());
+
+      await PushNotifications.register();
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      for (const fn of removers) fn();
+    };
+  }, [userId]);
+}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -31,6 +31,16 @@
     "cgv_link": "General Terms of Sale"
   },
   "sign_out": "Log out",
+  "notifications": {
+    "heading": "Notifications",
+    "description": "Stay informed about what matters — never a daily reminder.",
+    "info_label": "Important information",
+    "info_description": "Program updates, account events, security alerts.",
+    "progression_label": "Milestones reached",
+    "progression_description": "A short note when you complete a step (program week, history milestone). Off by default.",
+    "new_content_label": "New content",
+    "new_content_description": "Newly added recipes or programs. Off by default."
+  },
   "danger_zone": {
     "heading": "Danger zone",
     "description": "Deleting your account permanently removes your profile, history, and personal data. This cannot be undone.",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -31,6 +31,16 @@
     "cgv_link": "Conditions Générales de Vente"
   },
   "sign_out": "Se déconnecter",
+  "notifications": {
+    "heading": "Notifications",
+    "description": "Reçois ce qui te concerne, jamais de rappel quotidien.",
+    "info_label": "Informations importantes",
+    "info_description": "Mises à jour de ton programme, événements de compte, alertes de sécurité.",
+    "progression_label": "Étapes franchies",
+    "progression_description": "Un message court quand tu boucles une étape (semaine de programme, palier d'historique). Désactivé par défaut.",
+    "new_content_label": "Nouveaux contenus",
+    "new_content_description": "Nouvelles recettes ou nouveaux programmes ajoutés. Désactivé par défaut."
+  },
   "danger_zone": {
     "heading": "Zone dangereuse",
     "description": "La suppression efface définitivement ton compte, ton historique et tes données personnelles. Aucun retour en arrière possible.",

--- a/supabase/functions/register-push-device/index.ts
+++ b/supabase/functions/register-push-device/index.ts
@@ -1,0 +1,95 @@
+// Register or refresh a Firebase Cloud Messaging device token for the
+// authenticated user. Called by usePushNotifications on every app launch
+// after the user accepts the permission prompt — the token rotates over
+// time so we always upsert.
+//
+// Body: { token: string, platform: 'ios' | 'android', device_label?: string }
+// Response: { ok: true }
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/cors.ts';
+
+function jsonResponse(req: Request, data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(req: Request, message: string, status = 400) {
+  return jsonResponse(req, { error: message }, status);
+}
+
+const ALLOWED_PLATFORMS = new Set(['ios', 'android']);
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: getCorsHeaders(req) });
+  }
+  if (req.method !== 'POST') {
+    return errorResponse(req, 'Method not allowed', 405);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return errorResponse(req, 'Missing authorization', 401);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseServiceKey || !supabaseAnonKey) {
+    return errorResponse(req, 'Server misconfigured', 500);
+  }
+
+  const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+  if (authError || !user) {
+    return errorResponse(req, 'Non autorisé', 401);
+  }
+
+  let body: { token?: unknown; platform?: unknown; device_label?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(req, 'JSON invalide');
+  }
+
+  const token = typeof body.token === 'string' ? body.token.trim() : '';
+  const platform = typeof body.platform === 'string' ? body.platform : '';
+  const deviceLabel = typeof body.device_label === 'string' ? body.device_label.slice(0, 80) : null;
+
+  if (!token || token.length > 4096) {
+    return errorResponse(req, 'token requis');
+  }
+  if (!ALLOWED_PLATFORMS.has(platform)) {
+    return errorResponse(req, 'platform invalide');
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+  const { error: upsertError } = await supabaseAdmin
+    .from('user_devices')
+    .upsert(
+      {
+        user_id: user.id,
+        token,
+        platform,
+        device_label: deviceLabel,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: 'token' },
+    );
+
+  if (upsertError) {
+    console.error('register-push-device upsert failed:', upsertError);
+    return errorResponse(req, 'Enregistrement impossible', 500);
+  }
+
+  return jsonResponse(req, { ok: true });
+});

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -178,13 +178,17 @@ Deno.serve(async (req: Request) => {
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   // Honor the user's category opt-in. info defaults to true on signup;
-  // progression and new_content default to false.
+  // progression and new_content default to false. We select the three
+  // columns explicitly (instead of injecting body.category into the
+  // select) so the query shape stays static even if a future caller
+  // bypasses the ALLOWED_CATEGORIES check above.
   const { data: prefs } = await supabase
     .from('notification_preferences')
-    .select(body.category)
+    .select('info, progression, new_content')
     .eq('user_id', body.user_id)
-    .maybeSingle();
-  if (!prefs || prefs[body.category as keyof typeof prefs] !== true) {
+    .maybeSingle<{ info: boolean; progression: boolean; new_content: boolean }>();
+  const category = body.category as (typeof ALLOWED_CATEGORIES)[number];
+  if (!prefs || prefs[category] !== true) {
     return new Response(JSON.stringify({ sent: 0, removed: 0, skipped: 'opt-out' }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -223,15 +227,26 @@ Deno.serve(async (req: Request) => {
     });
   }
 
+  // Fan out in parallel — same body to every device for the user.
+  const results = await Promise.allSettled(
+    devices.map((device) =>
+      sendFcmMessage(accessToken, serviceAccount.project_id, {
+        token: device.token,
+        title: body.title!,
+        body: body.body!,
+        data: body.data,
+      }).then((res) => ({ device, ...res })),
+    ),
+  );
+
   let sent = 0;
   const idsToRemove: string[] = [];
-  for (const device of devices) {
-    const { status, bodyText } = await sendFcmMessage(accessToken, serviceAccount.project_id, {
-      token: device.token,
-      title: body.title,
-      body: body.body,
-      data: body.data,
-    });
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('FCM send rejected:', result.reason);
+      continue;
+    }
+    const { device, status, bodyText } = result.value;
     if (status >= 200 && status < 300) {
       sent += 1;
     } else if (status === 404 || status === 400) {

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -1,0 +1,255 @@
+// Send a push notification to all devices of a single user via Firebase
+// Cloud Messaging HTTP v1. Server-to-server only — guarded by an
+// INTERNAL_PUSH_SECRET header so we don't accept requests from authenticated
+// users (call sites: triggers DB, cron edge functions, internal admin
+// scripts).
+//
+// Body: {
+//   user_id: string,
+//   title: string,
+//   body: string,
+//   category: 'info' | 'progression' | 'new_content',
+//   data?: Record<string, string>
+// }
+// Response: { sent: number, removed: number }
+//
+// Required env:
+//   - SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+//   - INTERNAL_PUSH_SECRET (shared secret for internal callers)
+//   - FCM_SERVICE_ACCOUNT_JSON (Firebase Admin SDK service account JSON,
+//     stringified — used to build a Google OAuth access token)
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  project_id: string;
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const cleaned = pem
+    .replace('-----BEGIN PRIVATE KEY-----', '')
+    .replace('-----END PRIVATE KEY-----', '')
+    .replace(/\s+/g, '');
+  const binary = atob(cleaned);
+  const buf = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) buf[i] = binary.charCodeAt(i);
+  return buf.buffer;
+}
+
+function base64UrlEncode(input: ArrayBuffer | Uint8Array | string): string {
+  let bytes: Uint8Array;
+  if (typeof input === 'string') {
+    bytes = new TextEncoder().encode(input);
+  } else if (input instanceof Uint8Array) {
+    bytes = input;
+  } else {
+    bytes = new Uint8Array(input);
+  }
+  let str = '';
+  for (let i = 0; i < bytes.length; i += 1) str += String.fromCharCode(bytes[i]);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function getFcmAccessToken(serviceAccount: ServiceAccount): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const claims = {
+    iss: serviceAccount.client_email,
+    scope: 'https://www.googleapis.com/auth/firebase.messaging',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600,
+  };
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const headerB64 = base64UrlEncode(JSON.stringify(header));
+  const claimsB64 = base64UrlEncode(JSON.stringify(claims));
+  const unsigned = `${headerB64}.${claimsB64}`;
+
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToArrayBuffer(serviceAccount.private_key),
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, new TextEncoder().encode(unsigned));
+  const jwt = `${unsigned}.${base64UrlEncode(signature)}`;
+
+  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!tokenRes.ok) {
+    throw new Error(`OAuth token exchange failed: ${tokenRes.status} ${await tokenRes.text()}`);
+  }
+  const tokenJson = await tokenRes.json();
+  return tokenJson.access_token as string;
+}
+
+async function sendFcmMessage(
+  accessToken: string,
+  projectId: string,
+  payload: {
+    token: string;
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+  },
+): Promise<{ status: number; bodyText: string }> {
+  const message = {
+    message: {
+      token: payload.token,
+      notification: { title: payload.title, body: payload.body },
+      data: payload.data,
+    },
+  };
+  const res = await fetch(`https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10_000),
+  });
+  return { status: res.status, bodyText: await res.text() };
+}
+
+const ALLOWED_CATEGORIES = ['info', 'progression', 'new_content'] as const;
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const internalSecret = Deno.env.get('INTERNAL_PUSH_SECRET');
+  if (!internalSecret) {
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (req.headers.get('x-internal-secret') !== internalSecret) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const body = (await req.json().catch(() => null)) as {
+    user_id?: string;
+    title?: string;
+    body?: string;
+    category?: string;
+    data?: Record<string, string>;
+  } | null;
+  if (!body?.user_id || !body.title || !body.body || !body.category) {
+    return new Response(JSON.stringify({ error: 'Missing fields' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  if (!ALLOWED_CATEGORIES.includes(body.category as (typeof ALLOWED_CATEGORIES)[number])) {
+    return new Response(JSON.stringify({ error: 'Invalid category' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const fcmJson = Deno.env.get('FCM_SERVICE_ACCOUNT_JSON');
+  if (!supabaseUrl || !supabaseServiceKey || !fcmJson) {
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Honor the user's category opt-in. info defaults to true on signup;
+  // progression and new_content default to false.
+  const { data: prefs } = await supabase
+    .from('notification_preferences')
+    .select(body.category)
+    .eq('user_id', body.user_id)
+    .maybeSingle();
+  if (!prefs || prefs[body.category as keyof typeof prefs] !== true) {
+    return new Response(JSON.stringify({ sent: 0, removed: 0, skipped: 'opt-out' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { data: devices } = await supabase
+    .from('user_devices')
+    .select('id, token')
+    .eq('user_id', body.user_id);
+  if (!devices || devices.length === 0) {
+    return new Response(JSON.stringify({ sent: 0, removed: 0 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let serviceAccount: ServiceAccount;
+  try {
+    serviceAccount = JSON.parse(fcmJson) as ServiceAccount;
+  } catch {
+    return new Response(JSON.stringify({ error: 'FCM_SERVICE_ACCOUNT_JSON invalid' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let accessToken: string;
+  try {
+    accessToken = await getFcmAccessToken(serviceAccount);
+  } catch (err) {
+    console.error('FCM OAuth failed:', err);
+    return new Response(JSON.stringify({ error: 'FCM auth failed' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let sent = 0;
+  const idsToRemove: string[] = [];
+  for (const device of devices) {
+    const { status, bodyText } = await sendFcmMessage(accessToken, serviceAccount.project_id, {
+      token: device.token,
+      title: body.title,
+      body: body.body,
+      data: body.data,
+    });
+    if (status >= 200 && status < 300) {
+      sent += 1;
+    } else if (status === 404 || status === 400) {
+      // 404 = token unregistered, 400 = invalid token format. Both
+      // permanent — drop the device row so the next send doesn't retry.
+      idsToRemove.push(device.id);
+      console.warn('FCM removing token:', status, bodyText);
+    } else {
+      console.error('FCM send failed:', status, bodyText);
+    }
+  }
+
+  if (idsToRemove.length > 0) {
+    await supabase.from('user_devices').delete().in('id', idsToRemove);
+  }
+
+  return new Response(JSON.stringify({ sent, removed: idsToRemove.length }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/migrations/025_push_notifications.sql
+++ b/supabase/migrations/025_push_notifications.sql
@@ -1,0 +1,88 @@
+-- 025_push_notifications.sql
+-- Push notification infrastructure for native iOS/Android.
+-- Two tables: per-device tokens and per-user category preferences.
+-- Wan2Fit philosophy: notifications inform, never guilt. We deliberately
+-- do NOT include a "daily reminder" or "streak" category — those would
+-- conflict with the rest-day-friendly product principle.
+
+-- ─── user_devices: FCM tokens with platform metadata ───
+CREATE TABLE IF NOT EXISTS user_devices (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token        TEXT NOT NULL,
+  platform     TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+  device_label TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_devices_user_id ON user_devices(user_id);
+
+ALTER TABLE user_devices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own devices"
+  ON user_devices FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own devices"
+  ON user_devices FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- INSERT and UPDATE go through the register-push-device edge function so
+-- we never expose the raw token to client-side joins. Service role bypasses
+-- RLS so no policy is needed for edge fn writes.
+
+-- ─── notification_preferences: per-user opt-in flags ───
+-- Each column is a boolean opt-in for a notification CATEGORY. New
+-- categories should be added with a clear non-coercive intent. Forbidden
+-- categories (do not add): daily_reminder, streak, missed_day.
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  user_id              UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- Information that requires the user's attention (program updates,
+  -- account events, security alerts). Default ON because users expect it.
+  info                 BOOLEAN NOT NULL DEFAULT true,
+  -- Progression milestones the user opted into (e.g. "1st program week
+  -- completed"). Celebrative, never reminders. Default OFF — opt-in only.
+  progression          BOOLEAN NOT NULL DEFAULT false,
+  -- New content drops (recipes, programs). Default OFF.
+  new_content          BOOLEAN NOT NULL DEFAULT false,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own preferences"
+  ON notification_preferences FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can upsert own preferences"
+  ON notification_preferences FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own preferences"
+  ON notification_preferences FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Auto-create default row for new users via trigger so the UI can always
+-- read a row without an additional INSERT round-trip.
+CREATE OR REPLACE FUNCTION ensure_notification_preferences()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO notification_preferences (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS create_notification_preferences ON auth.users;
+CREATE TRIGGER create_notification_preferences
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION ensure_notification_preferences();

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -58,3 +58,24 @@ Sentry.replayIntegration({
 Alternative plus fine si `maskAllInputs: true` est trop strict pour le debug :
 - Garder le comportement par défaut
 - Ajouter `className="sentry-mask"` sur tous les inputs qui collectent de la donnée personnelle : formulaire nutrition, étapes onboarding programme, formulaire signup
+
+
+## Push notifications — rate limiting + OAuth cache (PR #6)
+
+**Priorité** : avant scale (>100 users actifs)
+**Statut** : MVP acceptable
+
+### Problème 1 — pas de rate limit sur send-push
+`supabase/functions/send-push` est gardé par un `x-internal-secret` header. Si le secret leak (dev shares, log accidentel), un attaquant peut spam tous les users sans limite. À ajouter avant prod publique :
+- compteur Redis ou table `push_log` (timestamp, user_id, category)
+- quota dur (ex: 10 sends/user/heure)
+
+### Problème 2 — pas de cache du token Google OAuth
+`getFcmAccessToken` génère un JWT RS256 + appel `oauth2.googleapis.com/token` à chaque invocation de `send-push`. Le token est valide 1h. Cache module-level avec expiry check ferait ça en O(1) pour les 99% suivants des appels.
+
+### Fix proposé
+1. Variable module-level `let cachedAccessToken: { value: string; expiresAt: number } | null` dans send-push/index.ts
+2. `if (cached && Date.now() < cached.expiresAt - 60_000) return cached.value`
+3. Sinon refetch et stocker
+
+


### PR DESCRIPTION
PR #6 of the iOS/Android migration. Adds the FCM plumbing without crossing the Wan2Fit guardrail: no daily reminder, no streak, no missed-day prompt - categories: info, progression opt-in, new_content opt-in. Migration 025 + register-push-device + send-push (FCM HTTP v1) + usePushNotifications hook + NotificationsSection toggles. Validated: lint 298, vitest 410, check:i18n 2218, build 153 routes.