### PR TITLE
feat(analytics): track recipe favorites + premium funnel events

### DIFF
--- a/src/components/PricingPage.tsx
+++ b/src/components/PricingPage.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
+import { captureEvent } from '../lib/analytics.ts';
 import { PricingCards } from './PricingCards.tsx';
 
 export function PricingPage() {
@@ -9,6 +11,10 @@ export function PricingPage() {
     title: t('pricing.page_title'),
     description: t('pricing.page_description'),
   });
+
+  useEffect(() => {
+    captureEvent('pricing_viewed');
+  }, []);
 
   return (
     <div className="max-w-5xl mx-auto px-6 md:px-10 py-10 md:py-16">

--- a/src/hooks/useRecipeFavorites.ts
+++ b/src/hooks/useRecipeFavorites.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import { captureEvent } from '../lib/analytics.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import { computeToggledFavorites } from '../utils/recipeFavorites.ts';
@@ -93,12 +94,17 @@ export function useRecipeFavorites(): UseRecipeFavoritesResult {
   const toggle = useCallback(
     async (recipeKey: string) => {
       if (!userId) return;
+      // Capture intent BEFORE the mutation flips the optimistic state
+      // — onMutate runs synchronously inside mutateAsync, so reading
+      // favoriteKeys after await would already be inverted.
+      const wasFavorite = favoriteKeys.has(recipeKey);
+      captureEvent(wasFavorite ? 'recipe_unfavorited' : 'recipe_favorited', { recipe_key: recipeKey });
       await mutation.mutateAsync(recipeKey).catch(() => {
         // Error is surfaced via React Query state; the optimistic rollback
         // already happened in `onError`.
       });
     },
-    [userId, mutation],
+    [userId, mutation, favoriteKeys],
   );
 
   return {

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import i18n from '../i18n/index.ts';
+import { captureEvent } from '../lib/analytics.ts';
 import { isNative } from '../lib/capacitor.ts';
 import { openWebUpgrade } from '../lib/native-upgrade.ts';
 import { supabase } from '../lib/supabase.ts';
@@ -47,6 +48,14 @@ export function useSubscription() {
   const checkout = useCallback(
     async (priceId: string): Promise<string | null> => {
       if (!supabase || !user) return tHookError('not_signed_in');
+
+      // Track BEFORE the redirect — if the Stripe checkout opens in
+      // a new origin or the magic-link bounce navigates away, the
+      // post-call event would never fire from this page.
+      captureEvent('checkout_initiated', {
+        price_id: priceId,
+        platform: isNative() ? 'native' : 'web',
+      });
 
       // Native bypass: hand the user off to wan2fit.fr via a one-shot
       // magic link so the Stripe checkout never runs inside the app


### PR DESCRIPTION
3 events qui complètent le funnel conversion :

- **recipe_favorited / recipe_unfavorited** dans `useRecipeFavorites.toggle` — capturé AVANT la mutation optimistic (sinon `favoriteKeys` est déjà inversé). Payload : `recipe_key` seulement, pas de contenu user.
- **pricing_viewed** au mount de `PricingPage` (`useEffect []`). Capte tous les paths (header CTA, settings upsell, upgrade fallback, URL directe) sans instrumenter chaque entry point.
- **checkout_initiated** dans `useSubscription.checkout`, AVANT le redirect / magic-link. Payload : `price_id` + `platform` (`native` / `web`) pour split conversion par surface.

Avec `signup_completed` (PR #205) + `session_started`/`session_completed` (PR #206), funnel complet :

`pricing_viewed` → `checkout_initiated` → (Stripe success_url) → `signup_completed` → `session_started` → `session_completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)