### PR TITLE
feat(health): pure-TS foundation for HealthKit + Health Connect

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -155,6 +155,17 @@ Fonctions à déployer dans le cadre de la migration mobile :
 - `create-web-upgrade-link` (PR #4) — génère un magic link Supabase pointant sur `/upgrade?priceId=…`. Env requis (Supabase dashboard → Edge Functions secrets) : `STRIPE_PRICE_MONTHLY`, `STRIPE_PRICE_YEARLY` (déjà présents puisque `create-checkout-session` les utilise déjà).
 - `delete-account` (PR #5) — annule la subscription Stripe active puis appelle `auth.admin.deleteUser`. Env requis : `STRIPE_SECRET_KEY` (déjà présent). Apple guideline 5.1.1(v) : la suppression in-app est **obligatoire** pour les apps qui permettent la création de compte — sans cette feature, soumission App Store auto-rejetée.
 - `register-push-device` (PR #6) — upsert (user, token, platform) dans `user_devices`. Aucun secret nouveau. Appelé par `usePushNotifications` à chaque launch après acceptation de la permission.
+
+## Health intégration (HealthKit + Health Connect)
+
+Foundation TS pure dans `src/lib/calorie-estimator.ts` et `src/lib/health-types.ts` — testable avant tout setup natif (cf. `calorie-estimator.test.ts`).
+
+À faire post `cap add` + Apple Dev validé :
+1. Installer plugins natifs : `npm install @perfood/capacitor-healthkit @kiwi-health/capacitor-health-connect`
+2. iOS : ajouter capability **HealthKit** dans Xcode (Signing & Capabilities). Ajouter `NSHealthShareUsageDescription` + `NSHealthUpdateUsageDescription` dans Info.plist (textes user-facing en FR/EN).
+3. Android : ajouter dans `AndroidManifest.xml` la permission `android.permission.health.READ_EXERCISE` + `WRITE_EXERCISE` + `READ_ACTIVE_CALORIES_BURNED` + le `<queries>` pour Health Connect.
+4. Créer `src/lib/health-bridge.ts` qui exporte `writeWorkout(summary: WorkoutSummary)` — utilise `formatToHKActivityType` (iOS) ou `formatToHealthConnectType` (Android).
+5. Câbler `writeWorkout` dans `EndScreen` (séance terminée) avec opt-in user (toggle settings + permission OS).
 - `send-push` (PR #6) — envoie une notification FCM HTTP v1 à toutes les devices d'un user. Server-to-server uniquement (header `x-internal-secret` requis). Env nouveaux à provisionner :
   - `INTERNAL_PUSH_SECRET` — chaîne aléatoire 32+ char (ex : `openssl rand -hex 32`)
   - `FCM_SERVICE_ACCOUNT_JSON` — JSON brut du Firebase Admin SDK service account (Console Firebase → Project settings → Service accounts → Generate new private key). Doit contenir `client_email`, `private_key`, `project_id`.

--- a/src/lib/calorie-estimator.test.ts
+++ b/src/lib/calorie-estimator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { estimateKcal } from './calorie-estimator.ts';
+import {
+  formatToHealthConnectType,
+  formatToHKActivityType,
+  HealthConnectExerciseType,
+  HKWorkoutActivityType,
+} from './health-types.ts';
+
+describe('estimateKcal', () => {
+  it('returns 0 for non-positive durations', () => {
+    expect(estimateKcal({ formatSlug: 'hiit', durationSeconds: 0 })).toBe(0);
+    expect(estimateKcal({ formatSlug: 'hiit', durationSeconds: -10 })).toBe(0);
+  });
+
+  it('uses the default 70 kg weight when none provided', () => {
+    // 30 min HIIT @ 9 MET, 70 kg → 9 × 70 × 0.5 = 315 kcal
+    expect(estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60 })).toBe(315);
+  });
+
+  it('scales linearly with weight', () => {
+    const base = estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60, weightKg: 70 });
+    const heavy = estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60, weightKg: 90 });
+    // 9 × 90 × 0.5 = 405 kcal
+    expect(heavy).toBe(405);
+    expect(heavy).toBeGreaterThan(base);
+  });
+
+  it('orders intensities correctly: tabata > hiit > amrap > circuit > emom > superset > strength', () => {
+    const opts = { durationSeconds: 30 * 60, weightKg: 70 } as const;
+    const tabata = estimateKcal({ ...opts, formatSlug: 'tabata' });
+    const hiit = estimateKcal({ ...opts, formatSlug: 'hiit' });
+    const amrap = estimateKcal({ ...opts, formatSlug: 'amrap' });
+    const circuit = estimateKcal({ ...opts, formatSlug: 'circuit' });
+    const emom = estimateKcal({ ...opts, formatSlug: 'emom' });
+    const superset = estimateKcal({ ...opts, formatSlug: 'superset' });
+    const renforcement = estimateKcal({ ...opts, formatSlug: 'renforcement' });
+
+    expect(tabata).toBeGreaterThan(hiit);
+    expect(hiit).toBeGreaterThan(amrap);
+    expect(amrap).toBeGreaterThan(circuit);
+    expect(circuit).toBeGreaterThan(emom);
+    expect(emom).toBeGreaterThan(superset);
+    expect(superset).toBeGreaterThan(renforcement);
+  });
+
+  it('treats a weight of 0 or negative as unknown (uses default)', () => {
+    const fallback = estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60 });
+    expect(estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60, weightKg: 0 })).toBe(fallback);
+    expect(estimateKcal({ formatSlug: 'hiit', durationSeconds: 30 * 60, weightKg: -5 })).toBe(fallback);
+  });
+
+  it('rounds to the nearest integer', () => {
+    const result = estimateKcal({ formatSlug: 'pyramide', durationSeconds: 12 * 60, weightKg: 68 });
+    // 5 × 68 × (720/3600) = 68 → integer already
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+describe('formatToHKActivityType', () => {
+  it('maps strength formats to HealthKit traditional/functional strength', () => {
+    expect(formatToHKActivityType('pyramide')).toBe(HKWorkoutActivityType.TraditionalStrengthTraining);
+    expect(formatToHKActivityType('renforcement')).toBe(HKWorkoutActivityType.TraditionalStrengthTraining);
+    expect(formatToHKActivityType('superset')).toBe(HKWorkoutActivityType.FunctionalStrengthTraining);
+  });
+
+  it('maps interval formats to HIIT', () => {
+    for (const slug of ['emom', 'circuit', 'amrap', 'hiit', 'tabata'] as const) {
+      expect(formatToHKActivityType(slug)).toBe(HKWorkoutActivityType.HighIntensityIntervalTraining);
+    }
+  });
+});
+
+describe('formatToHealthConnectType', () => {
+  it('maps strength formats to STRENGTH_TRAINING', () => {
+    expect(formatToHealthConnectType('pyramide')).toBe(HealthConnectExerciseType.StrengthTraining);
+    expect(formatToHealthConnectType('renforcement')).toBe(HealthConnectExerciseType.StrengthTraining);
+    expect(formatToHealthConnectType('superset')).toBe(HealthConnectExerciseType.StrengthTraining);
+  });
+
+  it('maps circuit to CircuitTraining and the rest to HIIT', () => {
+    expect(formatToHealthConnectType('circuit')).toBe(HealthConnectExerciseType.CircuitTraining);
+    for (const slug of ['emom', 'amrap', 'hiit', 'tabata'] as const) {
+      expect(formatToHealthConnectType(slug)).toBe(HealthConnectExerciseType.HighIntensityIntervalTraining);
+    }
+  });
+});

--- a/src/lib/calorie-estimator.ts
+++ b/src/lib/calorie-estimator.ts
@@ -1,0 +1,47 @@
+import type { FormatSlug } from './health-types.ts';
+
+// Energy expenditure for each Wan2Fit format, in MET (metabolic
+// equivalents). Values are taken from the Compendium of Physical
+// Activities (Ainsworth et al., 2024 update) and rounded to the nearest
+// half-MET — the literature's spread is wide enough that finer
+// precision would be false confidence.
+const FORMAT_MET: Record<FormatSlug, number> = {
+  pyramide: 5.0, // Resistance training, free weights, vigorous
+  renforcement: 5.0, // Strength training, general
+  superset: 6.0, // Strength training with reduced rest
+  emom: 7.0, // Every-minute-on-the-minute, structured intervals
+  circuit: 7.5, // Circuit training, vigorous effort
+  amrap: 8.0, // As-many-rounds-as-possible
+  hiit: 9.0, // Generic HIIT
+  tabata: 9.5, // Tabata protocol (highest sustained intensity)
+};
+
+const DEFAULT_WEIGHT_KG = 70;
+
+export interface CalorieInput {
+  formatSlug: FormatSlug;
+  durationSeconds: number;
+  /**
+   * User weight in kg. When unknown we assume 70 kg — the apparent
+   * precision of the formula is illusory either way (METs already
+   * carry ±20% spread), so an estimate from a default weight is fine
+   * for a "this session burned around X kcal" badge.
+   */
+  weightKg?: number;
+}
+
+/**
+ * Returns an integer kcal estimate for one workout block.
+ *
+ * Formula: kcal = MET × weight_kg × duration_hours
+ *
+ * Rounded to the nearest integer. Returns 0 for non-positive durations
+ * so the estimator never inflates an interrupted session.
+ */
+export function estimateKcal({ formatSlug, durationSeconds, weightKg }: CalorieInput): number {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return 0;
+  const met = FORMAT_MET[formatSlug];
+  const weight = weightKg && weightKg > 0 ? weightKg : DEFAULT_WEIGHT_KG;
+  const hours = durationSeconds / 3600;
+  return Math.round(met * weight * hours);
+}

--- a/src/lib/health-types.ts
+++ b/src/lib/health-types.ts
@@ -1,0 +1,70 @@
+// Bridge types between Wan2Fit's session vocabulary and the platform
+// health stores (HealthKit on iOS, Health Connect on Android). The
+// platform plugins are wired in a follow-up PR; for now this module is
+// pure typescript so we can unit-test the mapping in isolation.
+
+export type FormatSlug = 'pyramide' | 'renforcement' | 'superset' | 'emom' | 'circuit' | 'amrap' | 'hiit' | 'tabata';
+
+// HKWorkoutActivityType raw values from Apple's HealthKit framework.
+// We only enumerate the ones we map to — keeping the constants here
+// instead of pulling in @perfood/capacitor-healthkit's enum lets the
+// pure-TS module import without a Capacitor runtime.
+export const HKWorkoutActivityType = {
+  TraditionalStrengthTraining: 50,
+  FunctionalStrengthTraining: 20,
+  HighIntensityIntervalTraining: 79,
+  CrossTraining: 39,
+} as const;
+export type HKWorkoutActivityTypeId = (typeof HKWorkoutActivityType)[keyof typeof HKWorkoutActivityType];
+
+// Health Connect ExerciseType (Android) — same idea, only the values
+// we use, lifted from androidx.health.connect.client.records.ExerciseSessionRecord.
+// Stable since the Health Connect 1.0 GA.
+export const HealthConnectExerciseType = {
+  StrengthTraining: 54,
+  HighIntensityIntervalTraining: 38,
+  Calisthenics: 17,
+  CircuitTraining: 13,
+} as const;
+export type HealthConnectExerciseTypeId = (typeof HealthConnectExerciseType)[keyof typeof HealthConnectExerciseType];
+
+// Format → HealthKit / Health Connect.
+// Pyramid + strength + superset stay on the strength bucket (resistance,
+// rest periods). EMOM/circuit/AMRAP/HIIT/Tabata all map to HIIT — the
+// pacing is similar from the OS's metric standpoint (HR pattern, MET).
+const FORMAT_TO_HK_ACTIVITY: Record<FormatSlug, HKWorkoutActivityTypeId> = {
+  pyramide: HKWorkoutActivityType.TraditionalStrengthTraining,
+  renforcement: HKWorkoutActivityType.TraditionalStrengthTraining,
+  superset: HKWorkoutActivityType.FunctionalStrengthTraining,
+  emom: HKWorkoutActivityType.HighIntensityIntervalTraining,
+  circuit: HKWorkoutActivityType.HighIntensityIntervalTraining,
+  amrap: HKWorkoutActivityType.HighIntensityIntervalTraining,
+  hiit: HKWorkoutActivityType.HighIntensityIntervalTraining,
+  tabata: HKWorkoutActivityType.HighIntensityIntervalTraining,
+};
+
+const FORMAT_TO_HEALTH_CONNECT: Record<FormatSlug, HealthConnectExerciseTypeId> = {
+  pyramide: HealthConnectExerciseType.StrengthTraining,
+  renforcement: HealthConnectExerciseType.StrengthTraining,
+  superset: HealthConnectExerciseType.StrengthTraining,
+  emom: HealthConnectExerciseType.HighIntensityIntervalTraining,
+  circuit: HealthConnectExerciseType.CircuitTraining,
+  amrap: HealthConnectExerciseType.HighIntensityIntervalTraining,
+  hiit: HealthConnectExerciseType.HighIntensityIntervalTraining,
+  tabata: HealthConnectExerciseType.HighIntensityIntervalTraining,
+};
+
+export function formatToHKActivityType(slug: FormatSlug): HKWorkoutActivityTypeId {
+  return FORMAT_TO_HK_ACTIVITY[slug];
+}
+
+export function formatToHealthConnectType(slug: FormatSlug): HealthConnectExerciseTypeId {
+  return FORMAT_TO_HEALTH_CONNECT[slug];
+}
+
+export interface WorkoutSummary {
+  formatSlug: FormatSlug;
+  startedAt: Date;
+  durationSeconds: number;
+  estimatedKcal: number;
+}


### PR DESCRIPTION
## Summary
Pose la fondation TS pure de la PR Health intégration : calorie estimator + format → HKWorkoutActivityType / Health Connect ExerciseType. Le bridge natif (plugins iOS/Android) viendra en PR follow-up post Apple Dev validé.

- `src/lib/calorie-estimator.ts` : `estimateKcal({ formatSlug, durationSeconds, weightKg })` MET-based (Compendium of Physical Activities). Default 70 kg si poids inconnu.
- `src/lib/health-types.ts` : FormatSlug union, HKWorkoutActivityType + HealthConnectExerciseType raw constants (pas de dep plugin runtime), mappers, WorkoutSummary shape.
- `src/lib/calorie-estimator.test.ts` : 10 tests (edge cases, intensity ordering, weight scaling, mapping tables).
- Doc `mobile-dev.md` : post cap-add checklist (plugins, HealthKit capability, manifest permissions, EndScreen integration).

## Test plan
- [x] `npm run lint` (301 fichiers)
- [x] `npx vitest run` (420 tests, +10 nouveaux)
- [x] `npm run check:i18n` (2218 clés)
- [x] `npm run build` (153 routes)
- [ ] Bridge natif via plugins — PR follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)