### PR TITLE
test(mobile): unit-test useOnboarding (6 tests covering web + native + fallback)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@sentry/vite-plugin": "^5.1.1",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query-devtools": "^5.99.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -5494,6 +5495,55 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trapezedev/gradle-parse": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@trapezedev/gradle-parse/-/gradle-parse-7.1.3.tgz",
@@ -5707,6 +5757,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6172,6 +6230,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -7692,6 +7761,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7745,6 +7825,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -10571,6 +10659,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -11772,6 +11871,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11964,6 +12093,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@sentry/vite-plugin": "^5.1.1",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query-devtools": "^5.99.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/src/hooks/useOnboarding.test.ts
+++ b/src/hooks/useOnboarding.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @capacitor/preferences. We define the mock fns inline so each
+// test can re-stub them via mockResolvedValue / mockClear.
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: (...args: unknown[]) => mockGet(...args),
+    set: (...args: unknown[]) => mockSet(...args),
+  },
+}));
+
+// Mock capacitor.ts so isNative() can flip per test.
+const mockIsNative = vi.fn();
+vi.mock('../lib/capacitor.ts', () => ({
+  isNative: () => mockIsNative(),
+}));
+
+import { useOnboarding } from './useOnboarding.ts';
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockSet.mockReset();
+    mockIsNative.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns done immediately on web (skips Preferences entirely)', () => {
+    mockIsNative.mockReturnValue(false);
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.state).toBe('done');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('starts in loading then transitions to pending when no flag is stored', async () => {
+    mockIsNative.mockReturnValue(true);
+    mockGet.mockResolvedValue({ value: null });
+
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.state).toBe('loading');
+    await waitFor(() => expect(result.current.state).toBe('pending'));
+    expect(mockGet).toHaveBeenCalledWith({ key: 'wan2fit-onboarding-seen' });
+  });
+
+  it('transitions to done when the flag is already stored', async () => {
+    mockIsNative.mockReturnValue(true);
+    mockGet.mockResolvedValue({ value: '1' });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.state).toBe('done'));
+  });
+
+  it('falls back to done if Preferences.get throws (avoids blocking the UI)', async () => {
+    mockIsNative.mockReturnValue(true);
+    mockGet.mockRejectedValue(new Error('plugin missing'));
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.state).toBe('done'));
+  });
+
+  it('markCompleted updates state to done and writes the flag', async () => {
+    mockIsNative.mockReturnValue(true);
+    mockGet.mockResolvedValue({ value: null });
+    mockSet.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.state).toBe('pending'));
+
+    await act(async () => {
+      await result.current.markCompleted();
+    });
+
+    expect(result.current.state).toBe('done');
+    expect(mockSet).toHaveBeenCalledWith({ key: 'wan2fit-onboarding-seen', value: '1' });
+  });
+
+  it('markCompleted on web flips state without touching Preferences', async () => {
+    mockIsNative.mockReturnValue(false);
+    const { result } = renderHook(() => useOnboarding());
+
+    await act(async () => {
+      await result.current.markCompleted();
+    });
+
+    expect(result.current.state).toBe('done');
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Coverage sur le hook critique du first-launch onboarding. Mocks `@capacitor/preferences` + `capacitor.ts` pour exercer le flow sans Capacitor runtime.

6 cas :
- Web → `done` immédiat, Preferences pas touché
- Native + pas de flag → loading → pending
- Native + flag stored → loading → done
- Native + Preferences.get throws → fallback `done` (UI jamais bloquée si plugin cassé)
- markCompleted natif → state done + Preferences.set('wan2fit-onboarding-seen', '1')
- markCompleted web → state flip, Preferences.set pas appelé

`@testing-library/react` ajouté en devDep (renderHook + act).

**439 tests total** (vs 433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)