### PR TITLE
feat(mobile): native first-launch onboarding carousel (4 screens)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,9 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { lazy, Suspense, useEffect } from 'react';
 import { RouterProvider } from 'react-router';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
+import { OnboardingCarousel } from './components/onboarding/OnboardingCarousel.tsx';
 import { AuthProvider } from './contexts/AuthContext.tsx';
+import { useOnboarding } from './hooks/useOnboarding.ts';
 import { hideNativeSplash } from './lib/capacitor.ts';
 import { registerDeepLinkListener } from './lib/deepLinks.ts';
 import { queryClient } from './lib/queryClient.ts';
@@ -17,6 +19,8 @@ const ReactQueryDevtools = import.meta.env.DEV
   : null;
 
 export default function App() {
+  const onboarding = useOnboarding();
+
   // SplashScreen.hide is idempotent, so the StrictMode double-effect in dev
   // is safe. No cleanup needed — the splash is already gone after first call.
   useEffect(() => {
@@ -54,6 +58,23 @@ export default function App() {
         <AuthProvider>
           <RouterProvider router={router} />
         </AuthProvider>
+        {/* Native first-launch onboarding renders ABOVE the router so the
+            router can stay mounted for the post-onboarding navigate. The
+            hook short-circuits on web (state === 'done') so the overlay
+            never mounts in the PWA. */}
+        {onboarding.state === 'pending' && (
+          <OnboardingCarousel
+            onComplete={() => {
+              void onboarding.markCompleted();
+            }}
+            onLogin={() => {
+              void router.navigate('/signup');
+            }}
+            onExplore={() => {
+              void router.navigate('/');
+            }}
+          />
+        )}
         {ReactQueryDevtools && (
           <Suspense fallback={null}>
             <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />

--- a/src/components/onboarding/OnboardingCarousel.tsx
+++ b/src/components/onboarding/OnboardingCarousel.tsx
@@ -1,0 +1,171 @@
+import { ChevronRight, Sparkles } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Slide {
+  key: string;
+  image: string;
+  imageAlt: string;
+}
+
+const SLIDES: Slide[] = [
+  { key: 'pitch', image: '/images/illustration-onboarding.webp', imageAlt: '' },
+  { key: 'sessions', image: '/images/screenshot-player-hiit.webp', imageAlt: '' },
+  { key: 'nutrition', image: '/images/illustration-empty-state.webp', imageAlt: '' },
+  { key: 'philosophy', image: '/images/illustration-program.webp', imageAlt: '' },
+];
+
+interface Props {
+  onComplete: () => void;
+  onLogin: () => void;
+  onExplore: () => void;
+}
+
+// Native first-launch onboarding. Four screens, swipe horizontal via
+// CSS scroll-snap (no lib), dot indicators reflect the active slide.
+// Plain "Suivant" / "Next" button on slides 0–2; the last slide swaps
+// in two CTAs (sign up / explore) and a tertiary skip in the header
+// stays available throughout.
+export function OnboardingCarousel({ onComplete, onLogin, onExplore }: Props) {
+  const { t } = useTranslation('onboarding');
+  const scrollerRef = useRef<HTMLElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Update the active dot from scroll position. snap-mandatory keeps the
+  // index integer-aligned, so dividing by the slide width is safe.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const idx = Math.round(el.scrollLeft / el.clientWidth);
+        setActiveIndex(idx);
+        ticking = false;
+      });
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollTo = (index: number) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollTo({ left: index * el.clientWidth, behavior: 'smooth' });
+  };
+
+  const handleNext = () => {
+    if (activeIndex < SLIDES.length - 1) {
+      scrollTo(activeIndex + 1);
+    }
+  };
+
+  const handleLogin = () => {
+    onComplete();
+    onLogin();
+  };
+
+  const handleExplore = () => {
+    onComplete();
+    onExplore();
+  };
+
+  const handleSkip = () => {
+    onComplete();
+    onExplore();
+  };
+
+  const isLastSlide = activeIndex === SLIDES.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-surface flex flex-col">
+      {/* Skip in the safe area top — always available */}
+      <div className="pt-safe px-safe flex justify-end px-4 py-3">
+        <button
+          type="button"
+          onClick={handleSkip}
+          className="text-sm font-medium text-muted hover:text-strong transition-colors px-3 py-1.5"
+        >
+          {t('skip')}
+        </button>
+      </div>
+
+      {/* Slides — horizontal scroll-snap */}
+      <section
+        ref={scrollerRef}
+        className="flex-1 flex overflow-x-auto snap-x snap-mandatory overscroll-contain"
+        style={{ scrollbarWidth: 'none' }}
+        aria-roledescription="carousel"
+        aria-label={t('aria_carousel')}
+      >
+        {SLIDES.map((slide) => (
+          <section
+            key={slide.key}
+            className="snap-center shrink-0 w-full h-full flex flex-col items-center justify-center px-6"
+            aria-label={t(`slides.${slide.key}.title`)}
+          >
+            <div className="flex-1 flex items-end justify-center w-full max-w-sm">
+              <img src={slide.image} alt={slide.imageAlt} className="w-full max-h-[55vh] object-contain" />
+            </div>
+            <div className="flex flex-col items-center gap-3 max-w-sm text-center pb-4 pt-6">
+              <h2 className="text-2xl md:text-3xl font-bold text-heading leading-tight">
+                {t(`slides.${slide.key}.title`)}
+              </h2>
+              <p className="text-base text-body leading-relaxed">{t(`slides.${slide.key}.subtitle`)}</p>
+            </div>
+          </section>
+        ))}
+      </section>
+
+      {/* Dots */}
+      <div className="flex justify-center gap-2 py-4">
+        {SLIDES.map((slide, idx) => (
+          <button
+            key={slide.key}
+            type="button"
+            onClick={() => scrollTo(idx)}
+            aria-label={t('aria_goto_slide', { index: idx + 1 })}
+            aria-current={idx === activeIndex ? 'true' : undefined}
+            className={`h-2 rounded-full transition-all ${
+              idx === activeIndex ? 'w-8 bg-brand' : 'w-2 bg-divider-strong'
+            }`}
+          />
+        ))}
+      </div>
+
+      {/* Footer CTAs */}
+      <div className="pb-safe px-safe px-6 pb-6 pt-2">
+        {isLastSlide ? (
+          <div className="flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={handleLogin}
+              className="flex items-center justify-center gap-2 w-full py-3.5 rounded-2xl bg-brand text-white font-semibold transition-colors hover:bg-brand/90"
+            >
+              <Sparkles className="w-4 h-4" aria-hidden="true" />
+              {t('cta_signup')}
+            </button>
+            <button
+              type="button"
+              onClick={handleExplore}
+              className="w-full py-3.5 rounded-2xl border border-divider text-strong font-medium transition-colors hover:bg-surface-card"
+            >
+              {t('cta_explore')}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleNext}
+            className="flex items-center justify-center gap-1 w-full py-3.5 rounded-2xl bg-brand text-white font-semibold transition-colors hover:bg-brand/90"
+          >
+            {t('next')}
+            <ChevronRight className="w-4 h-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import { isNative } from '../lib/capacitor.ts';
+
+const STORAGE_KEY = 'wan2fit-onboarding-seen';
+
+type OnboardingState = 'loading' | 'pending' | 'done';
+
+// Tracks whether the native first-launch onboarding carousel has already
+// been shown for this install. Persisted via @capacitor/preferences (i.e.
+// NSUserDefaults / SharedPreferences) so a WebView storage purge doesn't
+// re-prompt the user.
+//
+// Web: returns 'done' immediately. The onboarding is intentionally
+// native-only — Apple App Reviewers care that the iOS first launch
+// pitches the value of the app, the PWA gets it via wan2fit.fr's home.
+export function useOnboarding(): {
+  state: OnboardingState;
+  markCompleted: () => Promise<void>;
+} {
+  const [state, setState] = useState<OnboardingState>(() => (isNative() ? 'loading' : 'done'));
+
+  useEffect(() => {
+    if (!isNative()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { Preferences } = await import('@capacitor/preferences');
+        const { value } = await Preferences.get({ key: STORAGE_KEY });
+        if (cancelled) return;
+        setState(value === '1' ? 'done' : 'pending');
+      } catch {
+        // If Preferences fails for any reason, we fall back to "done"
+        // rather than block the user behind the carousel forever.
+        if (!cancelled) setState('done');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const markCompleted = useCallback(async () => {
+    setState('done');
+    if (!isNative()) return;
+    try {
+      const { Preferences } = await import('@capacitor/preferences');
+      await Preferences.set({ key: STORAGE_KEY, value: '1' });
+    } catch {
+      // Silent — the in-memory state is already updated, so the user
+      // won't see the carousel again this session. Worst case it
+      // re-shows on next launch, which is acceptable.
+    }
+  }, []);
+
+  return { state, markCompleted };
+}

--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -1,0 +1,26 @@
+{
+  "skip": "Skip",
+  "next": "Next",
+  "cta_signup": "Create my account",
+  "cta_explore": "Explore first",
+  "aria_carousel": "Wan2Fit walkthrough",
+  "aria_goto_slide": "Go to slide {{index}}",
+  "slides": {
+    "pitch": {
+      "title": "Your workout, ready to launch",
+      "subtitle": "No equipment, anywhere. Built to fit your day."
+    },
+    "sessions": {
+      "title": "Guided sessions and programs",
+      "subtitle": "8 formats, 25 to 45 minutes. AI programs tailored to your goal."
+    },
+    "nutrition": {
+      "title": "Simple, readable nutrition",
+      "subtitle": "Track meals and tap into 40+ ready-to-log recipes."
+    },
+    "philosophy": {
+      "title": "At your pace, no pressure",
+      "subtitle": "No streak to keep, no guilt-trip reminders. You progress your way."
+    }
+  }
+}

--- a/src/i18n/locales/fr/onboarding.json
+++ b/src/i18n/locales/fr/onboarding.json
@@ -1,0 +1,26 @@
+{
+  "skip": "Passer",
+  "next": "Suivant",
+  "cta_signup": "Créer mon compte",
+  "cta_explore": "Découvrir d'abord",
+  "aria_carousel": "Présentation Wan2Fit",
+  "aria_goto_slide": "Aller à l'écran {{index}}",
+  "slides": {
+    "pitch": {
+      "title": "Ta séance prête à lancer",
+      "subtitle": "Sans matériel, où tu veux. Conçu pour s'adapter à ton quotidien."
+    },
+    "sessions": {
+      "title": "Séances guidées et programmes",
+      "subtitle": "8 formats variés, de 25 à 45 minutes. Programmes IA personnalisés selon ton objectif."
+    },
+    "nutrition": {
+      "title": "Nutrition simple et lisible",
+      "subtitle": "Suivi de tes repas et 40+ recettes prêtes à enregistrer en deux taps."
+    },
+    "philosophy": {
+      "title": "À ton rythme, sans pression",
+      "subtitle": "Pas de chaîne à maintenir, pas de rappel culpabilisant. Tu progresses comme tu veux."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Premier launch natif → carousel 4 écrans qui pitch la valeur de Wan2Fit avant que l'user voie la home. Native-only (PWA non impactée).

- **4 écrans** : pitch produit / séances+programmes / nutrition (40+ recettes) / philosophie no-streak.
- **Double CTA final** : "Créer mon compte" / "Découvrir d'abord" → user garde l'agency.
- **Skip** toujours visible en haut à droite (safe-area).
- **Gate** via `@capacitor/preferences` clé `wan2fit-onboarding-seen` → ne s'affiche qu'une seule fois par install.
- **Visuels** : réutilise les assets existants (`illustration-onboarding`, `screenshot-player-hiit`, `illustration-empty-state`, `illustration-program`) — pas de nouveau bundle d'images.
- **Carousel** : CSS scroll-snap (pas de lib swipe), dots indicators via scroll listener passif.
- **Mount** au-dessus du `RouterProvider` pour que le router reste actif (post-onboarding navigate fonctionne).
- **i18n** : nouveau namespace `onboarding`, 12 clés alignées FR + EN.

## Test plan
- [x] `npm run lint` (305 fichiers, 0 issue)
- [x] `npx vitest run` (420 tests)
- [x] `npm run check:i18n` (22 namespaces, 2232 clés)
- [x] `npm run build` (153 routes prerenderées)
- [x] iOS Simulator iPhone 16 : 1er launch → carousel s'affiche correctement (slide 1 "Ta séance prête à lancer" avec dots + CTA Suivant + Passer en safe-area top)
- [x] Subsequent launches : carousel **skipped** (Preferences gate active)
- [ ] Validation manuelle : swipe entre slides 1→4, double CTA fonctionne (à faire dans le simulator)

## Volontairement hors scope
- Variantes de copy ou A/B test — version de base, à itérer après mesures réelles
- Tracking PostHog `onboarding_completed` — viendra avec la PR PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)