### PR TITLE
fix(android): commit gradle entries for sentry-capacitor

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':capacitor-push-notifications')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
+    implementation project(':sentry-capacitor')
 
 }
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -28,3 +28,6 @@ project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capa
 
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
+include ':sentry-capacitor'
+project(':sentry-capacitor').projectDir = new File('../node_modules/@sentry/capacitor/android')


### PR DESCRIPTION
Fix follow-up de PR #191. `cap sync android` a régénéré les settings/build gradle pour enregistrer `@sentry/capacitor`. Les diffs étaient dirty après merge — cette PR les commit pour avoir un build Android reproductible.

## Test plan
- [x] `./gradlew assembleDebug` → BUILD SUCCESSFUL (déjà vérifié dans PR #191)