### PR TITLE
feat(mobile): iOS Privacy Manifest (App Store requirement)

### DIFF
--- a/claudedocs/mobile-dev.md
+++ b/claudedocs/mobile-dev.md
@@ -51,6 +51,20 @@ cd ios/App && xcodebuild -project App.xcodeproj -scheme App \
 cd android && ./gradlew assembleDebug
 ```
 
+## Privacy Manifest (App Store requirement)
+
+`ios/App/App/PrivacyInfo.xcprivacy` déclare ce qu'on collecte (email, user content, crash data, performance) et les Required Reasons API qu'on touche (UserDefaults via `@capacitor/preferences`, FileTimestamp via WKWebView, DiskSpace via Sentry, SystemBootTime via Sentry).
+
+Référencé dans `App.xcodeproj` via `scripts/add-ios-resource.mjs`. Quand on touche au manifest, refaire **build iOS** pour vérifier que le fichier est bien dans `App.app/PrivacyInfo.xcprivacy` :
+
+```bash
+cd ios/App
+xcodebuild ... build
+ls -la ./build/Build/Products/Debug-iphonesimulator/App.app/PrivacyInfo.xcprivacy
+```
+
+Si on ajoute un nouveau plugin natif qui touche une nouvelle Required Reasons API (cf. la liste Apple : https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api), ajouter une entrée dans `NSPrivacyAccessedAPITypes`. Soumission App Store rejetée sinon.
+
 ## Régénérer les icônes / splash
 
 Quand le logo brand évolue (`public/icon-512.png`), régénérer toute la chaîne via :

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		C335A845914249E88864ED3E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3DA0431417444A9F97D4DC69 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		3DA0431417444A9F97D4DC69 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +72,7 @@
 				504EC3131FED79650016851F /* Info.plist */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
+				3DA0431417444A9F97D4DC69 /* PrivacyInfo.xcprivacy */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -145,6 +148,7 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+				C335A845914249E88864ED3E /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/PrivacyInfo.xcprivacy
+++ b/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Privacy Manifest declared per Apple's spec
+	     https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+	     Required for App Store submissions since spring 2024. -->
+
+	<!-- We do not use IDFA / SKAdNetwork / SDK-based tracking. -->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+
+	<!-- Data we collect from the user. Linked = tied to the account. -->
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<!-- Email address — required to create the account. -->
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<!-- Workouts, programs, nutrition log — user-generated content. -->
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<!-- Crash and performance data via Sentry — anonymised. -->
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+
+	<!-- Required Reasons APIs we touch. Each entry is the API category
+	     plus the reason code from Apple's catalogue. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<!-- @capacitor/preferences persists the Supabase auth tokens
+			     in NSUserDefaults so a session survives app restart. -->
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<!-- WKWebView caches and Capacitor's bundled web assets read
+			     and write file timestamps inside the app sandbox. -->
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<!-- Disk space is read by the WebView for its own cache budget
+			     and by Sentry to attach context to crash reports. -->
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<!-- Sentry samples the system uptime to bucket crash reports. -->
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,8 @@
         "typescript": "~5.9.3",
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.2.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "xcode": "^3.0.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-pwa": "^1.2.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "xcode": "^3.0.1"
   }
 }

--- a/scripts/add-ios-resource.mjs
+++ b/scripts/add-ios-resource.mjs
@@ -1,0 +1,116 @@
+/**
+ * Reference a file under ios/App/App/ as a build resource of the App
+ * target so it lands in App.app at build time.
+ *
+ * Used by the PrivacyInfo.xcprivacy step (PR Privacy Manifest) — we
+ * commit the file alongside the source, but Xcode only bundles
+ * resources that are referenced in project.pbxproj. Without this the
+ * file is silently dropped from the .ipa, which is exactly the kind
+ * of failure that triggers an App Store rejection.
+ *
+ * Idempotent: running it twice is a no-op.
+ *
+ * Usage: node scripts/add-ios-resource.mjs <relative-path>
+ *
+ * The npm `xcode` package's high-level addResourceFile() crashes when
+ * a PBXGroup has `path` but no `name` (which is what Capacitor emits
+ * for the App folder), so we wire the entries by hand: PBXFileReference
+ * + PBXBuildFile + the Resources build phase + the App PBXGroup's
+ * children list.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import xcode from 'xcode';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_PATH = join(__dirname, '..', 'ios/App/App.xcodeproj/project.pbxproj');
+
+function findGroupByPath(project, path) {
+  const groups = project.hash.project.objects.PBXGroup;
+  for (const key of Object.keys(groups)) {
+    if (key.endsWith('_comment')) continue;
+    if (groups[key]?.path === path) return key;
+  }
+  return null;
+}
+
+function findResourcesBuildPhase(project) {
+  const phases = project.hash.project.objects.PBXResourcesBuildPhase;
+  for (const key of Object.keys(phases)) {
+    if (key.endsWith('_comment')) continue;
+    return key;
+  }
+  return null;
+}
+
+function main() {
+  const relativePath = process.argv[2];
+  if (!relativePath) {
+    console.error('usage: node scripts/add-ios-resource.mjs <relative-path>');
+    process.exit(1);
+  }
+
+  const project = xcode.project(PROJECT_PATH);
+  project.parseSync();
+
+  const fileName = relativePath.split('/').pop();
+
+  // Idempotency check.
+  const fileRefSection = project.pbxFileReferenceSection();
+  for (const id of Object.keys(fileRefSection)) {
+    if (id.endsWith('_comment')) continue;
+    const entry = fileRefSection[id];
+    if (entry?.path === fileName || entry?.name === fileName) {
+      console.log(`[xcodeproj] ${fileName} already referenced — skipping.`);
+      return;
+    }
+  }
+
+  const appGroupKey = findGroupByPath(project, 'App');
+  if (!appGroupKey) {
+    console.error('[xcodeproj] PBXGroup with path="App" not found.');
+    process.exit(1);
+  }
+
+  const resourcesPhaseKey = findResourcesBuildPhase(project);
+  if (!resourcesPhaseKey) {
+    console.error('[xcodeproj] PBXResourcesBuildPhase not found.');
+    process.exit(1);
+  }
+
+  const fileRefUuid = project.generateUuid();
+  const buildFileUuid = project.generateUuid();
+
+  // 1) PBXFileReference declaration.
+  project.hash.project.objects.PBXFileReference[fileRefUuid] = {
+    isa: 'PBXFileReference',
+    lastKnownFileType: 'text.xml',
+    path: fileName,
+    sourceTree: '"<group>"',
+  };
+  project.hash.project.objects.PBXFileReference[`${fileRefUuid}_comment`] = fileName;
+
+  // 2) PBXBuildFile entry that ties the ref to the build phase.
+  project.hash.project.objects.PBXBuildFile[buildFileUuid] = {
+    isa: 'PBXBuildFile',
+    fileRef: fileRefUuid,
+    fileRef_comment: fileName,
+  };
+  project.hash.project.objects.PBXBuildFile[`${buildFileUuid}_comment`] = `${fileName} in Resources`;
+
+  // 3) Add to the App PBXGroup so the file appears in the navigator.
+  const appGroup = project.hash.project.objects.PBXGroup[appGroupKey];
+  appGroup.children = appGroup.children || [];
+  appGroup.children.push({ value: fileRefUuid, comment: fileName });
+
+  // 4) Add to the Resources build phase so it ships in the bundle.
+  const resourcesPhase = project.hash.project.objects.PBXResourcesBuildPhase[resourcesPhaseKey];
+  resourcesPhase.files = resourcesPhase.files || [];
+  resourcesPhase.files.push({ value: buildFileUuid, comment: `${fileName} in Resources` });
+
+  writeFileSync(PROJECT_PATH, project.writeSync());
+  console.log(`[xcodeproj] added ${fileName} as a build resource of the App target.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
Apple rejette les soumissions et mises à jour sans `PrivacyInfo.xcprivacy` depuis printemps 2024. Cette PR ajoute le manifest et l'outillage pour le maintenir.

- `ios/App/App/PrivacyInfo.xcprivacy` :
  - **NSPrivacyTracking=false** (no IDFA, no SKAdNetwork)
  - **Collected data** : email + user content (linked, app functionality) ; crash + performance (anonymous, Sentry)
  - **Required Reasons APIs** :
    - UserDefaults / CA92.1 → `@capacitor/preferences` (auth tokens)
    - FileTimestamp / C617.1 → WKWebView caches sandbox
    - DiskSpace / E174.1 → WebView cache budget + Sentry
    - SystemBootTime / 35F9.1 → Sentry crash bucketing
- `scripts/add-ios-resource.mjs` : helper idempotent pour wire un fichier dans Xcode project. Capacitor utilise `PBXGroup path=App` sans `name`, ce qui plante le high-level API du package npm `xcode` → on écrit PBXFileReference + PBXBuildFile + Resources phase manuellement.
- `xcode` npm package ajouté en devDep (pas de gem ruby, pas de sudo).

**Validé** : rebuild iOS Simulator → BUILD SUCCEEDED → manifest présent dans `App.app/PrivacyInfo.xcprivacy` (3.9 KB).

## Test plan
- [x] `node scripts/add-ios-resource.mjs ios/App/App/PrivacyInfo.xcprivacy` (idempotent confirmé)
- [x] `xcodebuild -sdk iphonesimulator build` → BUILD SUCCEEDED
- [x] `ls App.app/PrivacyInfo.xcprivacy` → présent
- [x] `npm run lint` (301 fichiers), `vitest run` (420), `build` (153 routes)
- [ ] Validation finale par Xcode App Store Connect (post Apple Dev validé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)