### PR TITLE
feat(mobile): npm run sync:version (package.json → iOS + Android)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 10101
+        versionName "1.1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/claudedocs/release-process.md
+++ b/claudedocs/release-process.md
@@ -106,7 +106,7 @@ Sinon le prochain `supabase` sur ce repo touche prod par accident.
 
 - **OTA via Capgo** (patches JS) : `npm run build:native && capgo upload --channel production`. Pas de re-submission stores.
 - **Native rebuild** (changement de plugin natif, permission, bump SDK) : Xcode Archive → App Store Connect, Android Studio AAB → Play Console. Bump version requise.
-- **Versioning multi-cibles** : `scripts/sync-version.ts` (à créer) maintiendra `package.json` + `Info.plist CFBundleShortVersionString` + `android/app/build.gradle versionName` en sync. À documenter ici quand le script existe.
+- **Versioning multi-cibles** : `npm run sync:version` lit `package.json.version` et propage vers iOS (`MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` dans `project.pbxproj`) et Android (`versionName` + `versionCode` dans `build.gradle`). Le code numérique = `major*10000 + minor*100 + patch` (e.g. `2.1.0` → `20100`), strictement croissant. Lancer ce script à chaque bump version, juste après l'edit de `package.json`.
 
 ## Glossaire
 

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 10101;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 10101;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build && npm run prerender",
     "build:native": "tsc -b && CAPACITOR_BUILD=true vite build",
     "icons": "tsx scripts/generate-app-icon.ts && capacitor-assets generate",
+    "sync:version": "tsx scripts/sync-version.ts",
     "prerender": "tsx scripts/prerender.ts",
     "lint": "biome check src/",
     "lint:fix": "biome check --fix src/",

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -1,0 +1,76 @@
+/**
+ * Propagate package.json version to the iOS + Android native projects.
+ *
+ * Run: npm run sync:version
+ *
+ * Reads `package.json.version` (semver) and updates:
+ *   - android/app/build.gradle      → versionName + versionCode
+ *   - ios/App/App.xcodeproj/        → MARKETING_VERSION + CURRENT_PROJECT_VERSION
+ *
+ * Numeric build code derivation (Android versionCode + iOS
+ * CURRENT_PROJECT_VERSION) is `major * 10000 + minor * 100 + patch`,
+ * which keeps the value strictly increasing and stays well under
+ * Android's 2_100_000_000 limit until major hits 200000.
+ *
+ * Both stores enforce monotonic build numbers per release; the formula
+ * lets us re-derive the value from the semver string alone, so the
+ * script is idempotent — re-running it for the same package.json
+ * produces the same files and the next major/minor/patch bump always
+ * climbs the build number.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const PACKAGE_JSON = join(ROOT, 'package.json');
+const ANDROID_GRADLE = join(ROOT, 'android/app/build.gradle');
+const IOS_PBXPROJ = join(ROOT, 'ios/App/App.xcodeproj/project.pbxproj');
+
+function parseSemver(raw: string): { major: number; minor: number; patch: number } {
+  const match = raw.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!match) throw new Error(`package.json.version "${raw}" is not a clean major.minor.patch semver`);
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+function buildCode(major: number, minor: number, patch: number): number {
+  return major * 10000 + minor * 100 + patch;
+}
+
+function updateAndroid(versionName: string, versionCode: number): boolean {
+  const original = readFileSync(ANDROID_GRADLE, 'utf8');
+  let next = original.replace(/versionName\s+"[^"]+"/, `versionName "${versionName}"`);
+  next = next.replace(/versionCode\s+\d+/, `versionCode ${versionCode}`);
+  if (next === original) return false;
+  writeFileSync(ANDROID_GRADLE, next);
+  return true;
+}
+
+function updateIos(versionName: string, versionCode: number): boolean {
+  const original = readFileSync(IOS_PBXPROJ, 'utf8');
+  let next = original.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${versionName};`);
+  next = next.replace(/CURRENT_PROJECT_VERSION = [^;]+;/g, `CURRENT_PROJECT_VERSION = ${versionCode};`);
+  if (next === original) return false;
+  writeFileSync(IOS_PBXPROJ, next);
+  return true;
+}
+
+function main() {
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')) as { version?: string };
+  if (!pkg.version) {
+    console.error('package.json has no "version" field');
+    process.exit(1);
+  }
+  const { major, minor, patch } = parseSemver(pkg.version);
+  const code = buildCode(major, minor, patch);
+
+  const androidChanged = updateAndroid(pkg.version, code);
+  const iosChanged = updateIos(pkg.version, code);
+
+  console.log(`[sync-version] target ${pkg.version} (build code ${code})`);
+  console.log(`[sync-version] android/app/build.gradle: ${androidChanged ? 'updated' : 'unchanged'}`);
+  console.log(`[sync-version] ios/App/App.xcodeproj/project.pbxproj: ${iosChanged ? 'updated' : 'unchanged'}`);
+}
+
+main();


### PR DESCRIPTION
Tooling pour la prochaine release native. `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` (iOS) et `versionName` + `versionCode` (Android) doivent bouger en lockstep avec `package.json.version`. Edit manuel sur 3 fichiers = error-prone.

- `scripts/sync-version.ts` lit `package.json.version` et propage vers les 2 natifs.
- Build code numérique = `major*10000 + minor*100 + patch` (e.g. `2.1.0` → `20100`), strictement croissant + re-derivable depuis semver seul.
- **Idempotent** : re-running pour la même version = no-op.
- `npm run sync:version` exposé.
- `release-process.md` mis à jour (drop le "(à créer)").

Side effect : ce premier run a sync les 2 natifs sur la version actuelle (`1.1.1` → code 10101). Les builds natifs futurs partiront de cette base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)