### PR TITLE
feat(analytics): track meal_logged + program_created events

### DIFF
--- a/src/hooks/useDailyNutrition.ts
+++ b/src/hooks/useDailyNutrition.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import i18n from '../i18n/index.ts';
+import { captureEvent } from '../lib/analytics.ts';
 import { supabase } from '../lib/supabase.ts';
 import { notifySessionExpired, supabaseQuery } from '../lib/supabaseQuery.ts';
 import type {
@@ -119,6 +120,15 @@ export function useDailyNutrition(dateKey: string = todayYYYYMMDD()): UseDailyNu
         // from a separate range query — partial-match on the prefix invalidates
         // every cached window for this user.
         queryClient.invalidateQueries({ queryKey: ['nutritionRange', userId] });
+
+        // Track only structured fields. The user-typed `name` is excluded
+        // (custom meal description) — meal_type and source give us enough
+        // for "which entry mode is most used" without leaking content.
+        captureEvent('meal_logged', {
+          meal_type: input.meal_type,
+          source: input.source ?? 'manual',
+          back_dated: input.logged_date != null && input.logged_date !== dateKey,
+        });
         return inserted;
       } finally {
         inflightRef.current = false;

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { isSupportedLocale } from '../i18n';
+import { captureEvent } from '../lib/analytics.ts';
 import { supabase } from '../lib/supabase.ts';
 import type { GenerateProgramResponse, ProgramOnboardingInput } from '../types/custom-program.ts';
 import { extractEdgeFunctionError } from '../utils/edgeFunction.ts';
@@ -58,6 +59,17 @@ export function useGenerateProgram() {
         // are compared with strict ===, so undefined ≠ null).
         queryClient.invalidateQueries({ queryKey: ['userPrograms', userId ?? null] });
         queryClient.invalidateQueries({ queryKey: ['activeProgram', userId ?? null] });
+
+        // Structured payload only — input.objectifs / experience / frequence
+        // are categorical enums, never free text. Detail / blessure_detail
+        // (free text fields) intentionally omitted.
+        captureEvent('program_created', {
+          objectifs: input.objectifs,
+          experience_duree: input.experience_duree,
+          frequence_actuelle: input.frequence_actuelle,
+          seances_par_semaine: input.seances_par_semaine,
+          duree_semaines: input.duree_semaines,
+        });
 
         return data as GenerateProgramResponse;
       } catch (e) {


### PR DESCRIPTION
2 events de plus pour signaler engagement / rétention :

- **meal_logged** dans `useDailyNutrition.addMeal` après l'optimistic cache update. Payload : `meal_type`, `source` (`manual` / `off` / `recipe`), `back_dated` (rétroactif). Nom du repas (free-text) volontairement omis.
- **program_created** dans `useGenerateProgram` après resolution de l'edge function. Payload : champs catégoriques de l'onboarding (`objectifs[]`, `experience_duree`, `frequence_actuelle`, `seances_par_semaine`, `duree_semaines`). `objectif_detail` / `blessure_detail` (free text) et `age` / `sexe` (RGPD minimisés at rest) volontairement omis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)