### PR TITLE
fix(header): mobile truncation — shorter login label + safe-area padding

### DIFF
--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -63,7 +63,7 @@ export function BrandHeader() {
   const isTrackingActive = pathname === '/suivi' || pathname === '/decouvrir/suivi';
 
   return (
-    <header className="px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
+    <header className="pl-safe pr-safe px-4 sm:px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
       <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
         <Link to="/" className="flex items-center gap-2.5 shrink-0">
           <img src="/logo-wan2fit.png" alt="" className="w-7 h-7 md:w-8 md:h-8 shrink-0" />

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -75,7 +75,7 @@
     "back_to_login": "Back to log in"
   },
   "auth_button": {
-    "login_signup": "Log in / Sign up",
+    "login_signup": "Log in",
     "settings_aria": "Settings"
   },
   "errors": {

--- a/src/i18n/locales/fr/auth.json
+++ b/src/i18n/locales/fr/auth.json
@@ -75,7 +75,7 @@
     "back_to_login": "Retour à la connexion"
   },
   "auth_button": {
-    "login_signup": "Se connecter / S'inscrire",
+    "login_signup": "Connexion",
     "settings_aria": "Paramètres"
   },
   "errors": {


### PR DESCRIPTION
## Summary
Fix le tronquage horizontal du header sur iPhone Simulator ("S'inscri" coupé). 3 changements :
1. `auth_button.login_signup` raccourci : "Se connecter / S'inscrire" → "Connexion" (FR), "Log in / Sign up" → "Log in" (EN). La page /login a déjà un lien "Créer un compte" → l'affordance n'est pas perdue.
2. Header padding : `px-6 → px-4 sm:px-6 md:px-10 lg:px-14` (gain 16pt sur viewports <640pt).
3. `pl-safe pr-safe` ajoutés pour les iPhones landscape avec Dynamic Island.

**Validé natif** : rebuild iOS Simulator → header lisible `Wan2Fit | FR EN | Connexion` sans troncation.

## Test plan
- [x] `npm run lint`, `vitest run` (410), `check:i18n` (2218), `build` (153 routes)
- [x] iOS Simulator rebuild + screenshot OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)