### PR TITLE
fix(i18n): LocaleToggle navigates to twin URL so the choice sticks

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':capacitor-community-keep-awake')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-network')
     implementation project(':capacitor-preferences')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -11,6 +11,9 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-haptics'
+project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/haptics/android')
+
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 

--- a/src/components/landings/FeatureLandingTemplate.tsx
+++ b/src/components/landings/FeatureLandingTemplate.tsx
@@ -23,12 +23,14 @@ export function FeatureLandingTemplate({ meta, hero, benefits, finalCta }: Featu
   const { i18n } = useTranslation();
   const { pathname } = useLocation();
 
-  // Sync i18n locale with URL prefix so EN-mirrored landing URLs always render
-  // English content, even when navigated via SPA (no full reload).
+  // Force EN when the URL is the EN-mirror so a crawler-friendly landing
+  // always renders English content. We deliberately do NOT force FR on the
+  // canonical FR path — that would override a deliberate language switch
+  // by the user (LocaleToggle navigates to the twin URL when one exists,
+  // but on URLs without a mirror the user's choice must win).
   useEffect(() => {
-    const targetLng = pathname.startsWith('/en/') ? 'en' : 'fr';
-    if (i18n.language !== targetLng) {
-      void i18n.changeLanguage(targetLng);
+    if (pathname.startsWith('/en/') && i18n.language !== 'en') {
+      void i18n.changeLanguage('en');
     }
   }, [pathname, i18n]);
 

--- a/src/components/landings/FeatureLandingTemplate.tsx
+++ b/src/components/landings/FeatureLandingTemplate.tsx
@@ -28,11 +28,14 @@ export function FeatureLandingTemplate({ meta, hero, benefits, finalCta }: Featu
   // canonical FR path — that would override a deliberate language switch
   // by the user (LocaleToggle navigates to the twin URL when one exists,
   // but on URLs without a mirror the user's choice must win).
+  // i18n.language is listed as a dep on purpose: the i18n instance is a
+  // stable singleton so the effect would otherwise miss a language change
+  // happening between pathname updates.
   useEffect(() => {
     if (pathname.startsWith('/en/') && i18n.language !== 'en') {
       void i18n.changeLanguage('en');
     }
-  }, [pathname, i18n]);
+  }, [pathname, i18n.language, i18n]);
 
   useDocumentHead({ title: meta.title, description: meta.description });
 

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -1,14 +1,25 @@
 import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router';
 
 import { isSupportedLocale, type SupportedLocale } from '../i18n';
+import { twinPath } from '../utils/localePath.ts';
 
 export function useLocale() {
   const { i18n } = useTranslation();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
   const rawLocale = i18n.resolvedLanguage ?? i18n.language;
   const locale: SupportedLocale = isSupportedLocale(rawLocale) ? rawLocale : 'fr';
 
+  // For URLs whose path itself is localised (acquisition landings, recipe
+  // listing), navigate to the twin in the target locale before switching
+  // i18n. Without this, an effect bound to pathname (e.g. in
+  // FeatureLandingTemplate) would snap the language back to whatever the
+  // URL implies. For non-mirrored URLs, we just change the language.
   const setLocale = (next: SupportedLocale) => {
     if (next === locale) return;
+    const twin = twinPath(pathname, next);
+    if (twin) navigate(twin, { replace: true });
     void i18n.changeLanguage(next);
   };
 

--- a/src/utils/localePath.test.ts
+++ b/src/utils/localePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getRecipeLocaleFromPath, recipeListingUrlForLocale, recipeUrlForLocale } from './localePath.ts';
+import { getRecipeLocaleFromPath, recipeListingUrlForLocale, recipeUrlForLocale, twinPath } from './localePath.ts';
 
 describe('getRecipeLocaleFromPath', () => {
   it('returns en when path is under /en/', () => {
@@ -36,5 +36,42 @@ describe('recipeListingUrlForLocale', () => {
 
   it('points to the EN listing under /en/', () => {
     expect(recipeListingUrlForLocale('en')).toBe('/en/nutrition/recipes');
+  });
+});
+
+describe('twinPath', () => {
+  it('maps the four acquisition landings between FR and EN', () => {
+    expect(twinPath('/decouvrir/seances', 'en')).toBe('/en/discover/sessions');
+    expect(twinPath('/decouvrir/programmes', 'en')).toBe('/en/discover/programs');
+    expect(twinPath('/decouvrir/nutrition', 'en')).toBe('/en/discover/nutrition');
+    expect(twinPath('/decouvrir/suivi', 'en')).toBe('/en/discover/tracking');
+
+    expect(twinPath('/en/discover/sessions', 'fr')).toBe('/decouvrir/seances');
+    expect(twinPath('/en/discover/programs', 'fr')).toBe('/decouvrir/programmes');
+    expect(twinPath('/en/discover/nutrition', 'fr')).toBe('/decouvrir/nutrition');
+    expect(twinPath('/en/discover/tracking', 'fr')).toBe('/decouvrir/suivi');
+  });
+
+  it('maps the recipe listing between FR and EN', () => {
+    expect(twinPath('/nutrition/recettes', 'en')).toBe('/en/nutrition/recipes');
+    expect(twinPath('/en/nutrition/recipes', 'fr')).toBe('/nutrition/recettes');
+  });
+
+  it('falls back to the listing for recipe detail pages (slugs differ across locales)', () => {
+    expect(twinPath('/nutrition/recettes/toast-patate-douce', 'en')).toBe('/en/nutrition/recipes');
+    expect(twinPath('/en/nutrition/recipes/sweet-potato-toast', 'fr')).toBe('/nutrition/recettes');
+  });
+
+  it('returns null when there is no twin (Home, Player, programmes, etc.)', () => {
+    expect(twinPath('/', 'en')).toBeNull();
+    expect(twinPath('/seance/play', 'en')).toBeNull();
+    expect(twinPath('/programme/debutant-4-semaines', 'en')).toBeNull();
+    expect(twinPath('/login', 'fr')).toBeNull();
+    expect(twinPath('/legal/privacy', 'fr')).toBeNull();
+  });
+
+  it('returns null when the requested target equals the current locale', () => {
+    expect(twinPath('/decouvrir/seances', 'fr')).toBeNull();
+    expect(twinPath('/en/discover/sessions', 'en')).toBeNull();
   });
 });

--- a/src/utils/localePath.ts
+++ b/src/utils/localePath.ts
@@ -1,3 +1,4 @@
+import type { SupportedLocale } from '../i18n';
 import type { RecipeLocale } from '../types/recipe.ts';
 
 /**
@@ -25,4 +26,38 @@ export function recipeUrlForLocale(locale: RecipeLocale, slug: string): string {
 
 export function recipeListingUrlForLocale(locale: RecipeLocale): string {
   return locale === 'en' ? '/en/nutrition/recipes' : '/nutrition/recettes';
+}
+
+// FR canonical ↔ EN-prefixed paths for pages whose URL itself is localised.
+// Recipe detail slugs differ between locales (FR slug vs EN slug) so the
+// pair is intentionally limited to the listing — switching language on a
+// detail page falls back to the listing in the target locale (see twinPath).
+const PATH_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['/decouvrir/seances', '/en/discover/sessions'],
+  ['/decouvrir/programmes', '/en/discover/programs'],
+  ['/decouvrir/nutrition', '/en/discover/nutrition'],
+  ['/decouvrir/suivi', '/en/discover/tracking'],
+  ['/nutrition/recettes', '/en/nutrition/recipes'],
+];
+
+/**
+ * Returns the equivalent path in the target locale for pages whose URL is
+ * itself localised (acquisition landings, recipe listing). Returns null
+ * when the current page has no twin in the other locale — callers should
+ * keep the current URL in that case.
+ *
+ * Detail recipe URLs (`/nutrition/recettes/<fr-slug>` vs
+ * `/en/nutrition/recipes/<en-slug>`) cannot be mapped directly because
+ * the slugs differ; the function falls back to the listing URL of the
+ * target locale, which is the closest stable destination.
+ */
+export function twinPath(pathname: string, target: SupportedLocale): string | null {
+  if (target === 'en' && pathname.startsWith('/nutrition/recettes/')) return '/en/nutrition/recipes';
+  if (target === 'fr' && pathname.startsWith('/en/nutrition/recipes/')) return '/nutrition/recettes';
+
+  for (const [fr, en] of PATH_PAIRS) {
+    if (target === 'en' && pathname === fr) return en;
+    if (target === 'fr' && pathname === en) return fr;
+  }
+  return null;
 }

--- a/src/utils/localePath.ts
+++ b/src/utils/localePath.ts
@@ -52,6 +52,9 @@ const PATH_PAIRS: ReadonlyArray<readonly [string, string]> = [
  * target locale, which is the closest stable destination.
  */
 export function twinPath(pathname: string, target: SupportedLocale): string | null {
+  // Prefix checks must come before the exact-match loop: a path like
+  // `/nutrition/recettes/<slug>` would otherwise fall through and return
+  // null instead of falling back to the listing.
   if (target === 'en' && pathname.startsWith('/nutrition/recettes/')) return '/en/nutrition/recipes';
   if (target === 'fr' && pathname.startsWith('/en/nutrition/recipes/')) return '/nutrition/recettes';
 

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -79,3 +79,23 @@ Alternative plus fine si `maskAllInputs: true` est trop strict pour le debug :
 3. Sinon refetch et stocker
 
 
+## Recipe slug map — `twinPath` lossy on detail pages
+
+**Priorité** : faible (UX)
+**Introduit par** : PR #216 (fix locale toggle persistence)
+
+### Symptôme
+Sur `/en/nutrition/recipes/marinated-salmon-poke-bowl`, basculer en FR via le LocaleToggle redirige vers l'index `/nutrition/recettes` au lieu de la version FR de la recette (`/nutrition/recettes/poke-bowl-saumon-marine`). L'utilisateur perd son contexte de lecture. Symétrique côté EN.
+
+### Cause
+Les slugs de recette sont localisés indépendamment (FR : `poke-bowl-saumon-marine`, EN : `marinated-salmon-poke-bowl`). `utils/localePath.ts#twinPath` n'a pas accès au mapping `recipe_id → slug` côté client : il se rabat sur l'index, qui est au moins une destination stable.
+
+### Fix proposé
+1. Construire au build un objet `RECIPE_SLUG_MAP: Record<recipe_id, { fr: string; en: string }>` à partir des seeds JSON (`scripts/data/recipes_*_seed.json`) et l'inclure dans le bundle.
+2. Dans `twinPath`, parser le slug courant, retrouver le `recipe_id`, projeter vers le slug de l'autre locale.
+3. Garder le fallback à l'index si l'id n'est pas trouvé (recette ajoutée à un seul locale, etc.).
+
+### Coût/bénéfice
+Map de ~50 entrées soit ~3 KB gzipped. Effort : ~1 h. Bénéfice : pas de saut de contexte sur les détails recettes — important si on push les recettes en SEO.
+
+


### PR DESCRIPTION
## Bug report
On iOS simulator and Android emulator (both Capacitor builds), on \`/decouvrir/*\` or \`/en/discover/*\` landings:
- Toggle felt « not always clickable » (it visually didn't react to taps).
- Switching back to FR didn't persist — page snapped back to EN immediately.

## Root cause
\`FeatureLandingTemplate.tsx\` had a \`useEffect([pathname])\` that forced the language from the URL prefix in **both directions**: \`/en/* → 'en'\` AND \`/anything-else → 'fr'\`. \`LocaleToggle\` only called \`i18n.changeLanguage\` without navigating, so the effect snapped the language back instantly. Visually the button looked dead.

## Fix
- **\`utils/localePath.ts#twinPath\`** — new helper mapping FR canonical ↔ EN-prefixed paths for the four acquisition landings and the recipe listing. Recipe detail slugs differ across locales so it falls back to the listing URL of the target locale.
- **\`useLocale.setLocale\`** — navigates to the twin (\`replace: true\`) before \`changeLanguage\`. URLs without a mirror (Home, Player, programmes, settings, etc.) just flip the language and keep the current path.
- **\`FeatureLandingTemplate\`** — effect no longer forces FR on canonical FR paths; it only forces EN when the URL is \`/en/*\`. The user's choice now wins everywhere except on a crawler-served EN landing.

## Test plan
- [ ] On iOS / Android emulator on \`/decouvrir/seances\` (FR landing), tap EN in the toggle: URL changes to \`/en/discover/sessions\` and content stays in EN. Reverse works the same way.
- [ ] On Home (\`/\`), Player, \`/programmes\` etc., the toggle just flips the language without navigating.
- [ ] On a recipe detail (\`/nutrition/recettes/<slug>\`), tapping EN navigates to \`/en/nutrition/recipes\` (listing). Acceptable fallback because slugs differ.
- [ ] Lint, build, tests: 469/469 pass (was 464, +5 for twinPath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)