### PR TITLE
feat(mobile): haptic countdown 3-2-1 on Player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.3.1",
+        "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.3.1",
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/network": "^8.0.1",
@@ -2409,6 +2410,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/ios": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.3.1",
+    "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.3.1",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/network": "^8.0.1",

--- a/src/hooks/useWorkout.ts
+++ b/src/hooks/useWorkout.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { countdownGo, countdownTick } from '../lib/haptics.ts';
 import type { AtomicStep, PlayerStatus } from '../types/player.ts';
 import { useAudio } from './useAudio.ts';
 import { useTimer } from './useTimer.ts';
@@ -109,6 +110,9 @@ export function useWorkout(steps: AtomicStep[]) {
       } else if (status === 'active') {
         audio.beepCountdown();
       }
+      // Haptic mirror of the audio cue (native only, no-op on web).
+      // Heavy pulse on the final tick (1) so the body feels the "go".
+      void (timer.remaining === 1 ? countdownGo() : countdownTick());
     }
   }, [timer.remaining, audio.beepCountdown, audio.speakCountdown, status, timer.isRunning]);
 

--- a/src/hooks/useWorkout.ts
+++ b/src/hooks/useWorkout.ts
@@ -109,6 +109,10 @@ export function useWorkout(steps: AtomicStep[]) {
         audio.speakCountdown(timer.remaining);
       } else if (status === 'active') {
         audio.beepCountdown();
+      } else {
+        // Other phases (rest, transition, prepare) intentionally have no
+        // audio cue here — and shouldn't get a haptic either.
+        return;
       }
       // Haptic mirror of the audio cue (native only, no-op on web).
       // Heavy pulse on the final tick (1) so the body feels the "go".

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,28 @@
+import { isNative } from './capacitor.ts';
+
+// Map our intent to Capacitor's ImpactStyle without importing the plugin
+// at module load — keeps the web bundle clean (no native bindings).
+type Intensity = 'light' | 'medium' | 'heavy';
+
+async function impact(intensity: Intensity): Promise<void> {
+  if (!isNative()) return;
+  try {
+    const { Haptics, ImpactStyle } = await import('@capacitor/haptics');
+    const style =
+      intensity === 'heavy' ? ImpactStyle.Heavy : intensity === 'medium' ? ImpactStyle.Medium : ImpactStyle.Light;
+    await Haptics.impact({ style });
+  } catch (err) {
+    console.warn('[haptics] impact failed', err);
+  }
+}
+
+// Light tick on each remaining second of a 3-2-1 countdown — matches
+// the cadence of audio.beepCountdown / audio.speakCountdown.
+export function countdownTick(): Promise<void> {
+  return impact('light');
+}
+
+// Heavier "go" pulse when the countdown reaches zero / first work tick.
+export function countdownGo(): Promise<void> {
+  return impact('heavy');
+}


### PR DESCRIPTION
## Summary
- Light haptic tick on remaining seconds 3 and 2, heavy pulse on 1, mirroring the existing audio countdown on `countdown` and `active` phases.
- Web is a no-op via `isNative()` guard. `@capacitor/haptics` import is lazy so the web bundle stays clean (same pattern as `hideNativeSplash`).
- Other phases (rest, transition, prepare) intentionally have no haptic — branded `Wan..2..Fit` countdown remains audio-only.

## Test plan
- [ ] iOS device: start a workout with prepare phase → vibrations on 3-2-1 with stronger pulse on 1
- [ ] iOS device: during AMRAP / EMOM, verify haptic on last 3 sec of work timer (matches the audio beep)
- [ ] Android device: same checks on a physical device with vibration enabled
- [ ] Web (Chrome): no console errors, no extra network calls, no vibration (no-op)
- [ ] Pause/resume mid-countdown: no double-fire
- [ ] Lint, build, 453 unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)