### PR TITLE
docs(design-system): rebrand WanShape → Wan2Fit + fix stale localStorage key

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,4 +1,4 @@
-# WanShape Design System
+# Wan2Fit Design System
 
 Guide de référence des tokens visuels et conventions UI.
 
@@ -91,7 +91,7 @@ Bouton solid brand. Pour les form submits et actions secondaires.
 Texte avec dégradé brand.
 
 ```html
-<span class="gradient-text">WanShape</span>
+<span class="gradient-text">Wan2Fit</span>
 ```
 
 ## Typographie
@@ -105,7 +105,7 @@ Texte avec dégradé brand.
 
 3 modes : `system` (défaut), `dark`, `light`.
 
-- Stockage : `localStorage` clé `wan-shape-theme`
+- Stockage : `localStorage` clé `wan2fit-theme`
 - Attribut : `data-theme="light"` sur `<html>` (absent = dark)
 - Player et EndScreen : toujours dark, pas de switch
 - Hook : `useTheme()` retourne `{ preference, theme, cycleTheme }`


### PR DESCRIPTION
Doc-only fix : 3 occurrences résiduelles `WanShape` / `wan-shape` dans `DESIGN_SYSTEM.md`.

- Title : "WanShape Design System" → "Wan2Fit Design System"
- Gradient-text exemple : WanShape → Wan2Fit
- §Thème : la doc disait `localStorage clé 'wan-shape-theme'` mais le code utilise `'wan2fit-theme'` depuis le rebrand → fix doc

`claudedocs/*` (audits historiques mars/avril 2026) gardent leurs mentions WanShape — ce sont des snapshots datés à ne pas retconner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)