### PR TITLE
fix(mobile-test-batch): meal modal, plain goal tags, full i18n on fixed programs + sessions

### DIFF
--- a/src/components/NutritionPage.tsx
+++ b/src/components/NutritionPage.tsx
@@ -206,7 +206,7 @@ export function NutritionPage() {
         <NutritionHistorySection />
 
         {formOpen && (
-          <div className="fixed inset-0 z-[60] h-[100dvh] flex items-end sm:items-center justify-center p-0 sm:p-6">
+          <div className="fixed inset-0 z-[60] h-[100dvh] flex items-center justify-center p-4 sm:p-6">
             <button
               type="button"
               aria-label={t('page.close_modal_aria')}
@@ -219,7 +219,7 @@ export function NutritionPage() {
               aria-modal="true"
               aria-label={t('page.add_meal_modal_aria')}
               tabIndex={-1}
-              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-t-2xl sm:rounded-2xl bg-surface border border-card-border p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-6 shadow-xl focus:outline-none"
+              className="relative w-full max-w-lg max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto overscroll-contain rounded-2xl bg-surface border border-card-border p-4 sm:p-6 shadow-xl focus:outline-none"
             >
               <MealEntryForm
                 mealType={initialMealType}

--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -3,10 +3,12 @@ import { Link } from 'react-router';
 import type { Program } from '../types/completion.ts';
 import { FITNESS_COLORS } from '../utils/labels.ts';
 import { getProgramImage } from '../utils/programImage.ts';
+import { localizedProgramFields } from '../utils/programLocale.ts';
 
 export function ProgramCard({ program }: { program: Program }) {
-  const { t } = useTranslation('programs');
-  const image = getProgramImage(program.slug, program.goals);
+  const { t } = useTranslation(['programs', 'programs_data']);
+  const { title, description, goals } = localizedProgramFields(program, t);
+  const image = getProgramImage(program.slug, goals);
 
   return (
     <Link
@@ -35,13 +37,9 @@ export function ProgramCard({ program }: { program: Program }) {
 
           {/* Bottom: info */}
           <div className="space-y-2 mt-auto text-outline">
-            <h3 className="text-2xl font-bold text-white group-hover:text-white/90 transition-colors">
-              {program.title}
-            </h3>
+            <h3 className="text-2xl font-bold text-white group-hover:text-white/90 transition-colors">{title}</h3>
 
-            {program.description && (
-              <p className="text-sm text-white leading-relaxed line-clamp-2">{program.description}</p>
-            )}
+            {description && <p className="text-sm text-white leading-relaxed line-clamp-2">{description}</p>}
 
             <div className="flex items-center gap-3 text-xs text-white pt-1">
               <span className="flex items-center gap-1.5">
@@ -81,9 +79,9 @@ export function ProgramCard({ program }: { program: Program }) {
               </span>
             </div>
 
-            {program.goals.length > 0 && (
+            {goals.length > 0 && (
               <ul className="flex flex-wrap gap-2 pt-1">
-                {program.goals.map((goal) => (
+                {goals.map((goal) => (
                   <li
                     key={goal}
                     className="text-xs font-medium px-2.5 py-1 rounded-full bg-white/10 border border-white/15 text-white"

--- a/src/components/ProgramList.tsx
+++ b/src/components/ProgramList.tsx
@@ -8,12 +8,14 @@ import { useActiveProgram, usePrograms } from '../hooks/useProgram.ts';
 import { useUserPrograms } from '../hooks/useUserPrograms.ts';
 import { supabase } from '../lib/supabase.ts';
 import { getProgramImage } from '../utils/programImage.ts';
+import { localizedProgramFields } from '../utils/programLocale.ts';
+import { localizedSessionData } from '../utils/sessionLocale.ts';
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 import { LoadingSpinner } from './LoadingSpinner.tsx';
 import { ProgramCard } from './ProgramCard.tsx';
 
 export function ProgramList() {
-  const { t } = useTranslation('programs');
+  const { t } = useTranslation(['programs', 'programs_data', 'sessions_data']);
   const { user, profile } = useAuth();
   const { programs, loading } = usePrograms();
   const { programs: userPrograms, loading: userLoading } = useUserPrograms();
@@ -29,7 +31,19 @@ export function ProgramList() {
       ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
       : 0;
 
-  const activeImage = activeProgram ? getProgramImage(activeProgram.slug, activeProgram.goals) : '';
+  // The fixed (seed) programs were inserted FR-only in migration 002 — pull
+  // the localised title/goals from i18n so the active-program hero matches
+  // the user's current language.
+  const activeLocalized = activeProgram
+    ? localizedProgramFields(activeProgram, t)
+    : { title: '', description: null as string | null, goals: [] as string[] };
+
+  const activeImage = activeProgram ? getProgramImage(activeProgram.slug, activeLocalized.goals) : '';
+
+  const nextSessionTitle =
+    activeProgram?.nextSessionData && activeProgram.nextSessionOrder != null
+      ? localizedSessionData(activeProgram.slug, activeProgram.nextSessionOrder, activeProgram.nextSessionData, t).title
+      : (activeProgram?.nextSessionTitle ?? null);
 
   useDocumentHead({
     title: t('list.programs'),
@@ -88,7 +102,7 @@ export function ProgramList() {
                 {t('list.active_label')}
               </p>
               <h2 className="font-display text-xl md:text-2xl font-black text-white mb-2 truncate">
-                {activeProgram.title}
+                {activeLocalized.title}
               </h2>
               <div className="flex items-center gap-4 text-sm text-white/60">
                 <span>
@@ -97,10 +111,9 @@ export function ProgramList() {
                     total: activeProgram.totalSessions,
                   })}
                 </span>
-                {activeProgram.nextSessionTitle && (
+                {nextSessionTitle && (
                   <span className="truncate">
-                    {t('list.next_session')}{' '}
-                    <span className="text-white/90 font-semibold">{activeProgram.nextSessionTitle}</span>
+                    {t('list.next_session')} <span className="text-white/90 font-semibold">{nextSessionTitle}</span>
                   </span>
                 )}
               </div>
@@ -197,7 +210,7 @@ export function ProgramList() {
           <h2 className="text-xs font-bold uppercase tracking-wider text-subtle">{t('list.my_programs')}</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-5">
             {userPrograms.map((p) => {
-              const goalLabel = p.goals?.[0] ? t(`goal.${p.goals[0]}`) : '';
+              const goalLabel = p.goals?.[0] ?? '';
               const image = getProgramImage(p.slug, p.goals);
               return (
                 <Link

--- a/src/components/ProgramPage.tsx
+++ b/src/components/ProgramPage.tsx
@@ -10,12 +10,14 @@ import type { Session } from '../types/session.ts';
 import { getConsigneForWeek } from '../utils/coaching.ts';
 import { FITNESS_COLORS, GOAL_COLORS } from '../utils/labels.ts';
 import { getProgramImage } from '../utils/programImage.ts';
+import { localizedProgramFields } from '../utils/programLocale.ts';
+import { localizedSessionData } from '../utils/sessionLocale.ts';
 import { HealthDisclaimer } from './HealthDisclaimer.tsx';
 import { LoadingSpinner } from './LoadingSpinner.tsx';
 import { SessionAccordion } from './SessionAccordion.tsx';
 
 export function ProgramPage() {
-  const { t } = useTranslation('programs');
+  const { t } = useTranslation(['programs', 'programs_data', 'sessions_data']);
   const { slug } = useParams<{ slug: string }>();
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -27,9 +29,16 @@ export function ProgramPage() {
   const [collapsedWeeks, setCollapsedWeeks] = useState<Set<number>>(new Set());
   const deleteDialogRef = useRef<HTMLDivElement>(null);
 
+  // Fixed programs are seeded in French in the DB; the localised
+  // title/description/goals live in src/i18n/locales/{fr,en}/programs_data.json.
+  // Custom (AI) programs already store locale-native content.
+  const localized = program
+    ? localizedProgramFields(program, t)
+    : { title: '', description: null as string | null, goals: [] as string[] };
+
   useDocumentHead({
-    title: program ? `${program.title} ${t('page.title_suffix')}` : t('page.title_suffix'),
-    description: program?.description ?? undefined,
+    title: program ? `${localized.title} ${t('page.title_suffix')}` : t('page.title_suffix'),
+    description: localized.description ?? undefined,
   });
 
   const isCustom = program && !program.is_fixed;
@@ -192,7 +201,7 @@ export function ProgramPage() {
         <section className="space-y-5 -mx-6 -mt-8 md:mx-0 md:mt-0">
           <div className="relative min-h-[220px] sm:min-h-[280px] md:rounded-2xl overflow-hidden">
             <img
-              src={getProgramImage(program.slug, program.goals)}
+              src={getProgramImage(program.slug, localized.goals)}
               alt=""
               className="absolute inset-0 w-full h-full object-cover object-[50%_30%]"
             />
@@ -236,10 +245,12 @@ export function ProgramPage() {
                 </span>
 
                 <h1 className="font-display text-3xl md:text-4xl font-black tracking-tight text-white">
-                  {program.title}
+                  {localized.title}
                 </h1>
 
-                {program.description && <p className="text-sm leading-relaxed text-white/70">{program.description}</p>}
+                {localized.description && (
+                  <p className="text-sm leading-relaxed text-white/70">{localized.description}</p>
+                )}
 
                 <div className={`flex items-center gap-3 text-xs ${isCustom ? 'text-faint' : 'text-white/50'}`}>
                   <span className="flex items-center gap-1.5">
@@ -279,14 +290,14 @@ export function ProgramPage() {
                   </span>
                 </div>
 
-                {program.goals.length > 0 && (
+                {localized.goals.length > 0 && (
                   <ul className="flex flex-wrap gap-2">
-                    {program.goals.map((goal) => (
+                    {localized.goals.map((goal) => (
                       <li
                         key={goal}
                         className={`text-xs font-bold px-2.5 py-1 rounded-full text-white ${GOAL_COLORS[goal] ?? 'bg-rose-400/80'}`}
                       >
-                        {t(`goal.${goal}`) ?? goal}
+                        {goal}
                       </li>
                     ))}
                   </ul>
@@ -380,7 +391,7 @@ export function ProgramPage() {
               {!isCollapsed && (
                 <div className="space-y-3">
                   {sessions.map((ps) => {
-                    const data = ps.session_data as Session;
+                    const data = localizedSessionData(program.slug, ps.session_order, ps.session_data as Session, t);
                     const isDone = user ? program.completedSessionIds.has(ps.id) : false;
                     const isSuggested = user && ps.session_order === nextSessionOrder;
 

--- a/src/components/ProgramPlayerPage.tsx
+++ b/src/components/ProgramPlayerPage.tsx
@@ -5,6 +5,7 @@ import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { isHealthAccepted } from '../hooks/useHealthCheck.ts';
 import { useProgramSession } from '../hooks/useProgram.ts';
 import type { Session } from '../types/session.ts';
+import { localizedSessionData } from '../utils/sessionLocale.ts';
 import { PlayerLoader } from './LoadingSpinner.tsx';
 import { Player } from './Player.tsx';
 import { PlayerErrorBoundary } from './PlayerErrorBoundary.tsx';
@@ -13,11 +14,18 @@ import { SessionNotFound } from './SessionNotFound.tsx';
 export function ProgramPlayerPage() {
   const { slug, order } = useParams<{ slug: string; order: string }>();
   const { user, loading: authLoading } = useAuth();
-  const { t } = useTranslation('player');
+  const { t } = useTranslation(['player', 'sessions_data']);
   const orderNum = order ? Number.parseInt(order, 10) : undefined;
   const { session: programSession, loading } = useProgramSession(slug, orderNum);
 
-  const sessionData = programSession?.session_data as Session | undefined;
+  const dbSession = programSession?.session_data as Session | undefined;
+  // Fixed seed sessions are FR-only in the DB; their localised content
+  // lives in src/i18n/locales/{fr,en}/sessions_data.json. The helper is
+  // a no-op for AI-generated programs.
+  const sessionData =
+    dbSession && slug && programSession
+      ? localizedSessionData(slug, programSession.session_order, dbSession, t)
+      : dbSession;
 
   useDocumentHead({
     title: sessionData ? `${sessionData.title} — ${t('page.title_in_progress')}` : t('page.title_program'),

--- a/src/components/home/ConnectedContent.tsx
+++ b/src/components/home/ConnectedContent.tsx
@@ -5,7 +5,9 @@ import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useActiveProgram } from '../../hooks/useProgram.ts';
 import type { Session } from '../../types/session.ts';
 import { getProgramImage } from '../../utils/programImage.ts';
+import { localizedProgramFields } from '../../utils/programLocale.ts';
 import { getSessionImage } from '../../utils/sessionImage.ts';
+import { localizedSessionData } from '../../utils/sessionLocale.ts';
 import { DifficultyBadge } from '../DifficultyBadge.tsx';
 import { NutritionWidget } from '../nutrition/NutritionWidget.tsx';
 import { SessionAccordion } from '../SessionAccordion.tsx';
@@ -33,7 +35,7 @@ export function ConnectedContent({
   guardNavigation: (path: string) => void;
   formatShortDate: (key: string) => string;
 }) {
-  const { t } = useTranslation('home');
+  const { t } = useTranslation(['home', 'programs_data', 'sessions_data']);
   const { user, profile } = useAuth();
   const { activeProgram, loading: programLoading } = useActiveProgram(user?.id);
 
@@ -41,6 +43,19 @@ export function ConnectedContent({
     activeProgram && activeProgram.totalSessions > 0
       ? Math.round((activeProgram.completedCount / activeProgram.totalSessions) * 100)
       : 0;
+
+  // Fixed seed programs were inserted FR-only — pull the user's locale
+  // version from i18n. AI-generated programs already store locale-native
+  // content in the DB and are returned unchanged by the helper.
+  const activeLocalized = activeProgram
+    ? localizedProgramFields(activeProgram, t)
+    : { title: '', description: null as string | null, goals: [] as string[] };
+
+  const nextSession =
+    activeProgram?.nextSessionData && activeProgram.nextSessionOrder != null
+      ? localizedSessionData(activeProgram.slug, activeProgram.nextSessionOrder, activeProgram.nextSessionData, t)
+      : null;
+  const nextSessionTitle = nextSession?.title ?? activeProgram?.nextSessionTitle ?? null;
 
   const firstName = (profile?.display_name ?? user?.user_metadata?.display_name ?? '').split(' ')[0];
 
@@ -207,14 +222,14 @@ export function ConnectedContent({
                 </h4>
                 <Link to={`/programme/${activeProgram.slug}/suivi`} className="block relative h-36 group">
                   <img
-                    src={getProgramImage(activeProgram.slug, activeProgram.goals)}
-                    alt={activeProgram.title}
+                    src={getProgramImage(activeProgram.slug, activeLocalized.goals)}
+                    alt={activeLocalized.title}
                     className="w-full h-full object-cover object-[50%_30%]"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
                   <div className="absolute bottom-3 left-4 right-4">
                     <p className="font-display text-lg font-bold text-white leading-tight group-hover:text-white/80 transition-colors">
-                      {activeProgram.title.toUpperCase()}
+                      {activeLocalized.title.toUpperCase()}
                     </p>
                   </div>
                 </Link>
@@ -236,10 +251,10 @@ export function ConnectedContent({
                       />
                     </div>
                   </div>
-                  {activeProgram.nextSessionTitle && (
+                  {nextSessionTitle && (
                     <p className="text-xs text-muted mt-3">
                       {t('connected.program_card.next_session')}{' '}
-                      <span className="text-heading font-semibold">{activeProgram.nextSessionTitle}</span>
+                      <span className="text-heading font-semibold">{nextSessionTitle}</span>
                     </p>
                   )}
                   {activeProgram.nextSessionOrder != null && (
@@ -257,7 +272,7 @@ export function ConnectedContent({
                     </button>
                   )}
                 </div>
-                {activeProgram.nextSessionData && <SessionAccordion session={activeProgram.nextSessionData} />}
+                {nextSession && <SessionAccordion session={nextSession} />}
               </div>
             ) : (
               <Link

--- a/src/components/stats/ProgramCard.tsx
+++ b/src/components/stats/ProgramCard.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { useActiveProgram } from '../../hooks/useProgram.ts';
+import { localizedProgramFields } from '../../utils/programLocale.ts';
+import { localizedSessionData } from '../../utils/sessionLocale.ts';
 import { AnimatedNumber } from './AnimatedNumber.tsx';
 
 export interface ProgramCardProps {
@@ -9,10 +11,16 @@ export interface ProgramCardProps {
 }
 
 export function ProgramCard({ activeProgram, progressPct }: ProgramCardProps) {
-  const { t } = useTranslation('stats');
+  const { t } = useTranslation(['stats', 'programs_data', 'sessions_data']);
   const radius = 32;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - progressPct / 100);
+
+  const localizedProgram = localizedProgramFields(activeProgram, t);
+  const nextSessionTitle =
+    activeProgram.nextSessionData && activeProgram.nextSessionOrder != null
+      ? localizedSessionData(activeProgram.slug, activeProgram.nextSessionOrder, activeProgram.nextSessionData, t).title
+      : activeProgram.nextSessionTitle;
 
   return (
     <div className="flex items-center gap-5">
@@ -47,7 +55,7 @@ export function ProgramCard({ activeProgram, progressPct }: ProgramCardProps) {
       <div className="flex-1 min-w-0">
         <p className="text-xs font-bold uppercase tracking-wider text-brand mb-1">{t('program_card.active_label')}</p>
         <p className="text-base font-bold text-heading group-hover:text-brand transition-colors truncate">
-          {activeProgram.title}
+          {localizedProgram.title}
         </p>
         <p className="text-xs text-muted mt-1">
           {t('program_card.sessions_progress', {
@@ -55,10 +63,10 @@ export function ProgramCard({ activeProgram, progressPct }: ProgramCardProps) {
             total: activeProgram.totalSessions,
           })}
         </p>
-        {activeProgram.nextSessionTitle && (
+        {nextSessionTitle && (
           <p className="text-xs text-muted mt-1 flex items-center gap-1">
             {t('program_card.next_session')}{' '}
-            <span className="text-heading font-semibold truncate">{activeProgram.nextSessionTitle}</span>
+            <span className="text-heading font-semibold truncate">{nextSessionTitle}</span>
             <ChevronRight className="w-3 h-3 text-muted shrink-0" aria-hidden="true" />
           </p>
         )}

--- a/src/i18n/locales/en/programs_data.json
+++ b/src/i18n/locales/en/programs_data.json
@@ -1,5 +1,8 @@
 {
   "debutant-4-semaines": {
+    "title": "Beginner — 4 weeks",
+    "description": "A progressive program to ease into working out",
+    "goals": ["Discover the basic movements", "Build a routine", "Improve mobility"],
     "headline": "Build your foundations",
     "intro": "Getting back into sport or starting out? This 4-week program guides you step by step. Each week adds a little more intensity so you progress without ever feeling overwhelmed.",
     "audience": "Returning to activity, true beginners, or anyone who wants to (re)start on solid ground.",
@@ -34,6 +37,9 @@
     "tip": "No need to push hard from day one. Consistency is what matters most. 3 sessions per week is enough to see real results in a month."
   },
   "remise-en-forme": {
+    "title": "Get back in shape",
+    "description": "Comprehensive cardio and strength training program",
+    "goals": ["Get back in shape", "Burn calories", "Strengthen the whole body"],
     "headline": "Find your rhythm back",
     "intro": "You used to train but fell off the wagon? This program gets things back on track. Varied formats from the first week, progressive intensity — you'll find your feel quickly.",
     "audience": "Former athletes getting back in shape, or intermediate-level people who want to structure their training.",
@@ -68,6 +74,9 @@
     "tip": "If a session feels easy, that's normal — it means you're in shape for it. The following week will raise the bar."
   },
   "cardio-express": {
+    "title": "Cardio Express",
+    "description": "Short and intense HIIT and Tabata sessions",
+    "goals": ["Improve cardio", "Maximize your time", "Push your limits"],
     "headline": "Short, intense, effective",
     "intro": "No time for an hour of sport? This program bets on short, high-intensity sessions. 20 minutes is all it takes to sweat, progress, and get back to your day.",
     "audience": "Busy schedules, athletes who want results without spending hours training.",

--- a/src/i18n/locales/en/sessions_data.json
+++ b/src/i18n/locales/en/sessions_data.json
@@ -1,0 +1,1569 @@
+{
+  "cardio-express": {
+    "1": {
+      "title": "Fat-Burning HIIT",
+      "description": "Short high-intensity intervals to maximize calorie burn",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Quick warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Steady pace, arms fully extended overhead" },
+            { "name": "High knees", "instructions": "Drive knees above hip height, build pace progressively" },
+            { "name": "Dynamic arm circles", "instructions": "Large fast circles, forward then backward" }
+          ]
+        },
+        {
+          "name": "Fat-Burning HIIT",
+          "exercises": [
+            { "name": "Burpees", "instructions": "Drop to plank, push-up, stand and jump" },
+            {
+              "name": "Mountain climbers",
+              "instructions": "In plank, alternate driving knees toward your chest rapidly"
+            },
+            { "name": "Jump squats", "instructions": "Deep squat, explode upward, land softly" },
+            { "name": "Plank shoulder taps", "instructions": "High plank, alternately tap the opposite shoulder" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Gradually bring your heart rate down" },
+            {
+              "name": "Quad stretch",
+              "instructions": "Standing, grab your foot behind you, keep your knee pointing down"
+            },
+            {
+              "name": "Deep breathing",
+              "instructions": "Inhale 4s through the nose, exhale 6s through the mouth — 4 cycles"
+            }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Explosive Tabata",
+      "description": "Classic 20/10 Tabata format to spike your cardio in minimal time",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Quick warm-up",
+          "exercises": [
+            { "name": "Jogging in place", "instructions": "Light jog, build pace gradually" },
+            { "name": "Dynamic squats", "instructions": "Fast squats, rise onto your toes at the top" },
+            { "name": "Torso rotations", "instructions": "Feet planted, rotate your upper body dynamically" }
+          ]
+        },
+        {
+          "name": "Full-Body Tabata",
+          "exercises": [
+            { "name": "Burpees without jump", "instructions": "Drop to the floor, stand back up as fast as possible" },
+            {
+              "name": "Speed skaters",
+              "instructions": "Lateral jumps, touch the floor with the hand opposite the landing foot"
+            },
+            { "name": "High knees sprint", "instructions": "Sprint in place, drive knees as high as possible" },
+            { "name": "Plank jumping jacks", "instructions": "In plank, jump feet out wide then back together" }
+          ]
+        },
+        {
+          "name": "Express cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Ease your heart rate down by walking gently" },
+            { "name": "Calf stretch", "instructions": "Step one foot forward, push the back heel into the floor" },
+            { "name": "Hamstring stretch", "instructions": "Extend one leg in front, hinge forward at the hips" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Intense Cardio Circuit",
+      "description": "Variety of exercises in a circuit to build cardio and endurance",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Lateral shuffles", "instructions": "Dynamic side steps, stay low on your feet" },
+            { "name": "Knee drives with arms", "instructions": "Drive knees up while pushing arms overhead" },
+            { "name": "Dynamic forward lunges", "instructions": "Long strides forward, arms moving in opposition" }
+          ]
+        },
+        {
+          "name": "High-Energy Circuit",
+          "exercises": [
+            { "name": "Full burpees", "instructions": "Plank, push-up, explosive jump — keep the pace" },
+            {
+              "name": "Mountain climbers sprint",
+              "instructions": "Plank position, drive knees to your chest as fast as possible"
+            },
+            { "name": "Jump squats", "instructions": "Controlled descent, explosive jump, land flat-footed" },
+            {
+              "name": "Jumping lunges",
+              "instructions": "Alternate lunges with a jump, stay braced through the movement"
+            },
+            {
+              "name": "Commando planks",
+              "instructions": "Alternate between forearm plank and high plank without rotating your hips"
+            }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Decelerate gradually" },
+            { "name": "Hip flexor stretch", "instructions": "Back knee on the floor, push hips forward" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s — 3 cycles" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "HIIT Acceleration",
+      "description": "More rounds, less rest — stepping up the intensity",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Progressive jumping jacks", "instructions": "Start slow, accelerate through the final seconds" },
+            {
+              "name": "High knees",
+              "instructions": "Drive knees high, arms pumping in opposition, keep a steady pace"
+            },
+            {
+              "name": "World's greatest stretch",
+              "instructions": "Lunge, hand to floor, rotate torso and lift opposite arm"
+            }
+          ]
+        },
+        {
+          "name": "HIIT Acceleration",
+          "exercises": [
+            { "name": "Burpees with push-up", "instructions": "Drop to the floor, full push-up, stand and jump" },
+            { "name": "Jump squats", "instructions": "Deep squat, jump as high as possible" },
+            {
+              "name": "Cross-body mountain climbers",
+              "instructions": "Drive knee toward opposite elbow in plank, keep pace high"
+            },
+            {
+              "name": "Jumping lunges",
+              "instructions": "Alternate lunges with a jump, back knee nearly touches the floor"
+            },
+            {
+              "name": "Plank shoulder taps",
+              "instructions": "In high plank, tap opposite shoulder without rotating your hips"
+            }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Fully decelerate, take long breaths" },
+            { "name": "Quad stretch", "instructions": "Grab your foot, pull heel toward your glutes" },
+            { "name": "Chest stretch", "instructions": "Arm extended against a wall, rotate your torso away" }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Double Impact Tabata",
+      "description": "Two targeted Tabata blocks: legs then upper body",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Quick warm-up",
+          "exercises": [
+            { "name": "Dynamic squats", "instructions": "Fast squats, rise onto your toes" },
+            { "name": "Incline push-ups", "instructions": "Hands on a chair, fast push-ups" },
+            { "name": "Jumping jacks", "instructions": "High pace to get your heart rate up" }
+          ]
+        },
+        {
+          "name": "Tabata Legs",
+          "exercises": [
+            { "name": "Jump squats", "instructions": "Explosive squat, jump as high as possible, land softly" },
+            { "name": "Deep speed skaters", "instructions": "Wide lateral jumps, descend low, touch the floor" },
+            { "name": "Jumping lunges", "instructions": "Alternate lunges by exploding upward" },
+            { "name": "Squat pulses", "instructions": "Hold the bottom of your squat and pulse rapidly" }
+          ]
+        },
+        {
+          "name": "Tabata Upper Body",
+          "exercises": [
+            { "name": "Fast push-ups", "instructions": "Max-pace push-ups, chest to floor" },
+            { "name": "Fast commando planks", "instructions": "Move from forearms to hands as fast as possible" },
+            { "name": "Mountain climbers sprint", "instructions": "Sprint knees to chest in plank" },
+            { "name": "Pike push-ups", "instructions": "Inverted-V position, shoulder-focused push-ups, fast pace" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Wind down progressively" },
+            { "name": "Hamstring stretch", "instructions": "Leg extended in front, hinge forward" },
+            { "name": "Shoulder stretch", "instructions": "Pull one arm across your chest with the other hand" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Endurance-Power Circuit",
+      "description": "Longer circuit with compound exercises for endurance",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            {
+              "name": "Bear crawl",
+              "instructions": "Move forward and back on all fours, knees hovering off the floor"
+            },
+            { "name": "Dynamic forward lunges", "instructions": "Long forward strides" },
+            { "name": "Jumping jacks", "instructions": "High pace" }
+          ]
+        },
+        {
+          "name": "Power Circuit",
+          "exercises": [
+            { "name": "Full burpees", "instructions": "Plank, push-up, explosive jump" },
+            {
+              "name": "Squat pulse jumps",
+              "instructions": "3 pulses at the bottom of the squat then an explosive jump"
+            },
+            { "name": "Mountain climbers sprint", "instructions": "Maximum pace in plank" },
+            { "name": "Tuck jumps", "instructions": "Jump and pull your knees to your chest" },
+            { "name": "Plank knee taps", "instructions": "In plank, alternately tap each knee with the opposite hand" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Fully decelerate" },
+            { "name": "Deep calf stretch", "instructions": "Back foot flat on the floor, push through the heel" },
+            { "name": "Child's pose", "instructions": "Knees on the floor, arms extended in front" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "Maximum Power HIIT",
+      "description": "Long rounds, short rest — advanced exercises",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Intense warm-up",
+          "exercises": [
+            { "name": "Slow burpees", "instructions": "5 controlled burpees to warm up" },
+            { "name": "Light jumping lunges", "instructions": "Small hops between lunges" },
+            { "name": "Bear crawl", "instructions": "Move forward on all fours, knees hovering" }
+          ]
+        },
+        {
+          "name": "Power HIIT",
+          "exercises": [
+            {
+              "name": "Burpees with tuck jump",
+              "instructions": "Full burpee with a tuck jump instead of a regular jump"
+            },
+            { "name": "Tuck jump squats", "instructions": "Deep squat, jump and pull your knees to your chest" },
+            { "name": "Sprint mountain climbers", "instructions": "In plank, sprint your knees as fast as possible" },
+            { "name": "Explosive jumping lunges", "instructions": "Lunge jumps with maximum height" },
+            { "name": "Sprawls", "instructions": "Throw yourself flat to the floor, explode back up" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Very slow walk", "instructions": "Long nasal breaths" },
+            { "name": "Inner thigh stretch", "instructions": "Feet wide apart, lower gently" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "Infernal Tabata",
+      "description": "3 Tabata sets with no break",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Express warm-up",
+          "exercises": [
+            { "name": "Sprint in place", "instructions": "Run in place at 70% intensity" },
+            { "name": "Scorpion stretch", "instructions": "On your stomach, lift one foot toward the opposite hand" },
+            { "name": "Light jump squats", "instructions": "Small hops out of the squat" }
+          ]
+        },
+        {
+          "name": "Explosive Tabata Set A",
+          "exercises": [
+            { "name": "Burpees with tuck jump", "instructions": "Full burpee finishing with a knees-to-chest jump" },
+            { "name": "Speed skaters", "instructions": "Fast lateral jumps, touch the floor" },
+            { "name": "180° jump squats", "instructions": "Squat, jump and spin a full half-turn" },
+            { "name": "Plyometric push-ups", "instructions": "Explosive push-up, hands leave the floor" }
+          ]
+        },
+        {
+          "name": "Explosive Tabata Set B",
+          "exercises": [
+            { "name": "High knees sprint", "instructions": "Drive knees as high as possible, maximum speed" },
+            { "name": "Plank up-downs", "instructions": "Move from forearms to hands without swaying" },
+            { "name": "Fast jumping lunges", "instructions": "Alternating lunge jumps as fast as possible" },
+            { "name": "Sprawl to jump", "instructions": "Throw yourself to the floor, get up and jump immediately" }
+          ]
+        },
+        {
+          "name": "Tabata Finisher",
+          "exercises": [
+            { "name": "All-out burpees", "instructions": "Burpees at maximum speed" },
+            { "name": "Tuck jumps", "instructions": "Jump and pull knees to your chest" },
+            { "name": "Mountain climbers sprint", "instructions": "As fast as you can" },
+            { "name": "Star jumps", "instructions": "Jump wide, arms and legs spread" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Bring your heart rate down" },
+            { "name": "Deep calf stretch", "instructions": "Back foot flat on the floor" },
+            { "name": "Pigeon stretch", "instructions": "Front leg bent, sink your chest toward the floor" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "High-Intensity Circuit",
+      "description": "Advanced exercises, minimal rest",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Inchworms with push-up", "instructions": "Walk hands out to plank, push-up, walk back up" },
+            { "name": "Carioca", "instructions": "Lateral cross-step shuffle, quick feet" },
+            { "name": "High skipping", "instructions": "Skip with very high knee drive" }
+          ]
+        },
+        {
+          "name": "Circuit Level Up",
+          "exercises": [
+            { "name": "Burpees with tuck jump", "instructions": "Full burpee with a knees-to-chest jump" },
+            { "name": "Spider-Man mountain climbers", "instructions": "Drive knee toward the elbow on the same side" },
+            { "name": "Star jump squats", "instructions": "Deep squat, explode into a star jump" },
+            { "name": "Commando push-ups", "instructions": "Alternate forearm plank and high plank" },
+            { "name": "Broad jump burpees", "instructions": "Broad jump, then burpee on landing" },
+            { "name": "High knees sprint", "instructions": "Knees high sprint, absolute speed" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Wind down, shake out arms and legs" },
+            { "name": "Seated glute stretch", "instructions": "Cross ankle over knee, pull" },
+            { "name": "Breathing savasana", "instructions": "Lie on your back, breathe for 5 cycles" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "Ultimate HIIT",
+      "description": "The peak of the program — long work, short rest",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Intense warm-up",
+          "exercises": [
+            { "name": "Tempo burpees", "instructions": "Full burpees at a moderate tempo" },
+            { "name": "High knees with arms", "instructions": "Drive knees high, reach arms overhead" },
+            { "name": "Walking lunges with twist", "instructions": "Stride forward into a lunge, rotate your torso" }
+          ]
+        },
+        {
+          "name": "HIIT 45/15",
+          "exercises": [
+            { "name": "Devil press", "instructions": "Burpee, stand up and jump with arms overhead" },
+            { "name": "Tuck jump squats", "instructions": "Deep squat, jump and tuck knees to chest" },
+            { "name": "Mountain climbers sprint", "instructions": "Drive knees to your chest at maximum speed" },
+            { "name": "Alternating jumping lunges", "instructions": "Deep lunge jumps, pure explosiveness" },
+            { "name": "Sprawl to broad jump", "instructions": "Sprawl to the floor, stand and broad jump" },
+            { "name": "Plank jacks to push-up", "instructions": "Two plank jacks then one explosive push-up" }
+          ]
+        },
+        {
+          "name": "Final cooldown",
+          "exercises": [
+            { "name": "Very slow walk", "instructions": "Bring your heart rate down gently" },
+            { "name": "Deep quad stretch", "instructions": "Grab your foot, push your hip forward" },
+            { "name": "Back stretch", "instructions": "Seated, legs extended, hinge forward" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "All-Out Tabata",
+      "description": "Three Tabata sets with the most demanding exercises",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Full warm-up",
+          "exercises": [
+            { "name": "Progressive jumping jacks", "instructions": "Start slow, finish at maximum speed" },
+            { "name": "World's greatest stretch", "instructions": "Lunge, hand to floor, rotate torso upward" },
+            { "name": "Crescendo jump squats", "instructions": "Jump a little higher with each rep" }
+          ]
+        },
+        {
+          "name": "Tabata Devastation Set 1",
+          "exercises": [
+            { "name": "Burpee broad jumps", "instructions": "Burpee then broad jump forward, turn around" },
+            { "name": "Continuous 180° jump squats", "instructions": "Jump squat with half-turn, never stop" },
+            { "name": "Explosive sprawls", "instructions": "Throw yourself to the floor, explode back up" },
+            { "name": "Star jumps", "instructions": "Full star jump at maximum range" }
+          ]
+        },
+        {
+          "name": "Tabata Devastation Set 2",
+          "exercises": [
+            { "name": "Burpees with tuck jump", "instructions": "Burpee finishing with a tuck jump" },
+            { "name": "Wide plyometric push-ups", "instructions": "Explosive push-ups, hands leave and land wide" },
+            { "name": "Deep speed skaters", "instructions": "Wide lateral jumps, descend very low" },
+            { "name": "All-out high knees", "instructions": "Sprint in place at 100% effort" }
+          ]
+        },
+        {
+          "name": "Recovery stretches",
+          "exercises": [
+            { "name": "Recovery walk", "instructions": "Walk very slowly, breathe through your nose" },
+            { "name": "Hamstring stretch", "instructions": "Heel on a surface, hinge forward" },
+            { "name": "Cobra stretch", "instructions": "On your stomach, push through your hands to open your chest" },
+            { "name": "Full breathing", "instructions": "Inhale into belly, ribs, chest — exhale slowly" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "Final Boss Circuit",
+      "description": "The hardest circuit of the program — minimal rest, maximum rounds",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Maximum activation",
+          "exercises": [
+            { "name": "Controlled burpees", "instructions": "Full burpees at a moderate pace" },
+            { "name": "Lateral shuffles", "instructions": "Fast side-to-side shuffles, touch the floor" },
+            { "name": "A-skips", "instructions": "High knee skips moving forward, arms in opposition" }
+          ]
+        },
+        {
+          "name": "Final Circuit",
+          "exercises": [
+            { "name": "Burpee tuck jump broad jump", "instructions": "Burpee, tuck jump, broad jump — the full trio" },
+            { "name": "Mountain climbers sprint", "instructions": "Absolute speed, hips low" },
+            { "name": "360° jump squats", "instructions": "Deep squat, jump and spin a full rotation" },
+            { "name": "Superman push-ups", "instructions": "Explosive push-up, lift arms and legs off the floor" },
+            { "name": "High knees to tuck jumps", "instructions": "4 fast high knees then 1 tuck jump" },
+            { "name": "Sprawl with rotation", "instructions": "Sprawl to the floor, stand up and turn 180°" }
+          ]
+        },
+        {
+          "name": "Program final cooldown",
+          "exercises": [
+            { "name": "Very slow walk", "instructions": "Let your heart rate drop" },
+            { "name": "Full leg stretch", "instructions": "Deep lunge, alternate sides" },
+            { "name": "Pigeon stretch", "instructions": "Front leg bent, release your hips" },
+            { "name": "Final savasana", "instructions": "Lie down, arms out wide, palms up — program complete" }
+          ]
+        }
+      ]
+    }
+  },
+  "debutant-4-semaines": {
+    "1": {
+      "title": "Full-Body Discovery",
+      "description": "First fundamental movements: squats, modified push-ups and core work",
+      "focus": ["full-body", "mobility"],
+      "blocks": [
+        {
+          "name": "Gentle warm-up",
+          "exercises": [
+            {
+              "name": "Joint rotations",
+              "instructions": "Neck, shoulders, wrists, hips, ankles — slow and controlled"
+            },
+            { "name": "Walking in place", "instructions": "Gradually raise your knees, swing your arms" },
+            { "name": "Hip circles", "instructions": "Hands on hips, large circles in both directions" }
+          ]
+        },
+        {
+          "name": "Fundamentals",
+          "exercises": [
+            {
+              "name": "Assisted squats",
+              "instructions": "Feet shoulder-width apart, sit back as if into a chair, hands forward for balance"
+            },
+            {
+              "name": "Knee push-ups",
+              "instructions": "Hands shoulder-width apart, knees on the floor, lower your chest to the ground"
+            },
+            {
+              "name": "Knee plank",
+              "instructions": "Forearms on the floor, knees down, body aligned, hold for 20 seconds"
+            },
+            {
+              "name": "Glute bridge",
+              "instructions": "Lying on your back, feet flat, lift your hips by squeezing your glutes"
+            }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Quad stretch", "instructions": "Standing, grab your foot behind you, each leg" },
+            { "name": "Hamstring stretch", "instructions": "Seated, legs extended, hinge forward at the hips" },
+            { "name": "Chest stretch", "instructions": "Arm against a wall, gently rotate your torso away" }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Easy Cardio",
+      "description": "Light circuit to activate cardio without stressing your joints",
+      "focus": ["cardio", "endurance"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Brisk walking in place", "instructions": "Accelerate gradually, use big arm swings" },
+            { "name": "Light heel flicks", "instructions": "In place, gently flick your heels toward your glutes" },
+            { "name": "Torso rotations", "instructions": "Feet planted, rotate your upper body left and right" }
+          ]
+        },
+        {
+          "name": "Beginner Cardio Circuit",
+          "exercises": [
+            { "name": "Lateral shuffles", "instructions": "Dynamic side steps, stay low" },
+            { "name": "Knee drives", "instructions": "Lift knees to hip height, moderate pace" },
+            { "name": "Sumo squats", "instructions": "Feet wide, toes out, lower slowly" },
+            { "name": "Bear walk", "instructions": "On all fours, knees hovering, move forward and back" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk in place", "instructions": "Ease down gradually, breathe deeply" },
+            { "name": "Calf stretch", "instructions": "One foot forward, press the back heel into the floor" },
+            { "name": "Deep breathing", "instructions": "Inhale 4s, hold 4s, exhale 4s — 3 cycles" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Strength & Core",
+      "description": "Core and posture focus with controlled and accessible movements",
+      "focus": ["core", "posture"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            {
+              "name": "Cat-cow",
+              "instructions": "On all fours, alternate rounding and arching your back with your breath"
+            },
+            {
+              "name": "Thoracic rotation",
+              "instructions": "On all fours, one hand behind your head, open your elbow toward the sky"
+            },
+            { "name": "Arm swings", "instructions": "Standing, let your arms swing loosely side to side" }
+          ]
+        },
+        {
+          "name": "Core & Posture",
+          "exercises": [
+            {
+              "name": "Dead bug",
+              "instructions": "Lying down, arms reaching toward the ceiling, extend one leg and the opposite arm"
+            },
+            { "name": "Superman", "instructions": "Lying face down, lift arms and legs simultaneously, hold for 2s" },
+            {
+              "name": "Side plank on knees",
+              "instructions": "Elbow and knee on the floor, body aligned, hold 15 seconds each side"
+            },
+            {
+              "name": "Reverse lunges",
+              "instructions": "Take a big step back, back knee nearly touches the floor, stand up"
+            }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Knees on the floor, arms extended in front, release your back" },
+            {
+              "name": "Supine twist",
+              "instructions": "Lying down, draw one knee toward your chest and let it fall to the opposite side"
+            },
+            { "name": "Psoas stretch", "instructions": "Low lunge, push the hip of the back knee forward" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "Full-Body Progression",
+      "description": "Back to the fundamentals with more volume and less rest",
+      "focus": ["full-body", "strength"],
+      "blocks": [
+        {
+          "name": "Active warm-up",
+          "exercises": [
+            { "name": "Light jumping jacks", "instructions": "Moderate jumps, arms overhead, comfortable pace" },
+            { "name": "Arm circles", "instructions": "Small circles then large circles, forward then backward" },
+            {
+              "name": "Mobility squats",
+              "instructions": "Lower slowly into a deep squat, elbows inside knees to open the hips"
+            }
+          ]
+        },
+        {
+          "name": "Full-body strength",
+          "exercises": [
+            {
+              "name": "Squats",
+              "instructions": "Feet shoulder-width apart, controlled descent, drive through your heels"
+            },
+            {
+              "name": "Knee push-ups",
+              "instructions": "Lower your chest to the floor, push up as you exhale, keep your core tight"
+            },
+            {
+              "name": "Alternating lunges",
+              "instructions": "Big step forward, back knee near the floor, alternate legs"
+            },
+            { "name": "Knee plank", "instructions": "Forearms on floor, knees down, brace your core, hold 25 seconds" },
+            {
+              "name": "Glute bridge",
+              "instructions": "Lift your hips, squeeze your glutes at the top for 2 seconds, lower down"
+            }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            {
+              "name": "Standing quad stretch",
+              "instructions": "Grab your foot, pull heel toward glutes, keep knee pointing down"
+            },
+            {
+              "name": "Hip flexor stretch",
+              "instructions": "Back knee on the floor, shift pelvis forward, feel the stretch at the front of the hip"
+            },
+            {
+              "name": "Back stretch",
+              "instructions": "Standing, clasp hands in front, round your back and push hands away"
+            }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Progressive Cardio",
+      "description": "Longer circuits with dynamic movements",
+      "focus": ["cardio", "endurance"],
+      "blocks": [
+        {
+          "name": "Cardio warm-up",
+          "exercises": [
+            { "name": "Moderate knee drives", "instructions": "Lift knees above hip height" },
+            { "name": "Lateral shuffles", "instructions": "Fast side steps" },
+            { "name": "Dynamic hip circles", "instructions": "Lift one knee and draw a circle" }
+          ]
+        },
+        {
+          "name": "Endurance Circuit",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Jumps with arms reaching overhead" },
+            { "name": "Squats with toe raise", "instructions": "Regular squat, rise onto your toes at the top" },
+            { "name": "Slow mountain climbers", "instructions": "Push-up position, drive one knee toward your chest" },
+            { "name": "Lateral shuffles + floor touch", "instructions": "Three side steps, touch the floor" },
+            { "name": "Light jumping lunges", "instructions": "Small hops to alternate legs" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Wind down gradually" },
+            { "name": "Wall calf stretch", "instructions": "Hands on the wall, one foot back" },
+            { "name": "Standing inner thigh stretch", "instructions": "Feet very wide, bend one knee" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Core & Stability",
+      "description": "Strengthening your center",
+      "focus": ["core", "stability"],
+      "blocks": [
+        {
+          "name": "Targeted warm-up",
+          "exercises": [
+            { "name": "Cat-cow", "instructions": "Round your back on the exhale, arch on the inhale" },
+            { "name": "Glute bridge", "instructions": "Lift your hips over 3 seconds, hold for 2 seconds" },
+            { "name": "Alternating bird dogs", "instructions": "On all fours, extend right arm and left leg" }
+          ]
+        },
+        {
+          "name": "Core & Control",
+          "exercises": [
+            { "name": "Dead bug", "instructions": "Back flat on the floor, extend opposite arm and leg" },
+            { "name": "Superman with hold", "instructions": "Lift arms and legs, hold for 3 seconds at the top" },
+            { "name": "Knee plank", "instructions": "Forearms on floor, knees down, hold 30 seconds" },
+            { "name": "Side plank on knees", "instructions": "Elbow and knee on the floor, hips raised" },
+            { "name": "Reverse crunch", "instructions": "Knees at 90°, pull knees toward your chest" }
+          ]
+        },
+        {
+          "name": "Deep stretches",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Hips back toward heels, arms extended in front" },
+            { "name": "Gentle cobra", "instructions": "Lying face down, gently lift your upper body" },
+            { "name": "Seated twist", "instructions": "Seated with legs crossed, rotate your torso" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "Intermediate Full-Body",
+      "description": "Full versions of the fundamental movements",
+      "focus": ["full-body", "strength"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Moderate pace, arms fully extended" },
+            { "name": "Mobility lunges", "instructions": "Deep forward lunge, elbow toward the front foot" },
+            { "name": "Inchworm", "instructions": "Standing, walk hands to plank position" }
+          ]
+        },
+        {
+          "name": "Full strength",
+          "exercises": [
+            { "name": "Squats", "instructions": "2-second descent, exhale on the way up" },
+            { "name": "Push-ups", "instructions": "Body braced, chest to floor, elbows at 45°" },
+            { "name": "Reverse lunges", "instructions": "Big step back, back knee near the floor" },
+            { "name": "Full plank", "instructions": "Forearms and toes, body in a straight line" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Piriforme stretch", "instructions": "Cross one ankle over the opposite knee" },
+            { "name": "Shoulder stretch", "instructions": "Pull one arm across your chest with the other hand" },
+            { "name": "Standing hamstring stretch", "instructions": "One foot on a raised surface, leg straight" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "EMOM Cardio",
+      "description": "EMOM format to structure your cardio effort",
+      "focus": ["cardio", "rhythm"],
+      "blocks": [
+        {
+          "name": "Cardio activation",
+          "exercises": [
+            { "name": "Running in place", "instructions": "Light jog in place, build pace" },
+            { "name": "Dynamic knee drives", "instructions": "High knees, arms pumping in opposition" },
+            { "name": "Light jump squats", "instructions": "Regular squat then a small hop" }
+          ]
+        },
+        {
+          "name": "EMOM Cardio 8 min",
+          "exercises": [
+            { "name": "Burpees without jump", "instructions": "Drop to the floor, stand back up" },
+            { "name": "Fast knee drives", "instructions": "Drive knees above hip height, quick pace" }
+          ]
+        },
+        {
+          "name": "Cardio finisher",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Fast pace, arms extended" },
+            { "name": "Dynamic sumo squats", "instructions": "Feet wide, lower and rise without pausing" },
+            { "name": "Plank shoulder taps", "instructions": "Push-up position, tap the opposite shoulder" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Wind down gradually" },
+            { "name": "Quad stretch", "instructions": "Standing, grab one foot" },
+            { "name": "Diaphragmatic breathing", "instructions": "Hands on your belly, inhale 5s, exhale 5s" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "Advanced Core",
+      "description": "Full plank holds and stability exercises",
+      "focus": ["core", "stability"],
+      "blocks": [
+        {
+          "name": "Core wake-up",
+          "exercises": [
+            { "name": "Dynamic cat-cow", "instructions": "Alternate rounding and arching quickly" },
+            { "name": "Slow dead bug", "instructions": "Arms and legs in the air, extend slowly" },
+            { "name": "Standing thoracic rotation", "instructions": "Arms crossed, rotate your upper body" }
+          ]
+        },
+        {
+          "name": "Reinforced core",
+          "exercises": [
+            { "name": "Full plank", "instructions": "Forearms and toes, body perfectly aligned" },
+            { "name": "Side plank", "instructions": "Elbow and stacked feet on the floor, hips raised" },
+            { "name": "Dead bug with full extension", "instructions": "Back flat on the floor, extend fully" },
+            { "name": "Bicycle crunches", "instructions": "Drive elbow toward opposite knee in a pedaling motion" },
+            { "name": "Swimmer Superman", "instructions": "Lift arms and legs, alternate as if swimming" }
+          ]
+        },
+        {
+          "name": "Deep stretches",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Knees wide, arms extended in front" },
+            { "name": "Cobra", "instructions": "On your stomach, push through your hands to lift your chest" },
+            { "name": "Supine twist", "instructions": "Arms in a T, knees to one side" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "Full-Body Challenge",
+      "description": "Combined movements and supersets",
+      "focus": ["full-body", "muscular endurance"],
+      "blocks": [
+        {
+          "name": "Full warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Steady pace, arms fully extended" },
+            { "name": "Inchworm + push-up", "instructions": "Walk out to plank, 1 push-up, walk back up" },
+            { "name": "Squat + torso rotation", "instructions": "Squat down, rotate your torso" }
+          ]
+        },
+        {
+          "name": "Full-Body Supersets",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Squats", "instructions": "2-second descent, explosive rise" },
+                { "name": "Push-ups", "instructions": "Body braced, controlled descent" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Alternating lunges", "instructions": "Big step forward, back knee near the floor" },
+                { "name": "Plank shoulder taps", "instructions": "Push-up position, tap the opposite shoulder" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Finisher",
+          "exercises": [
+            { "name": "Walking glute bridge", "instructions": "Hips up, take a step forward" },
+            { "name": "Full plank", "instructions": "Straight body, brace core and glutes" }
+          ]
+        },
+        {
+          "name": "Full stretches",
+          "exercises": [
+            { "name": "Quad stretch", "instructions": "Grab your foot, pull toward your glutes" },
+            { "name": "Wall chest stretch", "instructions": "Arm in an L against the wall" },
+            { "name": "Child's pose", "instructions": "Hips to heels, arms extended in front" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "Intense Cardio",
+      "description": "Demanding circuit combining compound movements",
+      "focus": ["cardio", "power"],
+      "blocks": [
+        {
+          "name": "Intense activation",
+          "exercises": [
+            { "name": "Running in place", "instructions": "Build pace progressively" },
+            { "name": "Jump squats", "instructions": "Deep squat, jump as you come up" },
+            { "name": "Slow mountain climbers", "instructions": "Plank position, drive knees in" }
+          ]
+        },
+        {
+          "name": "High-Energy Circuit",
+          "exercises": [
+            { "name": "Burpees without jump", "instructions": "Drop to the floor, stand back up" },
+            { "name": "Fast mountain climbers", "instructions": "Alternate knees to chest quickly" },
+            { "name": "Jump squats", "instructions": "Controlled descent, explosive jump" },
+            { "name": "Plank with rotation", "instructions": "Rotate your body, arm reaching skyward" },
+            { "name": "Fast knee drives", "instructions": "Sprint in place, knees high" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Decelerating walk in place", "instructions": "Start fast and slow down" },
+            { "name": "Hamstring stretch", "instructions": "One foot on a raised surface, leg straight" },
+            { "name": "Calf stretch", "instructions": "Toes on a step" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "Core & Total Control",
+      "description": "Final session combining core work and stability",
+      "focus": ["core", "control"],
+      "blocks": [
+        {
+          "name": "Deep activation",
+          "exercises": [
+            { "name": "Dynamic cat-cow", "instructions": "Flow through rounded and arched back" },
+            { "name": "Inchworm", "instructions": "Standing, walk hands to plank position" },
+            { "name": "Dead bug warm-up", "instructions": "Back on the floor, arms and knees at 90°" }
+          ]
+        },
+        {
+          "name": "Core EMOM 6 min",
+          "exercises": [
+            { "name": "Full plank", "instructions": "Hold a plank for 30 seconds" },
+            { "name": "Bicycle crunches", "instructions": "Drive elbow toward opposite knee in a pedaling motion" }
+          ]
+        },
+        {
+          "name": "Core Supersets",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Full dead bug", "instructions": "Complete extension of opposite arm and leg" },
+                { "name": "Superman with hold", "instructions": "Lift arms and legs, hold for 3 seconds" }
+              ]
+            },
+            {
+              "exercises": [
+                {
+                  "name": "Side plank with rotation",
+                  "instructions": "On your elbow, rotate your torso toward the floor"
+                },
+                { "name": "Single-leg hip thrust", "instructions": "One foot on the floor, the other leg in the air" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Stability finisher",
+          "exercises": [
+            { "name": "Plank foot tap", "instructions": "Pike your hips up, touch one foot with the opposite hand" },
+            { "name": "Hollow hold", "instructions": "Back on the floor, arms and legs extended in the air" }
+          ]
+        },
+        {
+          "name": "Final relaxation",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Knees wide, arms extended in front" },
+            { "name": "Supine twist", "instructions": "Arms in a T, knees to one side" },
+            { "name": "Savasana", "instructions": "Lying on your back, eyes closed, breathe calmly" }
+          ]
+        }
+      ]
+    }
+  },
+  "remise-en-forme": {
+    "1": {
+      "title": "Upper Body",
+      "description": "Push/pull strength for shoulders, chest and back",
+      "focus": ["upper body", "strength"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Arm circles", "instructions": "Large circles forward then backward" },
+            { "name": "Inchworms", "instructions": "Standing, walk hands out to plank, walk back up" },
+            { "name": "Wall push-ups", "instructions": "Hands on the wall, slow push-ups to warm up the shoulders" }
+          ]
+        },
+        {
+          "name": "Push & Pull",
+          "exercises": [
+            { "name": "Push-ups", "instructions": "Hands shoulder-width apart, body braced" },
+            { "name": "Pike push-ups", "instructions": "Inverted-V position, bend your elbows" },
+            { "name": "Superman Y", "instructions": "Lying face down, lift arms in a Y shape and your legs" },
+            { "name": "Diamond push-ups", "instructions": "Hands in a diamond shape under your chest" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Chest stretch", "instructions": "Arm extended against a wall, rotate your torso away" },
+            { "name": "Tricep stretch", "instructions": "Arm overhead, bend your elbow" },
+            { "name": "Shoulder stretch", "instructions": "Arm extended across your chest" }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Cardio Circuit",
+      "description": "Full circuit to restart your cardio",
+      "focus": ["cardio", "full-body"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Jump with arms and legs wide" },
+            { "name": "Knee drives", "instructions": "Knees to hip height" },
+            { "name": "Dynamic forward lunges", "instructions": "Alternate lunges moving forward" }
+          ]
+        },
+        {
+          "name": "Full-Body Cardio",
+          "exercises": [
+            { "name": "Burpees without jump", "instructions": "Plank, push-up, stand up" },
+            { "name": "Jump squats", "instructions": "Explosive squat with jump" },
+            { "name": "Mountain climbers", "instructions": "In plank, drive knees toward your chest" },
+            { "name": "Jumping lunges", "instructions": "Alternate lunges with a jump" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Wind down gradually" },
+            { "name": "Quad stretch", "instructions": "Grab your foot behind you" },
+            { "name": "Child's pose", "instructions": "Knees on the floor, arms extended in front" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Lower Body & Core",
+      "description": "Thighs, glutes and abs",
+      "focus": ["lower body", "core"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Hip circles", "instructions": "Large circles in both directions" },
+            { "name": "Good mornings", "instructions": "Hands behind your head, hinge your torso forward" },
+            { "name": "Light squats", "instructions": "Slow squats to warm up your knees" }
+          ]
+        },
+        {
+          "name": "Legs & Core",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Sumo squats", "instructions": "Feet wide, toes out" },
+                { "name": "Crunches", "instructions": "Lift your shoulder blades off the floor" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Bulgarian lunges", "instructions": "Back foot on a chair" },
+                { "name": "Plank", "instructions": "Forearms, body aligned, 30 seconds" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Leg crossed in front, hinge your torso forward" },
+            { "name": "Supine twist", "instructions": "Knee toward your chest, let it fall to the opposite side" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "EMOM Endurance",
+      "description": "Every-minute-on-the-minute work for muscular endurance",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Stay light on your feet" },
+            { "name": "Inchworms", "instructions": "Walk hands to plank, push-up, walk back up" },
+            { "name": "Dynamic squats", "instructions": "Lower and rise quickly" }
+          ]
+        },
+        {
+          "name": "EMOM 12 minutes",
+          "exercises": [
+            { "name": "Push-ups", "instructions": "Regular push-ups, steady pace" },
+            { "name": "Jump squats", "instructions": "Explode upward, land softly" },
+            { "name": "Mountain climbers", "instructions": "Drive knees to your chest quickly" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" },
+            { "name": "Hamstring stretch", "instructions": "Seated, legs extended, hinge forward" },
+            { "name": "Child's pose", "instructions": "Knees on the floor, arms extended, release" }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Upper Body — Strength",
+      "description": "Progressive strength training with push/pull supersets",
+      "focus": ["upper body", "strength"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Progressive arm circles", "instructions": "Small circles then large circles" },
+            { "name": "Incline push-ups", "instructions": "Hands on a chair, slow push-ups" },
+            { "name": "Scapular push-ups", "instructions": "In plank, squeeze and release your shoulder blades" }
+          ]
+        },
+        {
+          "name": "Push & Pull supersets",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Push-ups", "instructions": "Lower chest to the floor, controlled pace" },
+                { "name": "Superman W", "instructions": "Lift your chest and pull your elbows into a W shape" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Pike push-ups", "instructions": "Inverted-V position, control the descent" },
+                { "name": "Reverse snow angels", "instructions": "Sweep arms in an arc overhead" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Tricep finisher",
+          "exercises": [
+            { "name": "Diamond push-ups", "instructions": "Hands in a diamond, elbows tight" },
+            { "name": "Chair dips", "instructions": "Lower your hips, elbows to 90°" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Floor chest stretch", "instructions": "Arm at 90°, gently roll" },
+            { "name": "Lat stretch", "instructions": "On your knees, arms extended, push hips back" },
+            { "name": "Tricep stretch", "instructions": "Arm overhead, bend your elbow" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Cardio HIIT",
+      "description": "High-intensity intervals for cardio",
+      "focus": ["cardio", "hiit"],
+      "blocks": [
+        {
+          "name": "Dynamic warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Progressive pace" },
+            { "name": "High knees", "instructions": "Drive knees above hip height" },
+            { "name": "Dynamic lateral lunges", "instructions": "Alternate left and right" }
+          ]
+        },
+        {
+          "name": "Full-Body HIIT",
+          "exercises": [
+            { "name": "Full burpees", "instructions": "Plank, push-up, explosive jump" },
+            { "name": "Speed squats", "instructions": "Fast and deep squats" },
+            { "name": "Commando planks", "instructions": "Alternate forearm plank and high plank" },
+            { "name": "Tuck jumps", "instructions": "Jump and pull your knees to your chest" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Walking in place", "instructions": "Bring your heart rate down" },
+            { "name": "Hip flexor stretch", "instructions": "Back knee on the floor, hip pushed forward" },
+            { "name": "Diaphragmatic breathing", "instructions": "Hands on your belly, inhale 4s, exhale 6s" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "Lower Body & Core — Volume",
+      "description": "Increasing volume on legs",
+      "focus": ["lower body", "core"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Ankle circles", "instructions": "Point your toes and draw circles" },
+            { "name": "Good mornings", "instructions": "Hinge your torso, keep your back flat" },
+            { "name": "Squats with pause", "instructions": "Lower down, hold for 3 seconds at the bottom" }
+          ]
+        },
+        {
+          "name": "Legs — Volume",
+          "exercises": [
+            { "name": "Sumo squats", "instructions": "Feet wide, lower slowly" },
+            { "name": "Bulgarian lunges", "instructions": "Back foot on a chair" },
+            { "name": "Single-leg hip thrust", "instructions": "One leg extended in the air" }
+          ]
+        },
+        {
+          "name": "Intensive core",
+          "exercises": [
+            { "name": "Bicycle crunches", "instructions": "Drive elbow toward opposite knee" },
+            { "name": "Plank", "instructions": "Body aligned head to toe" },
+            { "name": "Russian twists", "instructions": "Feet off the floor, rotate your torso" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Leg crossed in front, release your torso" },
+            { "name": "Lying quad stretch", "instructions": "Lying on your side, grab your foot" },
+            { "name": "Cobra", "instructions": "Push through your hands to stretch your abs" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "EMOM Endurance +",
+      "description": "Extended EMOM with more reps",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Progressive pace" },
+            { "name": "Inchworms with push-up", "instructions": "Walk to plank, push-up, walk back up" },
+            { "name": "Dynamic lunges", "instructions": "Alternate lunges, long strides" }
+          ]
+        },
+        {
+          "name": "EMOM 15 minutes",
+          "exercises": [
+            { "name": "Push-ups", "instructions": "Regular push-ups, steady tempo" },
+            { "name": "Jump squats", "instructions": "Explode upward, soft landing" },
+            { "name": "Mountain climbers", "instructions": "Drive knees to your chest, quick pace" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" },
+            { "name": "Hamstring stretch", "instructions": "Seated, legs extended, hinge forward" },
+            { "name": "Child's pose", "instructions": "Forehead to the floor, fully release" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "Upper Body — Power",
+      "description": "Explosive and advanced variations",
+      "focus": ["upper body", "power"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Arm circles", "instructions": "Fast circles" },
+            { "name": "Fast incline push-ups", "instructions": "Fast push-ups with hands on a chair" },
+            { "name": "Bear crawl", "instructions": "Move forward on all fours, knees hovering" }
+          ]
+        },
+        {
+          "name": "Explosive push",
+          "exercises": [
+            { "name": "Clapping push-ups", "instructions": "Push explosively, hands leave the floor" },
+            { "name": "Elevated pike push-ups", "instructions": "Feet on a chair, inverted-V, control the descent" },
+            { "name": "Archer push-ups", "instructions": "One arm does the push-up, the other extends out" }
+          ]
+        },
+        {
+          "name": "Volume finisher",
+          "exercises": [
+            { "name": "Diamond push-ups", "instructions": "Hands in a diamond, elbows tight" },
+            { "name": "Chair dips", "instructions": "Lower your hips, elbows to 90°" },
+            { "name": "Swimmer Superman", "instructions": "Lift arms and legs, alternate in a swimming motion" },
+            { "name": "Commando planks", "instructions": "Alternate forearm plank and high plank" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Chest stretch", "instructions": "Arm against the wall, rotate your torso" },
+            { "name": "Lat stretch", "instructions": "On your knees, arms extended, push hips back" },
+            { "name": "Neck stretch", "instructions": "Tilt your head, hand on the temple" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "Cardio Tabata",
+      "description": "Tabata format: 20s effort / 10s rest",
+      "focus": ["cardio", "tabata"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Steady pace" },
+            { "name": "Slow burpees", "instructions": "5 controlled burpees to warm up" },
+            { "name": "Light jumping lunges", "instructions": "Small hops between lunges" }
+          ]
+        },
+        {
+          "name": "Cardio Tabata",
+          "exercises": [
+            { "name": "Full burpees", "instructions": "Plank, push-up, explosive jump" },
+            { "name": "Mountain climbers sprint", "instructions": "Maximum pace" },
+            { "name": "Jump squats", "instructions": "Deep squat, maximum jump" },
+            { "name": "Plank jumping jacks", "instructions": "In plank, jump feet out wide then back together" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Slow walk", "instructions": "Fully decelerate" },
+            { "name": "Quad stretch", "instructions": "Grab your foot behind you" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "Lower Body & Core — Explosive",
+      "description": "Explosive leg movements and advanced core work",
+      "focus": ["lower body", "power"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Progressive squats", "instructions": "5 slow, 5 normal, 5 fast" },
+            { "name": "Multiplanar lunges", "instructions": "Forward, lateral, backward — each leg" },
+            { "name": "Slow dead bug", "instructions": "Arms and legs in the air, extend slowly" }
+          ]
+        },
+        {
+          "name": "Leg Power",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Jump squats with pause", "instructions": "Lower, pause 1s at the bottom, explode" },
+                { "name": "V-ups", "instructions": "Lift legs and torso simultaneously" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Jumping lunges", "instructions": "Alternate with a jump, back knee near the floor" },
+                { "name": "Side plank with hip lift", "instructions": "In side plank, lower and raise your hip" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Ab finisher",
+          "exercises": [
+            { "name": "Bicycle crunches", "instructions": "Drive elbow toward opposite knee, quick pace" },
+            { "name": "Slow mountain climbers", "instructions": "Knee toward opposite elbow, hold for 1 second" },
+            { "name": "Plank foot touch", "instructions": "Reach under your body to tap the opposite foot" }
+          ]
+        },
+        {
+          "name": "Stretches",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Front leg crossed, torso toward the floor" },
+            { "name": "Supine twist", "instructions": "Knees to one side, arms in a T" },
+            { "name": "Cobra", "instructions": "Push through your hands to open your chest" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "Advanced EMOM Endurance",
+      "description": "EMOM 16 min with 4 exercises per minute",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Steady pace" },
+            { "name": "Inchworms with push-up", "instructions": "Walk to plank, push-up, walk back up" },
+            { "name": "Light jump squats", "instructions": "Small hops to activate your legs" }
+          ]
+        },
+        {
+          "name": "EMOM 16 minutes",
+          "exercises": [
+            { "name": "Burpees", "instructions": "Full burpee with push-up and jump" },
+            { "name": "Push-ups", "instructions": "Regular push-ups, lower to the floor" },
+            { "name": "Jump squats", "instructions": "Deep squat, maximum jump" },
+            { "name": "Mountain climbers", "instructions": "Drive knees to your chest, quick pace" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" },
+            { "name": "Hamstring stretch", "instructions": "Seated, legs extended, hinge forward" },
+            { "name": "Child's pose", "instructions": "Forehead to the floor, fully release" }
+          ]
+        }
+      ]
+    },
+    "13": {
+      "title": "Upper Body — Max Effort",
+      "description": "Intense session combining volume and explosiveness",
+      "focus": ["upper body", "power"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Inchworms with push-up", "instructions": "Walk to plank, push-up, walk back up" },
+            { "name": "Scapular push-ups", "instructions": "In plank, squeeze and release your shoulder blades" },
+            { "name": "Bear crawl", "instructions": "Move forward on all fours, knees hovering" }
+          ]
+        },
+        {
+          "name": "Push Max",
+          "exercises": [
+            { "name": "Clapping push-ups", "instructions": "Push explosively, hands leave the floor" },
+            { "name": "Elevated pike push-ups", "instructions": "Feet on a chair, control the descent" },
+            { "name": "Archer push-ups", "instructions": "One arm does the push-up, the other extends out" }
+          ]
+        },
+        {
+          "name": "Total finisher",
+          "exercises": [
+            { "name": "Diamond push-ups", "instructions": "Hands in a diamond, elbows tight" },
+            { "name": "Chair dips", "instructions": "Lower down, elbows to 90°" },
+            { "name": "Swimmer Superman", "instructions": "Swimming motion, arms and legs off the floor" },
+            { "name": "Commando planks", "instructions": "Alternate forearm plank and high plank" }
+          ]
+        },
+        {
+          "name": "Deep stretches",
+          "exercises": [
+            { "name": "Floor chest stretch", "instructions": "Lying down, arm in a T, roll gently to one side" },
+            { "name": "Lat stretch", "instructions": "On your knees, arms extended, push hips back" },
+            { "name": "Neck and trap stretch", "instructions": "Tilt your head, hand on the temple" }
+          ]
+        }
+      ]
+    },
+    "14": {
+      "title": "Extreme Cardio",
+      "description": "Maximum HIIT with compound sequences",
+      "focus": ["cardio", "hiit"],
+      "blocks": [
+        {
+          "name": "High-intensity warm-up",
+          "exercises": [
+            { "name": "Fast high knees", "instructions": "Drive knees above hip height, high pace" },
+            { "name": "Controlled burpees", "instructions": "5 burpees with push-up, moderate pace" },
+            { "name": "Light jumping lunges", "instructions": "Small hops to warm up your thighs" }
+          ]
+        },
+        {
+          "name": "Extreme HIIT",
+          "exercises": [
+            { "name": "Burpees with tuck jump", "instructions": "Full burpee then jump with knees to chest" },
+            { "name": "Mountain climbers sprint", "instructions": "Maximum pace, drive knees to chest" },
+            { "name": "180° jump squats", "instructions": "Jump squat with a half-turn in the air" },
+            { "name": "Plank jumping jacks", "instructions": "In plank, jump feet out wide then back together" }
+          ]
+        },
+        {
+          "name": "Cooldown",
+          "exercises": [
+            { "name": "Very slow walk", "instructions": "Long exhale with every step" },
+            { "name": "Quad stretch", "instructions": "Grab your foot, pull gently" },
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s" }
+          ]
+        }
+      ]
+    },
+    "15": {
+      "title": "Lower Body & Core — Total",
+      "description": "Combined legs and abs at maximum intensity",
+      "focus": ["lower body", "core", "power"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Progressive squats", "instructions": "5 slow, 5 normal, 5 fast" },
+            { "name": "Multiplanar lunges", "instructions": "Forward, lateral, backward — each leg" },
+            { "name": "Slow dead bug", "instructions": "Arms and legs in the air, extend slowly" }
+          ]
+        },
+        {
+          "name": "Max Leg Power",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Jump squats with pause", "instructions": "Lower, pause 1s, explode" },
+                { "name": "V-ups", "instructions": "Lift legs and torso simultaneously" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Jumping lunges", "instructions": "Alternate with a jump, knee near the floor" },
+                { "name": "Side plank with hip lift", "instructions": "Lower your hip to the floor then raise back up" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Ab finisher",
+          "exercises": [
+            { "name": "Fast bicycle crunches", "instructions": "Drive elbow toward opposite knee, maximum pace" },
+            { "name": "Slow mountain climbers", "instructions": "Knee toward opposite elbow, hold for 1 second" },
+            { "name": "Plank foot touch", "instructions": "Reach under your body to tap the opposite foot" }
+          ]
+        },
+        {
+          "name": "Deep stretches",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Front leg crossed, torso toward the floor" },
+            { "name": "Supine twist", "instructions": "Knees to one side, arms in a T" },
+            { "name": "Cobra", "instructions": "Push through your hands to open your chest" }
+          ]
+        }
+      ]
+    },
+    "16": {
+      "title": "Final EMOM Endurance",
+      "description": "Ultimate EMOM with compound exercises",
+      "focus": ["endurance", "full-body", "power"],
+      "blocks": [
+        {
+          "name": "Warm-up",
+          "exercises": [
+            { "name": "Fast jumping jacks", "instructions": "Steady pace, arms extended" },
+            {
+              "name": "Inchworms with push-up and rotation",
+              "instructions": "Inchworm, push-up, T-rotation with arm reaching skyward"
+            },
+            { "name": "Light jumping lunges", "instructions": "Small hops to activate your legs" }
+          ]
+        },
+        {
+          "name": "EMOM 20 minutes",
+          "exercises": [
+            { "name": "Burpees with push-up", "instructions": "Full burpee with push-up and jump" },
+            { "name": "Pike push-ups", "instructions": "Inverted-V position, controlled descent" },
+            { "name": "Jump squats", "instructions": "Deep squat, maximum jump, land silently" },
+            { "name": "Cross-body mountain climbers", "instructions": "Drive knee toward opposite elbow, quick pace" }
+          ]
+        },
+        {
+          "name": "Final cooldown",
+          "exercises": [
+            { "name": "4-7-8 breathing", "instructions": "Inhale 4s, hold 7s, exhale 8s — 5 cycles" },
+            { "name": "Hamstring stretch", "instructions": "Seated, legs extended, hinge forward" },
+            { "name": "Child's pose", "instructions": "Knees wide, arms in front, fully release" }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/i18n/locales/fr/programs_data.json
+++ b/src/i18n/locales/fr/programs_data.json
@@ -1,5 +1,8 @@
 {
   "debutant-4-semaines": {
+    "title": "Débutant 4 semaines",
+    "description": "Programme progressif pour démarrer le sport en douceur",
+    "goals": ["Découvrir les exercices de base", "Construire une routine", "Améliorer la mobilité"],
     "headline": "Construis tes fondations",
     "intro": "Tu reprends le sport ou tu débutes ? Ce programme de 4 semaines t'accompagne pas à pas. Chaque semaine ajoute un peu d'intensité pour que tu progresses sans jamais te sentir dépassé.",
     "audience": "Reprise d'activité, vrai débutant, ou toute personne qui veut (re)partir sur de bonnes bases.",
@@ -34,6 +37,9 @@
     "tip": "Pas besoin de forcer dès le début. Le plus important, c'est la régularité. 3 séances par semaine suffisent pour voir des résultats concrets en un mois."
   },
   "remise-en-forme": {
+    "title": "Remise en forme",
+    "description": "Programme complet cardio et renforcement musculaire",
+    "goals": ["Retrouver la forme", "Brûler des calories", "Renforcer tout le corps"],
     "headline": "Retrouve ton rythme",
     "intro": "Tu as déjà fait du sport mais tu as décroché ? Ce programme remet les choses en place. Formats variés dès la première semaine, intensité progressive — tu retrouves tes sensations rapidement.",
     "audience": "Ancien sportif en reprise, ou niveau intermédiaire qui veut structurer son entraînement.",
@@ -68,6 +74,9 @@
     "tip": "Si une séance te semble facile, c'est normal — c'est le signe que tu es en forme pour ça. La semaine suivante ajustera le curseur."
   },
   "cardio-express": {
+    "title": "Cardio Express",
+    "description": "Sessions courtes et intenses HIIT et Tabata",
+    "goals": ["Améliorer le cardio", "Maximiser le temps", "Repousser ses limites"],
     "headline": "Court, intense, efficace",
     "intro": "Pas le temps de faire une heure de sport ? Ce programme mise sur des séances courtes à haute intensité. 20 minutes suffisent pour transpirer, progresser et repartir.",
     "audience": "Emploi du temps chargé, sportif qui veut du résultat sans y passer des heures.",

--- a/src/i18n/locales/fr/sessions_data.json
+++ b/src/i18n/locales/fr/sessions_data.json
@@ -1,0 +1,1620 @@
+{
+  "cardio-express": {
+    "1": {
+      "title": "HIIT Brûle-Graisses",
+      "description": "Intervalles courts à haute intensité pour un maximum de calories brûlées",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Échauffement express",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme soutenu, bras bien tendus au-dessus de la tête" },
+            { "name": "High knees", "instructions": "Monter les genoux au-dessus des hanches, rythme progressif" },
+            {
+              "name": "Arm circles dynamiques",
+              "instructions": "Grands cercles rapides des bras, en avant puis en arrière"
+            }
+          ]
+        },
+        {
+          "name": "HIIT Brûle-Graisses",
+          "exercises": [
+            { "name": "Burpees", "instructions": "Descendre en planche, pompe, remonter et sauter" },
+            { "name": "Mountain climbers", "instructions": "En planche, alterner genoux vers la poitrine rapidement" },
+            { "name": "Squats sautés", "instructions": "Squat profond, exploser vers le haut, amortir en douceur" },
+            {
+              "name": "Planche avec toucher épaule",
+              "instructions": "En planche haute, toucher l'épaule opposée en alternance"
+            }
+          ]
+        },
+        {
+          "name": "Récupération",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Ralentir le rythme cardiaque progressivement" },
+            {
+              "name": "Étirement quadriceps",
+              "instructions": "Debout, attraper le pied derrière soi, garder le genou vers le bas"
+            },
+            {
+              "name": "Respiration profonde",
+              "instructions": "Inspirer 4s par le nez, expirer 6s par la bouche — 4 cycles"
+            }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Tabata Explosif",
+      "description": "Format Tabata classique 20/10 pour exploser le cardio en un minimum de temps",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Échauffement rapide",
+          "exercises": [
+            {
+              "name": "Trottiner sur place",
+              "instructions": "Course légère sur place, monter le rythme progressivement"
+            },
+            { "name": "Squats dynamiques", "instructions": "Squats rapides, remonter sur la pointe des pieds" },
+            { "name": "Rotation du buste", "instructions": "Pieds fixes, tourner le haut du corps dynamiquement" }
+          ]
+        },
+        {
+          "name": "Tabata Full-Body",
+          "exercises": [
+            { "name": "Burpees sans saut", "instructions": "Descendre au sol, remonter debout le plus vite possible" },
+            {
+              "name": "Speed skaters",
+              "instructions": "Sauts latéraux, toucher le sol avec la main opposée au pied d'appui"
+            },
+            { "name": "High knees sprint", "instructions": "Sprint sur place, genoux le plus haut possible" },
+            { "name": "Planche saut écart", "instructions": "En planche, sauter pieds écartés puis serrés" }
+          ]
+        },
+        {
+          "name": "Étirements express",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Baisser le rythme cardiaque en marchant doucement" },
+            { "name": "Étirement mollets", "instructions": "Un pied en avant, pousser le talon arrière au sol" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Jambe tendue devant, pencher le buste" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Circuit Cardio Intense",
+      "description": "Enchaînement d'exercices variés en circuit pour travailler le cardio et l'endurance",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Pas chassés", "instructions": "Pas latéraux dynamiques, rester bas sur les appuis" },
+            { "name": "Montées de genoux avec bras", "instructions": "Lever les genoux en poussant les bras au ciel" },
+            { "name": "Fentes avant dynamiques", "instructions": "Grandes fentes en avançant, bras en opposition" }
+          ]
+        },
+        {
+          "name": "Circuit Haute Énergie",
+          "exercises": [
+            { "name": "Burpees complets", "instructions": "Planche, pompe, saut explosif, enchaîner rapidement" },
+            {
+              "name": "Mountain climbers sprint",
+              "instructions": "Position planche, genoux vers la poitrine le plus vite possible"
+            },
+            { "name": "Squats sautés", "instructions": "Descente contrôlée, saut explosif, réception pieds à plat" },
+            {
+              "name": "Jumping lunges",
+              "instructions": "Fentes sautées en alternance, rester gainé dans le mouvement"
+            },
+            {
+              "name": "Planche commando",
+              "instructions": "Alterner planche coudes et planche mains sans rotation des hanches"
+            }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Décélérer progressivement" },
+            {
+              "name": "Étirement fléchisseurs de hanche",
+              "instructions": "Genou arrière au sol, hanche poussée en avant"
+            },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s — 3 cycles" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "HIIT Accélération",
+      "description": "Plus de rounds, moins de repos — on monte en intensité",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            {
+              "name": "Jumping jacks progressifs",
+              "instructions": "Commencer lentement, accélérer sur les dernières secondes"
+            },
+            { "name": "High knees", "instructions": "Genoux hauts, bras en opposition, rythme soutenu" },
+            { "name": "World's greatest stretch", "instructions": "Fente, main au sol, rotation du buste bras levé" }
+          ]
+        },
+        {
+          "name": "HIIT Accélération",
+          "exercises": [
+            { "name": "Burpees avec pompe", "instructions": "Descendre au sol, pompe complète, remonter et sauter" },
+            { "name": "Jump squats", "instructions": "Squat profond, sauter le plus haut possible" },
+            {
+              "name": "Mountain climbers croisés",
+              "instructions": "Genou vers le coude opposé en planche, rythme soutenu"
+            },
+            { "name": "Fentes sautées", "instructions": "Alterner les fentes en sautant, genou arrière frôle le sol" },
+            {
+              "name": "Plank shoulder taps",
+              "instructions": "En planche, toucher épaule opposée sans tourner les hanches"
+            }
+          ]
+        },
+        {
+          "name": "Récupération",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Décélérer complètement, longues respirations" },
+            { "name": "Étirement quadriceps", "instructions": "Attraper le pied, tirer le talon vers les fessiers" },
+            { "name": "Étirement pectoraux", "instructions": "Bras tendu contre un mur, tourner le buste" }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Tabata Double Impact",
+      "description": "Deux blocs Tabata ciblés : jambes puis haut du corps",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Échauffement rapide",
+          "exercises": [
+            { "name": "Squats dynamiques", "instructions": "Squats rapides, monter sur la pointe des pieds" },
+            { "name": "Pompes inclinées", "instructions": "Mains sur une chaise, pompes rapides" },
+            { "name": "Jumping jacks", "instructions": "Rythme élevé pour monter le cardio" }
+          ]
+        },
+        {
+          "name": "Tabata Legs",
+          "exercises": [
+            { "name": "Jump squats", "instructions": "Squat explosif, sauter le plus haut possible, amortir" },
+            {
+              "name": "Speed skaters profonds",
+              "instructions": "Grands sauts latéraux, descendre bas, toucher le sol"
+            },
+            { "name": "Fentes sautées", "instructions": "Alterner les fentes en explosant vers le haut" },
+            { "name": "Squat pulses", "instructions": "Rester en bas du squat, faire de petites impulsions rapides" }
+          ]
+        },
+        {
+          "name": "Tabata Upper Body",
+          "exercises": [
+            { "name": "Pompes rapides", "instructions": "Pompes à rythme maximal, descendre la poitrine au sol" },
+            {
+              "name": "Planche commando rapide",
+              "instructions": "Monter et descendre des coudes aux mains le plus vite possible"
+            },
+            { "name": "Mountain climbers sprint", "instructions": "Sprint des genoux vers la poitrine en planche" },
+            { "name": "Pike push-ups", "instructions": "Position V inversé, pompes pour les épaules, rythme rapide" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Ralentir progressivement" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Jambe tendue devant, pencher le buste" },
+            { "name": "Étirement épaules", "instructions": "Bras devant la poitrine, tirer avec l'autre main" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Circuit Endurance-Puissance",
+      "description": "Circuit plus long avec exercices composés pour l'endurance",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Bear crawl", "instructions": "Avancer et reculer en quadrupédie, genoux décollés" },
+            { "name": "Fentes avant dynamiques", "instructions": "Grandes fentes en avançant" },
+            { "name": "Jumping jacks", "instructions": "Rythme élevé" }
+          ]
+        },
+        {
+          "name": "Circuit Puissance",
+          "exercises": [
+            { "name": "Burpees complets", "instructions": "Planche, pompe, saut explosif" },
+            { "name": "Squat pulse jumps", "instructions": "3 pulses en bas du squat puis saut explosif" },
+            { "name": "Mountain climbers sprint", "instructions": "Rythme maximal en planche" },
+            { "name": "Tuck jumps", "instructions": "Sauter et ramener les genoux à la poitrine" },
+            {
+              "name": "Planche avec toucher genoux",
+              "instructions": "En planche, toucher les genoux alternativement avec les mains"
+            }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Décélérer complètement" },
+            { "name": "Étirement mollets profond", "instructions": "Pied arrière bien à plat, pousser le talon" },
+            { "name": "Child's pose", "instructions": "Genoux au sol, bras tendus devant" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "HIIT Puissance Maximale",
+      "description": "Rounds longs, repos court — exercices avancés",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Échauffement intense",
+          "exercises": [
+            { "name": "Burpees lents", "instructions": "5 burpees contrôlés pour échauffer" },
+            { "name": "Fentes sautées légères", "instructions": "Petits sauts entre les fentes" },
+            { "name": "Bear crawl", "instructions": "Avancer en quadrupédie genoux décollés" }
+          ]
+        },
+        {
+          "name": "HIIT Puissance",
+          "exercises": [
+            {
+              "name": "Burpees avec tuck jump",
+              "instructions": "Burpee complet avec tuck jump au lieu du saut classique"
+            },
+            {
+              "name": "Squats sautés groupés",
+              "instructions": "Squat profond, sauter en ramenant les genoux à la poitrine"
+            },
+            {
+              "name": "Mountain climbers sprinter",
+              "instructions": "En planche, sprinter les genoux le plus vite possible"
+            },
+            { "name": "Jumping lunges explosifs", "instructions": "Fentes sautées avec maximum de hauteur" },
+            { "name": "Sprawls", "instructions": "Se jeter au sol à plat ventre, remonter en explosant" }
+          ]
+        },
+        {
+          "name": "Récupération",
+          "exercises": [
+            { "name": "Marche très lente", "instructions": "Longues respirations nasales" },
+            { "name": "Étirement adducteurs", "instructions": "Jambes écartées, descendre doucement" },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, retenir 7s, expirer 8s" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "Tabata Infernal",
+      "description": "3 sets Tabata sans répit",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Échauffement express",
+          "exercises": [
+            { "name": "Sprint sur place", "instructions": "Courir sur place à 70% d'intensité" },
+            { "name": "Scorpion stretch", "instructions": "Sur le ventre, lever un pied vers la main opposée" },
+            { "name": "Squat jumps légers", "instructions": "Petits sauts depuis le squat" }
+          ]
+        },
+        {
+          "name": "Tabata Explosif Set A",
+          "exercises": [
+            { "name": "Burpees avec tuck jump", "instructions": "Burpee complet terminé par un saut genoux poitrine" },
+            { "name": "Speed skaters", "instructions": "Sauts latéraux rapides, toucher le sol" },
+            { "name": "Squat 180° sautés", "instructions": "Squat, sauter avec demi-tour complet" },
+            { "name": "Pompes plyo", "instructions": "Pompe explosive, mains décollent du sol" }
+          ]
+        },
+        {
+          "name": "Tabata Explosif Set B",
+          "exercises": [
+            { "name": "High knees sprint", "instructions": "Genoux le plus haut possible, vitesse maximale" },
+            { "name": "Plank up-downs", "instructions": "Passer des coudes aux mains sans balancer" },
+            { "name": "Jumping lunges rapides", "instructions": "Fentes sautées le plus vite possible" },
+            { "name": "Sprawl to jump", "instructions": "Se jeter au sol, remonter et sauter immédiatement" }
+          ]
+        },
+        {
+          "name": "Tabata Finisher",
+          "exercises": [
+            { "name": "Burpees all-out", "instructions": "Burpees à vitesse maximale" },
+            { "name": "Tuck jumps", "instructions": "Sauts groupés, genoux à la poitrine" },
+            { "name": "Mountain climbers sprint", "instructions": "Le plus vite possible" },
+            { "name": "Star jumps", "instructions": "Sauter en étoile, bras et jambes écartés" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Baisser le rythme cardiaque" },
+            { "name": "Étirement mollets profond", "instructions": "Pied arrière bien à plat" },
+            { "name": "Pigeon stretch", "instructions": "Jambe avant pliée, descendre le buste" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "Circuit Haute Intensité",
+      "description": "Exercices avancés, repos minimal",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Inchworms avec pompe", "instructions": "Marcher les mains en planche, pompe, revenir" },
+            { "name": "Carioca", "instructions": "Déplacement latéral croisé, pieds rapides" },
+            { "name": "Skipping hauts", "instructions": "Monter les genoux très hauts en sautillant" }
+          ]
+        },
+        {
+          "name": "Circuit Level Up",
+          "exercises": [
+            { "name": "Burpees avec tuck jump", "instructions": "Burpee complet avec saut genoux poitrine" },
+            { "name": "Spider-Man mountain climbers", "instructions": "Genou vers le coude du même côté" },
+            { "name": "Squat sauté étoile", "instructions": "Squat profond, exploser en star jump" },
+            { "name": "Pompes commando", "instructions": "Alterner planche coudes et planche mains" },
+            { "name": "Broad jump burpees", "instructions": "Saut en longueur, burpee à la réception" },
+            { "name": "High knees sprint", "instructions": "Sprint genoux hauts, vitesse absolue" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Ralentir, secouer bras et jambes" },
+            { "name": "Étirement fessiers assis", "instructions": "Croiser cheville sur genou, tirer" },
+            { "name": "Savasana respirée", "instructions": "Allongé sur le dos, respirer 5 cycles" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "HIIT Ultime",
+      "description": "Le sommet du programme — travail long, repos court",
+      "focus": ["cardio", "HIIT"],
+      "blocks": [
+        {
+          "name": "Échauffement intense",
+          "exercises": [
+            { "name": "Burpees tempo", "instructions": "Burpees complets à tempo modéré" },
+            { "name": "High knees avec bras", "instructions": "Genoux hauts, bras au ciel" },
+            { "name": "Fentes marchées avec twist", "instructions": "Fente en avançant, tourner le buste" }
+          ]
+        },
+        {
+          "name": "HIIT 45/15",
+          "exercises": [
+            { "name": "Devil press", "instructions": "Burpee, se relever et lever les bras en sautant" },
+            { "name": "Squat jump tuck", "instructions": "Squat profond, sauter en groupé genoux poitrine" },
+            { "name": "Mountain climbers sprint", "instructions": "Sprinter les genoux à vitesse maximale" },
+            { "name": "Jumping lunges alternés", "instructions": "Fentes sautées profondes, explosivité pure" },
+            { "name": "Sprawl to broad jump", "instructions": "Sprawl au sol, remonter et saut en longueur" },
+            { "name": "Plank jacks to push-up", "instructions": "Deux plank jacks puis une pompe explosive" }
+          ]
+        },
+        {
+          "name": "Récupération finale",
+          "exercises": [
+            { "name": "Marche très lente", "instructions": "Réduire le rythme cardiaque doucement" },
+            { "name": "Étirement quadriceps profond", "instructions": "Attraper le pied, pousser la hanche en avant" },
+            { "name": "Étirement dos", "instructions": "Assis, jambes tendues, pencher le buste" },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, retenir 7s, expirer 8s" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "Tabata All-Out",
+      "description": "Trois sets Tabata avec les exercices les plus exigeants",
+      "focus": ["cardio", "Tabata"],
+      "blocks": [
+        {
+          "name": "Échauffement complet",
+          "exercises": [
+            { "name": "Jumping jacks progressifs", "instructions": "Commencer lentement, finir à vitesse maximale" },
+            { "name": "World's greatest stretch", "instructions": "Fente, main au sol, rotation du buste" },
+            { "name": "Squat jumps crescendo", "instructions": "Sauter de plus en plus haut à chaque rep" }
+          ]
+        },
+        {
+          "name": "Tabata Devastation Set 1",
+          "exercises": [
+            { "name": "Burpee broad jumps", "instructions": "Burpee puis saut en longueur, se retourner" },
+            { "name": "Squat jump 180° continus", "instructions": "Squat sauté avec demi-tour, ne jamais s'arrêter" },
+            { "name": "Sprawls explosifs", "instructions": "Se jeter au sol, remonter en explosant" },
+            { "name": "Star jumps", "instructions": "Sauter en étoile maximale" }
+          ]
+        },
+        {
+          "name": "Tabata Devastation Set 2",
+          "exercises": [
+            { "name": "Burpees avec tuck jump", "instructions": "Burpee terminé par un tuck jump" },
+            { "name": "Pompes plyo larges", "instructions": "Pompes explosives, mains décollent et se posent large" },
+            { "name": "Speed skaters profonds", "instructions": "Grands sauts latéraux, descendre très bas" },
+            { "name": "High knees all-out", "instructions": "Sprint sur place, 100% d'effort" }
+          ]
+        },
+        {
+          "name": "Étirements de récupération",
+          "exercises": [
+            { "name": "Marche de récupération", "instructions": "Marcher très lentement, respirer par le nez" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Talon sur un support, pencher le buste" },
+            { "name": "Cobra stretch", "instructions": "Sur le ventre, pousser les mains pour ouvrir la poitrine" },
+            { "name": "Respiration complète", "instructions": "Inspirer ventre, côtes, poitrine — expirer lentement" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "Circuit Final Boss",
+      "description": "Le circuit le plus difficile du programme — repos minimal, tours maximum",
+      "focus": ["cardio", "circuit"],
+      "blocks": [
+        {
+          "name": "Activation maximale",
+          "exercises": [
+            { "name": "Burpees contrôlés", "instructions": "Burpees complets à rythme modéré" },
+            { "name": "Lateral shuffles", "instructions": "Déplacements latéraux rapides, toucher le sol" },
+            { "name": "A-skips", "instructions": "Sauts genoux hauts en avançant, bras en opposition" }
+          ]
+        },
+        {
+          "name": "Circuit Final",
+          "exercises": [
+            {
+              "name": "Burpee tuck jump broad jump",
+              "instructions": "Burpee, tuck jump, saut en longueur — le trio complet"
+            },
+            { "name": "Mountain climbers sprint", "instructions": "Vitesse absolue, hanches basses" },
+            { "name": "Squat sauté 360°", "instructions": "Squat profond, sauter en faisant un tour complet" },
+            { "name": "Pompes superman", "instructions": "Pompe explosive, lever bras et jambes en l'air" },
+            { "name": "High knees à tuck jumps", "instructions": "4 high knees rapides puis 1 tuck jump" },
+            { "name": "Sprawl avec rotation", "instructions": "Sprawl au sol, remonter en tournant 180°" }
+          ]
+        },
+        {
+          "name": "Récupération finale du programme",
+          "exercises": [
+            { "name": "Marche très lente", "instructions": "Laisser le rythme cardiaque descendre" },
+            { "name": "Étirement complet jambes", "instructions": "Fente basse, alterner" },
+            { "name": "Pigeon stretch", "instructions": "Jambe avant pliée, relâcher les hanches" },
+            {
+              "name": "Savasana finale",
+              "instructions": "Allongé, bras écartés, paumes vers le ciel — programme terminé"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "debutant-4-semaines": {
+    "1": {
+      "title": "Découverte Full-Body",
+      "description": "Premiers mouvements fondamentaux : squats, pompes adaptées et gainage",
+      "focus": ["full-body", "mobilité"],
+      "blocks": [
+        {
+          "name": "Échauffement doux",
+          "exercises": [
+            {
+              "name": "Rotations articulaires",
+              "instructions": "Cou, épaules, poignets, hanches, chevilles — lents et contrôlés"
+            },
+            { "name": "Marche sur place", "instructions": "Lever les genoux progressivement, balancer les bras" },
+            { "name": "Cercles de hanches", "instructions": "Mains sur les hanches, grands cercles dans les deux sens" }
+          ]
+        },
+        {
+          "name": "Fondamentaux",
+          "exercises": [
+            {
+              "name": "Squats assistés",
+              "instructions": "Pieds largeur épaules, descendre comme pour s'asseoir, mains devant pour l'équilibre"
+            },
+            {
+              "name": "Pompes sur genoux",
+              "instructions": "Mains largeur épaules, genoux au sol, descendre la poitrine vers le sol"
+            },
+            {
+              "name": "Planche sur genoux",
+              "instructions": "Avant-bras au sol, genoux au sol, corps aligné, tenir 20 secondes"
+            },
+            {
+              "name": "Pont fessier",
+              "instructions": "Allongé sur le dos, pieds au sol, soulever les hanches en serrant les fessiers"
+            }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Étirement quadriceps", "instructions": "Debout, attraper le pied derrière soi, chaque jambe" },
+            {
+              "name": "Étirement ischio-jambiers",
+              "instructions": "Assis, jambes tendues, pencher le buste vers l'avant"
+            },
+            { "name": "Étirement pectoraux", "instructions": "Bras contre un mur, tourner le buste doucement" }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Cardio Doux",
+      "description": "Circuit léger pour activer le cardio sans surcharger les articulations",
+      "focus": ["cardio", "endurance"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            {
+              "name": "Marche rapide sur place",
+              "instructions": "Accélérer progressivement, grands mouvements de bras"
+            },
+            {
+              "name": "Talons-fesses légers",
+              "instructions": "Sur place, ramener les talons vers les fessiers en douceur"
+            },
+            { "name": "Rotations du buste", "instructions": "Pieds fixes, tourner le haut du corps de gauche à droite" }
+          ]
+        },
+        {
+          "name": "Circuit Cardio Débutant",
+          "exercises": [
+            { "name": "Pas chassés", "instructions": "Pas latéraux dynamiques, rester bas sur les appuis" },
+            { "name": "Montées de genoux", "instructions": "Lever les genoux à hauteur des hanches, rythme modéré" },
+            { "name": "Squats sumo", "instructions": "Pieds écartés, pointes vers l'extérieur, descendre lentement" },
+            { "name": "Marche de l'ours", "instructions": "À quatre pattes, genoux décollés du sol, avancer/reculer" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche lente sur place", "instructions": "Ralentir progressivement, respirer profondément" },
+            { "name": "Étirement mollets", "instructions": "Un pied en avant, pousser le talon arrière au sol" },
+            { "name": "Respiration profonde", "instructions": "Inspirer 4s, bloquer 4s, expirer 4s — 3 cycles" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Renforcement & Gainage",
+      "description": "Focus core et posture avec des mouvements contrôlés et accessibles",
+      "focus": ["core", "posture"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Cat-cow", "instructions": "À quatre pattes, alterner dos rond et dos creux en respirant" },
+            {
+              "name": "Rotation thoracique",
+              "instructions": "À quatre pattes, une main derrière la tête, ouvrir le coude vers le ciel"
+            },
+            {
+              "name": "Balancement des bras",
+              "instructions": "Debout, laisser les bras se balancer de gauche à droite"
+            }
+          ]
+        },
+        {
+          "name": "Core & Posture",
+          "exercises": [
+            {
+              "name": "Dead bug",
+              "instructions": "Allongé, bras tendus vers le plafond, étendre une jambe et le bras opposé"
+            },
+            {
+              "name": "Superman",
+              "instructions": "Allongé sur le ventre, lever bras et jambes simultanément, tenir 2s"
+            },
+            {
+              "name": "Gainage latéral sur genoux",
+              "instructions": "Sur le coude et le genou, corps aligné, tenir 15 secondes chaque côté"
+            },
+            { "name": "Fentes arrière", "instructions": "Un grand pas en arrière, genou frôle le sol, remonter" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Genoux au sol, bras tendus devant, relâcher le dos" },
+            {
+              "name": "Torsion allongée",
+              "instructions": "Allongé, ramener un genou vers la poitrine et le laisser tomber de l'autre côté"
+            },
+            { "name": "Étirement psoas", "instructions": "Fente basse, pousser la hanche du genou au sol vers l'avant" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "Full-Body Progression",
+      "description": "On reprend les fondamentaux avec plus de volume et moins de repos",
+      "focus": ["full-body", "renforcement"],
+      "blocks": [
+        {
+          "name": "Échauffement actif",
+          "exercises": [
+            {
+              "name": "Jumping jacks légers",
+              "instructions": "Sauts modérés, bras au-dessus de la tête, rythme confortable"
+            },
+            {
+              "name": "Cercles de bras",
+              "instructions": "Petits cercles puis grands cercles, en avant puis en arrière"
+            },
+            {
+              "name": "Squats de mobilité",
+              "instructions": "Descendre doucement en squat profond, coudes à l'intérieur des genoux pour ouvrir les hanches"
+            }
+          ]
+        },
+        {
+          "name": "Renforcement global",
+          "exercises": [
+            {
+              "name": "Squats",
+              "instructions": "Pieds largeur épaules, descente contrôlée, pousser à travers les talons"
+            },
+            {
+              "name": "Pompes sur genoux",
+              "instructions": "Descendre la poitrine jusqu'au sol, remonter en expirant, garder les abdos serrés"
+            },
+            {
+              "name": "Fentes alternées",
+              "instructions": "Grand pas en avant, genou arrière frôle le sol, alterner les jambes"
+            },
+            {
+              "name": "Planche sur genoux",
+              "instructions": "Avant-bras au sol, genoux au sol, serrer les abdos, tenir 25 secondes"
+            },
+            {
+              "name": "Pont fessier",
+              "instructions": "Soulever les hanches, serrer les fessiers en haut 2 secondes, redescendre"
+            }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            {
+              "name": "Étirement quadriceps debout",
+              "instructions": "Attraper le pied, tirer le talon vers les fessiers, garder le genou pointé vers le sol"
+            },
+            {
+              "name": "Étirement fléchisseurs de hanche",
+              "instructions": "Genou au sol, avancer le bassin, sentir l'étirement devant la hanche"
+            },
+            {
+              "name": "Étirement dos",
+              "instructions": "Debout, croiser les mains devant soi, arrondir le dos en poussant les mains loin"
+            }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Cardio Progressif",
+      "description": "Circuits plus longs avec des mouvements dynamiques",
+      "focus": ["cardio", "endurance"],
+      "blocks": [
+        {
+          "name": "Échauffement cardio",
+          "exercises": [
+            { "name": "Montées de genoux modérées", "instructions": "Lever les genoux au-dessus des hanches" },
+            { "name": "Pas chassés", "instructions": "Pas latéraux rapides" },
+            { "name": "Rotations de hanches dynamiques", "instructions": "Lever un genou, faire un cercle" }
+          ]
+        },
+        {
+          "name": "Circuit Endurance",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Sauts avec bras au-dessus de la tête" },
+            { "name": "Squats avec impulsion", "instructions": "Squat classique, se mettre sur la pointe des pieds" },
+            {
+              "name": "Mountain climbers lents",
+              "instructions": "Position de pompe, ramener un genou vers la poitrine"
+            },
+            { "name": "Pas chassés + toucher sol", "instructions": "Trois pas latéraux, toucher le sol" },
+            { "name": "Fentes sautées légères", "instructions": "Petits sauts pour alterner" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Ralentir progressivement" },
+            { "name": "Étirement mollets au mur", "instructions": "Mains au mur, un pied en arrière" },
+            { "name": "Étirement adducteurs debout", "instructions": "Pieds très écartés, fléchir une jambe" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Core & Stabilité",
+      "description": "Renforcement du centre du corps",
+      "focus": ["core", "stabilité"],
+      "blocks": [
+        {
+          "name": "Échauffement ciblé",
+          "exercises": [
+            { "name": "Cat-cow", "instructions": "Dos rond sur l'expiration, dos creux sur l'inspiration" },
+            { "name": "Glute bridge", "instructions": "Monter les hanches sur 3 secondes, tenir 2 secondes" },
+            { "name": "Bird dog alterné", "instructions": "À quatre pattes, tendre bras droit et jambe gauche" }
+          ]
+        },
+        {
+          "name": "Gainage & Contrôle",
+          "exercises": [
+            { "name": "Dead bug", "instructions": "Dos plaqué au sol, tendre bras et jambe opposés" },
+            { "name": "Superman avec pause", "instructions": "Lever bras et jambes, tenir 3 secondes en haut" },
+            { "name": "Planche sur genoux", "instructions": "Avant-bras au sol, genoux au sol, tenir 30 secondes" },
+            { "name": "Gainage latéral sur genoux", "instructions": "Coude et genou au sol, hanches hautes" },
+            { "name": "Crunch inversé", "instructions": "Genoux à 90°, ramener les genoux vers la poitrine" }
+          ]
+        },
+        {
+          "name": "Étirements profonds",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Fesses sur les talons, bras tendus devant" },
+            { "name": "Cobra doux", "instructions": "Allongé sur le ventre, relever le buste doucement" },
+            { "name": "Torsion assise", "instructions": "Assis jambes croisées, tourner le buste" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "Full-Body Intermédiaire",
+      "description": "Variantes complètes des mouvements fondamentaux",
+      "focus": ["full-body", "force"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme modéré, bras bien tendus" },
+            { "name": "Fentes de mobilité", "instructions": "Fente avant profonde, coude vers le pied avant" },
+            { "name": "Inchworm", "instructions": "Debout, poser les mains au sol, marcher en planche" }
+          ]
+        },
+        {
+          "name": "Renforcement complet",
+          "exercises": [
+            { "name": "Squats", "instructions": "Descente sur 2 secondes, remonter en expirant" },
+            { "name": "Pompes classiques", "instructions": "Corps gainé, descendre la poitrine au sol, coudes à 45°" },
+            { "name": "Fentes arrière", "instructions": "Grand pas en arrière, genou frôle le sol" },
+            { "name": "Planche complète", "instructions": "Avant-bras et pointes de pieds, corps droit" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Étirement piriforme", "instructions": "Croiser une cheville sur le genou opposé" },
+            { "name": "Étirement épaules", "instructions": "Bras devant la poitrine, le maintenir avec l'autre main" },
+            { "name": "Étirement ischio-jambiers debout", "instructions": "Un pied sur un support, jambe tendue" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "Cardio EMOM",
+      "description": "Format EMOM pour structurer l'effort cardio",
+      "focus": ["cardio", "rythme"],
+      "blocks": [
+        {
+          "name": "Activation cardio",
+          "exercises": [
+            { "name": "Course sur place", "instructions": "Trottiner sur place, monter le rythme" },
+            { "name": "Montées de genoux dynamiques", "instructions": "Genoux hauts, bras en opposition" },
+            { "name": "Squats sautés légers", "instructions": "Squat classique puis petit saut" }
+          ]
+        },
+        {
+          "name": "EMOM Cardio 8 min",
+          "exercises": [
+            { "name": "Burpees sans saut", "instructions": "Descendre au sol, remonter debout" },
+            { "name": "Montées de genoux rapides", "instructions": "Genoux au-dessus des hanches, rythme rapide" }
+          ]
+        },
+        {
+          "name": "Finisher Cardio",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme rapide, bras tendus" },
+            { "name": "Squats sumo dynamiques", "instructions": "Pieds écartés, descendre et remonter sans pause" },
+            { "name": "Planche avec toucher d'épaule", "instructions": "Position de pompe, toucher l'épaule opposée" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Ralentir progressivement" },
+            { "name": "Étirement quadriceps", "instructions": "Debout, attraper un pied" },
+            { "name": "Respiration diaphragmatique", "instructions": "Mains sur le ventre, inspirer 5s, expirer 5s" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "Core Avancé",
+      "description": "Gainage complet sur les pieds et exercices de stabilité",
+      "focus": ["core", "stabilité"],
+      "blocks": [
+        {
+          "name": "Réveil du core",
+          "exercises": [
+            { "name": "Cat-cow dynamique", "instructions": "Alterner dos rond et creux rapidement" },
+            { "name": "Dead bug lent", "instructions": "Bras et jambes en l'air, étendre lentement" },
+            { "name": "Rotation thoracique debout", "instructions": "Bras croisés, tourner le haut du corps" }
+          ]
+        },
+        {
+          "name": "Gainage renforcé",
+          "exercises": [
+            { "name": "Planche complète", "instructions": "Avant-bras et pointes de pieds, corps parfaitement aligné" },
+            { "name": "Gainage latéral", "instructions": "Sur le coude et les pieds empilés, hanches hautes" },
+            { "name": "Dead bug avec extension complète", "instructions": "Dos plaqué au sol, étendre complètement" },
+            { "name": "Bicycle crunchs", "instructions": "Coude vers genou opposé en pédalant" },
+            { "name": "Superman nageur", "instructions": "Lever bras et jambes, alterner comme en nageant" }
+          ]
+        },
+        {
+          "name": "Étirements profonds",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Genoux écartés, bras tendus devant" },
+            { "name": "Cobra", "instructions": "Sur le ventre, pousser sur les mains pour relever le buste" },
+            { "name": "Torsion allongée", "instructions": "Bras en croix, genoux d'un côté" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "Full-Body Challenge",
+      "description": "Mouvements combinés et supersets",
+      "focus": ["full-body", "endurance musculaire"],
+      "blocks": [
+        {
+          "name": "Échauffement complet",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme soutenu, bras bien tendus" },
+            { "name": "Inchworm + pompe", "instructions": "Avancer en planche, 1 pompe, revenir debout" },
+            { "name": "Squat + rotation du buste", "instructions": "Descendre en squat, tourner le buste" }
+          ]
+        },
+        {
+          "name": "Supersets Full-Body",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Squats", "instructions": "Descente sur 2 secondes, remonter dynamiquement" },
+                { "name": "Pompes classiques", "instructions": "Corps gainé, descente contrôlée" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Fentes alternées", "instructions": "Grand pas en avant, genou arrière frôle le sol" },
+                {
+                  "name": "Planche avec toucher d'épaule",
+                  "instructions": "Position de pompe, toucher l'épaule opposée"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Finisher",
+          "exercises": [
+            { "name": "Glute bridge marché", "instructions": "Hanches en haut, faire un pas en avant" },
+            { "name": "Planche complète", "instructions": "Corps droit, serrer abdos et fessiers" }
+          ]
+        },
+        {
+          "name": "Étirements complets",
+          "exercises": [
+            { "name": "Étirement quadriceps", "instructions": "Attraper le pied, tirer vers les fessiers" },
+            { "name": "Étirement pectoraux au mur", "instructions": "Bras en L contre le mur" },
+            { "name": "Child's pose", "instructions": "Fesses sur les talons, bras tendus devant" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "Cardio Intense",
+      "description": "Circuit exigeant combinant mouvements composés",
+      "focus": ["cardio", "puissance"],
+      "blocks": [
+        {
+          "name": "Activation intense",
+          "exercises": [
+            { "name": "Course sur place", "instructions": "Monter le rythme progressivement" },
+            { "name": "Squats sautés", "instructions": "Squat profond, sauter en remontant" },
+            { "name": "Mountain climbers lents", "instructions": "Position de planche, ramener les genoux" }
+          ]
+        },
+        {
+          "name": "Circuit Haute Énergie",
+          "exercises": [
+            { "name": "Burpees sans saut", "instructions": "Descendre au sol, remonter debout" },
+            { "name": "Mountain climbers rapides", "instructions": "Alterner genoux vers poitrine vite" },
+            { "name": "Squats sautés", "instructions": "Descente contrôlée, sauter dynamiquement" },
+            { "name": "Planche avec rotation", "instructions": "Tourner le corps, bras au ciel" },
+            { "name": "Montées de genoux rapides", "instructions": "Sprint sur place, genoux hauts" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche sur place décélérée", "instructions": "Commencer vite et ralentir" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Un pied sur un support, jambe tendue" },
+            { "name": "Étirement mollets", "instructions": "Pointe du pied sur une marche" },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "Core & Contrôle Total",
+      "description": "Séance finale combinant gainage et stabilité",
+      "focus": ["core", "contrôle"],
+      "blocks": [
+        {
+          "name": "Activation profonde",
+          "exercises": [
+            { "name": "Cat-cow dynamique", "instructions": "Enchaîner dos rond et dos creux" },
+            { "name": "Inchworm", "instructions": "Debout, mains au sol, avancer en planche" },
+            { "name": "Dead bug échauffement", "instructions": "Dos au sol, bras et genoux à 90°" }
+          ]
+        },
+        {
+          "name": "EMOM Gainage 6 min",
+          "exercises": [
+            { "name": "Planche complète", "instructions": "Tenir 30 secondes en planche" },
+            { "name": "Bicycle crunchs", "instructions": "Coude vers genou opposé en pédalant" }
+          ]
+        },
+        {
+          "name": "Supersets Core",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Dead bug complet", "instructions": "Extension complète bras et jambe opposés" },
+                { "name": "Superman avec pause", "instructions": "Lever bras et jambes, tenir 3 secondes" }
+              ]
+            },
+            {
+              "exercises": [
+                {
+                  "name": "Gainage latéral avec rotation",
+                  "instructions": "Sur le coude, tourner le buste vers le sol"
+                },
+                { "name": "Hip thrust unilatéral", "instructions": "Un pied au sol, l'autre jambe en l'air" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Finisher stabilité",
+          "exercises": [
+            { "name": "Planche avec toucher pied", "instructions": "Monter les hanches en pike, toucher le pied" },
+            { "name": "Hollow hold", "instructions": "Dos au sol, bras et jambes tendus en l'air" }
+          ]
+        },
+        {
+          "name": "Détente finale",
+          "exercises": [
+            { "name": "Child's pose", "instructions": "Genoux écartés, bras tendus devant" },
+            { "name": "Torsion allongée", "instructions": "Bras en croix, genoux d'un côté" },
+            { "name": "Savasana", "instructions": "Allongé sur le dos, fermer les yeux, respirer calmement" }
+          ]
+        }
+      ]
+    }
+  },
+  "remise-en-forme": {
+    "1": {
+      "title": "Haut du corps",
+      "description": "Renforcement push/pull pour épaules, poitrine et dos",
+      "focus": ["haut du corps", "renforcement"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Arm circles", "instructions": "Grands cercles de bras vers l'avant puis vers l'arrière" },
+            { "name": "Inchworms", "instructions": "Debout, marcher les mains en planche, revenir debout" },
+            { "name": "Pompes contre mur", "instructions": "Mains au mur, pompes lentes pour échauffer les épaules" }
+          ]
+        },
+        {
+          "name": "Push & Pull",
+          "exercises": [
+            { "name": "Pompes classiques", "instructions": "Mains largeur épaules, corps gainé" },
+            { "name": "Pike push-ups", "instructions": "Position V inversé, plier les coudes" },
+            { "name": "Superman Y", "instructions": "Allongé, lever les bras en Y et les jambes" },
+            { "name": "Pompes diamant", "instructions": "Mains en losange sous la poitrine" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Étirement pectoraux", "instructions": "Bras tendu contre un mur, tourner le buste" },
+            { "name": "Étirement triceps", "instructions": "Bras au-dessus de la tête, plier le coude" },
+            { "name": "Étirement épaules", "instructions": "Bras tendu devant la poitrine" }
+          ]
+        }
+      ]
+    },
+    "2": {
+      "title": "Cardio Circuit",
+      "description": "Circuit complet pour relancer le cardio",
+      "focus": ["cardio", "full-body"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Écarter bras et jambes en sautant" },
+            { "name": "Montées de genoux", "instructions": "Genoux à hauteur des hanches" },
+            { "name": "Fentes avant dynamiques", "instructions": "Alterner les fentes en avançant" }
+          ]
+        },
+        {
+          "name": "Full-Body Cardio",
+          "exercises": [
+            { "name": "Burpees sans saut", "instructions": "Planche, pompe, remonter debout" },
+            { "name": "Squats sautés", "instructions": "Squat explosif avec saut" },
+            { "name": "Mountain climbers", "instructions": "En planche, genoux vers la poitrine" },
+            { "name": "Fentes sautées", "instructions": "Alterner les fentes en sautant" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Ralentir progressivement" },
+            { "name": "Étirement quadriceps", "instructions": "Attraper le pied derrière soi" },
+            { "name": "Child's pose", "instructions": "Genoux au sol, bras tendus devant" }
+          ]
+        }
+      ]
+    },
+    "3": {
+      "title": "Bas du corps & Core",
+      "description": "Cuisses, fessiers et abdominaux",
+      "focus": ["bas du corps", "core"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Cercles de hanches", "instructions": "Grands cercles dans les deux sens" },
+            { "name": "Good mornings", "instructions": "Mains derrière la tête, pencher le buste" },
+            { "name": "Squats légers", "instructions": "Squats lents pour échauffer les genoux" }
+          ]
+        },
+        {
+          "name": "Jambes & Core",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Squats sumo", "instructions": "Pieds écartés, pointes vers l'extérieur" },
+                { "name": "Crunchs", "instructions": "Soulever les épaules du sol" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Fentes bulgares", "instructions": "Pied arrière sur une chaise" },
+                { "name": "Planche", "instructions": "Avant-bras, corps aligné, 30 secondes" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Jambe croisée devant, pencher le buste" },
+            { "name": "Torsion allongée", "instructions": "Genou vers la poitrine, laisser tomber de l'autre côté" }
+          ]
+        }
+      ]
+    },
+    "4": {
+      "title": "EMOM Endurance",
+      "description": "Travail à la minute pour l'endurance musculaire",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rester léger sur les pieds" },
+            { "name": "Inchworms", "instructions": "Marcher les mains en planche, pompe, revenir" },
+            { "name": "Squats dynamiques", "instructions": "Descendre et remonter rapidement" }
+          ]
+        },
+        {
+          "name": "EMOM 12 minutes",
+          "exercises": [
+            { "name": "Pompes", "instructions": "Pompes classiques, rythme régulier" },
+            { "name": "Squats sautés", "instructions": "Exploser vers le haut, amortir en douceur" },
+            { "name": "Mountain climbers", "instructions": "Genoux vers la poitrine rapidement" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Assis, jambes tendues, pencher le buste" },
+            { "name": "Child's pose", "instructions": "Genoux au sol, bras tendus, relâcher" }
+          ]
+        }
+      ]
+    },
+    "5": {
+      "title": "Haut du corps — Force",
+      "description": "Renforcement progressif avec supersets push/pull",
+      "focus": ["haut du corps", "renforcement"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Arm circles progressifs", "instructions": "Petits cercles puis grands cercles" },
+            { "name": "Pompes inclinées", "instructions": "Mains sur une chaise, pompes lentes" },
+            { "name": "Scapular push-ups", "instructions": "En planche, rapprocher et écarter les omoplates" }
+          ]
+        },
+        {
+          "name": "Push & Pull supersets",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Pompes classiques", "instructions": "Descendre la poitrine au sol, rythme contrôlé" },
+                { "name": "Superman W", "instructions": "Lever le buste et tirer les coudes en W" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Pike push-ups", "instructions": "Position V inversé, contrôler la descente" },
+                { "name": "Reverse snow angels", "instructions": "Bras en arc de cercle au-dessus de la tête" }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Finition triceps",
+          "exercises": [
+            { "name": "Pompes diamant", "instructions": "Mains en losange, coudes serrés" },
+            { "name": "Dips sur chaise", "instructions": "Descendre les fesses, coudes à 90°" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Étirement pectoraux au sol", "instructions": "Bras tendu à 90°, rouler doucement" },
+            { "name": "Étirement dorsaux", "instructions": "À genoux, bras tendus, pousser les hanches" },
+            { "name": "Étirement triceps", "instructions": "Bras au-dessus de la tête, plier le coude" }
+          ]
+        }
+      ]
+    },
+    "6": {
+      "title": "Cardio HIIT",
+      "description": "Intervalles haute intensité pour le cardio",
+      "focus": ["cardio", "hiit"],
+      "blocks": [
+        {
+          "name": "Échauffement dynamique",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme progressif" },
+            { "name": "High knees", "instructions": "Genoux au-dessus des hanches" },
+            { "name": "Fentes latérales dynamiques", "instructions": "Alterner gauche-droite" }
+          ]
+        },
+        {
+          "name": "HIIT Full-Body",
+          "exercises": [
+            { "name": "Burpees complets", "instructions": "Planche, pompe, saut explosif" },
+            { "name": "Speed squats", "instructions": "Squats rapides et profonds" },
+            { "name": "Planche commando", "instructions": "Alterner avant-bras et bras tendus" },
+            { "name": "Tuck jumps", "instructions": "Sauter genoux vers la poitrine" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche sur place", "instructions": "Ralentir le rythme cardiaque" },
+            { "name": "Étirement fléchisseurs de hanche", "instructions": "Genou arrière au sol, hanche en avant" },
+            { "name": "Respiration diaphragmatique", "instructions": "Mains sur le ventre, inspirer 4s, expirer 6s" }
+          ]
+        }
+      ]
+    },
+    "7": {
+      "title": "Bas du corps & Core — Volume",
+      "description": "Montée en volume sur les jambes",
+      "focus": ["bas du corps", "core"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Cercles de chevilles", "instructions": "Pointe du pied, dessiner des cercles" },
+            { "name": "Good mornings", "instructions": "Pencher le buste, dos plat" },
+            { "name": "Squats avec pause", "instructions": "Descendre, tenir 3 secondes en bas" }
+          ]
+        },
+        {
+          "name": "Jambes — Volume",
+          "exercises": [
+            { "name": "Squats sumo", "instructions": "Pieds écartés, descendre lentement" },
+            { "name": "Fentes bulgares", "instructions": "Pied arrière sur une chaise" },
+            { "name": "Hip thrust unilatéral", "instructions": "Une jambe tendue en l'air" }
+          ]
+        },
+        {
+          "name": "Core intensif",
+          "exercises": [
+            { "name": "Bicycle crunchs", "instructions": "Coude vers genou opposé" },
+            { "name": "Planche", "instructions": "Corps aligné tête-pieds" },
+            { "name": "Russian twists", "instructions": "Pieds décollés, tourner le buste" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Jambe croisée devant, relâcher le buste" },
+            { "name": "Étirement quadriceps allongé", "instructions": "Allongé sur le côté, attraper le pied" },
+            { "name": "Cobra", "instructions": "Pousser les mains pour étirer les abdos" }
+          ]
+        }
+      ]
+    },
+    "8": {
+      "title": "EMOM Endurance +",
+      "description": "EMOM allongé avec plus de répétitions",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme progressif" },
+            { "name": "Inchworms avec pompe", "instructions": "Marcher en planche, pompe, revenir" },
+            { "name": "Fentes dynamiques", "instructions": "Alterner les fentes, grands pas" }
+          ]
+        },
+        {
+          "name": "EMOM 15 minutes",
+          "exercises": [
+            { "name": "Pompes", "instructions": "Pompes classiques, tempo régulier" },
+            { "name": "Squats sautés", "instructions": "Exploser vers le haut, réception souple" },
+            { "name": "Mountain climbers", "instructions": "Genoux vers la poitrine, rythme rapide" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Assis, jambes tendues, pencher le buste" },
+            { "name": "Child's pose", "instructions": "Front au sol, relâcher complètement" }
+          ]
+        }
+      ]
+    },
+    "9": {
+      "title": "Haut du corps — Puissance",
+      "description": "Variations explosives et avancées",
+      "focus": ["haut du corps", "puissance"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Arm circles", "instructions": "Cercles rapides" },
+            { "name": "Pompes inclinées rapides", "instructions": "Pompes rapides mains sur une chaise" },
+            { "name": "Bear crawl", "instructions": "Avancer en quadrupédie genoux décollés" }
+          ]
+        },
+        {
+          "name": "Push explosif",
+          "exercises": [
+            { "name": "Pompes claquées", "instructions": "Pousser explosivement, mains décollent du sol" },
+            {
+              "name": "Pike push-ups pieds surélevés",
+              "instructions": "Pieds sur une chaise, position V, contrôler la descente"
+            },
+            { "name": "Pompes archer", "instructions": "Un bras fait la pompe, l'autre est tendu" }
+          ]
+        },
+        {
+          "name": "Finition volume",
+          "exercises": [
+            { "name": "Pompes diamant", "instructions": "Mains en losange, coudes serrés" },
+            { "name": "Dips sur chaise", "instructions": "Descendre les fesses, coudes à 90°" },
+            { "name": "Superman nageur", "instructions": "Lever bras et jambes, alterner comme en nageant" },
+            { "name": "Planche commando", "instructions": "Alterner avant-bras et bras tendus" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Étirement pectoraux", "instructions": "Bras contre le mur, tourner le buste" },
+            { "name": "Étirement dorsaux", "instructions": "À genoux, bras tendus, pousser les hanches" },
+            { "name": "Étirement cou", "instructions": "Incliner la tête, main sur la tempe" }
+          ]
+        }
+      ]
+    },
+    "10": {
+      "title": "Cardio Tabata",
+      "description": "Format Tabata : 20s effort / 10s repos",
+      "focus": ["cardio", "tabata"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme soutenu" },
+            { "name": "Burpees lents", "instructions": "5 burpees contrôlés pour échauffer" },
+            { "name": "Fentes sautées légères", "instructions": "Petits sauts entre les fentes" }
+          ]
+        },
+        {
+          "name": "Tabata Cardio",
+          "exercises": [
+            { "name": "Burpees complets", "instructions": "Planche, pompe, saut explosif" },
+            { "name": "Mountain climbers sprint", "instructions": "Rythme maximal" },
+            { "name": "Squats sautés", "instructions": "Squat profond, saut maximal" },
+            { "name": "Planche saut écart", "instructions": "En planche, sauter pieds écartés puis serrés" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche lente", "instructions": "Décélérer complètement" },
+            { "name": "Étirement quadriceps", "instructions": "Attraper le pied derrière soi" },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" }
+          ]
+        }
+      ]
+    },
+    "11": {
+      "title": "Bas du corps & Core — Explosif",
+      "description": "Mouvements explosifs pour les jambes et gainage avancé",
+      "focus": ["bas du corps", "puissance"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Squats progressifs", "instructions": "5 lents, 5 normaux, 5 rapides" },
+            { "name": "Fentes multiplanaires", "instructions": "Avant, latérale, arrière — chaque jambe" },
+            { "name": "Dead bug lent", "instructions": "Bras et jambes en l'air, étendre lentement" }
+          ]
+        },
+        {
+          "name": "Puissance Jambes",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Squats sautés avec pause", "instructions": "Descendre, pause 1s en bas, exploser" },
+                { "name": "V-ups", "instructions": "Lever jambes et buste simultanément" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Fentes sautées", "instructions": "Alterner en sautant, genou arrière frôle le sol" },
+                {
+                  "name": "Gainage latéral avec élévation de hanche",
+                  "instructions": "En planche latérale, descendre et remonter la hanche"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Abdos finition",
+          "exercises": [
+            { "name": "Bicycle crunchs", "instructions": "Coude vers genou opposé, rythme rapide" },
+            { "name": "Mountain climbers lents", "instructions": "Genou vers coude opposé, tenir 1 seconde" },
+            { "name": "Planche toucher de pieds", "instructions": "Main au pied opposé en passant sous le corps" }
+          ]
+        },
+        {
+          "name": "Étirements",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Jambe avant croisée, buste au sol" },
+            { "name": "Torsion allongée", "instructions": "Genoux d'un côté, bras en T" },
+            { "name": "Cobra", "instructions": "Pousser les mains, ouvrir la poitrine" }
+          ]
+        }
+      ]
+    },
+    "12": {
+      "title": "EMOM Endurance Avancé",
+      "description": "EMOM 16 min avec 4 exercices par minute",
+      "focus": ["endurance", "full-body"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Jumping jacks", "instructions": "Rythme soutenu" },
+            { "name": "Inchworms avec pompe", "instructions": "Marcher en planche, pompe, revenir" },
+            { "name": "Squats sautés légers", "instructions": "Petits sauts pour activer les jambes" }
+          ]
+        },
+        {
+          "name": "EMOM 16 minutes",
+          "exercises": [
+            { "name": "Burpees", "instructions": "Burpee complet avec pompe et saut" },
+            { "name": "Pompes", "instructions": "Pompes classiques, descendre au sol" },
+            { "name": "Squats sautés", "instructions": "Squat profond, saut maximal" },
+            { "name": "Mountain climbers", "instructions": "Genoux vers la poitrine, rythme rapide" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Assis, jambes tendues, pencher le buste" },
+            { "name": "Child's pose", "instructions": "Front au sol, relâcher complètement" }
+          ]
+        }
+      ]
+    },
+    "13": {
+      "title": "Haut du corps — Max Effort",
+      "description": "Séance intense combinant volume et explosivité",
+      "focus": ["haut du corps", "puissance"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Inchworms avec pompe", "instructions": "Marcher en planche, pompe, revenir" },
+            { "name": "Scapular push-ups", "instructions": "En planche, rapprocher et écarter les omoplates" },
+            { "name": "Bear crawl", "instructions": "Avancer en quadrupédie, genoux décollés" }
+          ]
+        },
+        {
+          "name": "Push Max",
+          "exercises": [
+            { "name": "Pompes claquées", "instructions": "Pousser explosivement, mains décollent" },
+            { "name": "Pike push-ups pieds surélevés", "instructions": "Pieds sur une chaise, contrôler la descente" },
+            { "name": "Pompes archer", "instructions": "Un bras fait la pompe, l'autre tendu" }
+          ]
+        },
+        {
+          "name": "Finition totale",
+          "exercises": [
+            { "name": "Pompes diamant", "instructions": "Mains en losange, coudes serrés" },
+            { "name": "Dips sur chaise", "instructions": "Descendre, coudes à 90°" },
+            { "name": "Superman nageur", "instructions": "Mouvement de nage, bras et jambes décollés" },
+            { "name": "Planche commando", "instructions": "Alterner avant-bras et bras tendus" }
+          ]
+        },
+        {
+          "name": "Étirements profonds",
+          "exercises": [
+            { "name": "Étirement pectoraux au sol", "instructions": "Allongé, bras en T, rouler sur un côté" },
+            { "name": "Étirement dorsaux", "instructions": "À genoux, bras tendus, pousser les hanches" },
+            { "name": "Étirement cou et trapèzes", "instructions": "Incliner la tête, main sur la tempe" }
+          ]
+        }
+      ]
+    },
+    "14": {
+      "title": "Cardio Extreme",
+      "description": "HIIT maximal avec enchaînements composés",
+      "focus": ["cardio", "hiit"],
+      "blocks": [
+        {
+          "name": "Échauffement haute intensité",
+          "exercises": [
+            { "name": "High knees rapides", "instructions": "Genoux au-dessus des hanches, rythme élevé" },
+            { "name": "Burpees contrôlés", "instructions": "5 burpees avec pompe, rythme modéré" },
+            { "name": "Fentes sautées légères", "instructions": "Petits sauts pour échauffer les cuisses" }
+          ]
+        },
+        {
+          "name": "HIIT Extreme",
+          "exercises": [
+            { "name": "Burpees avec tuck jump", "instructions": "Burpee complet puis saut genoux poitrine" },
+            { "name": "Mountain climbers sprint", "instructions": "Rythme maximal, genoux vers la poitrine" },
+            { "name": "Squats sautés 180", "instructions": "Squat sauté avec demi-tour en l'air" },
+            { "name": "Planche saut écart", "instructions": "En planche, pieds écartés puis serrés" }
+          ]
+        },
+        {
+          "name": "Retour au calme",
+          "exercises": [
+            { "name": "Marche très lente", "instructions": "Expirer longuement à chaque pas" },
+            { "name": "Étirement quadriceps", "instructions": "Attraper le pied, tirer doucement" },
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s" }
+          ]
+        }
+      ]
+    },
+    "15": {
+      "title": "Bas du corps & Core — Total",
+      "description": "Séance combinée jambes et abdominaux maximum",
+      "focus": ["bas du corps", "core", "puissance"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Squats progressifs", "instructions": "5 lents, 5 normaux, 5 rapides" },
+            { "name": "Fentes multiplanaires", "instructions": "Avant, latérale, arrière — chaque jambe" },
+            { "name": "Dead bug lent", "instructions": "Bras et jambes en l'air, étendre lentement" }
+          ]
+        },
+        {
+          "name": "Puissance Jambes Max",
+          "pairs": [
+            {
+              "exercises": [
+                { "name": "Squats sautés avec pause", "instructions": "Descendre, pause 1s, exploser" },
+                { "name": "V-ups", "instructions": "Lever jambes et buste simultanément" }
+              ]
+            },
+            {
+              "exercises": [
+                { "name": "Fentes sautées", "instructions": "Alterner en sautant, genou frôle le sol" },
+                {
+                  "name": "Gainage latéral avec élévation de hanche",
+                  "instructions": "Descendre la hanche au sol puis remonter"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Abdos finition",
+          "exercises": [
+            { "name": "Bicycle crunchs rapides", "instructions": "Coude vers genou opposé, rythme maximal" },
+            { "name": "Mountain climbers lents", "instructions": "Genou vers coude opposé, tenir 1 seconde" },
+            { "name": "Planche toucher de pieds", "instructions": "Main au pied opposé sous le corps" }
+          ]
+        },
+        {
+          "name": "Étirements profonds",
+          "exercises": [
+            { "name": "Pigeon stretch", "instructions": "Jambe avant croisée, buste au sol" },
+            { "name": "Torsion allongée", "instructions": "Genoux d'un côté, bras en T" },
+            { "name": "Cobra", "instructions": "Pousser les mains, ouvrir la poitrine" }
+          ]
+        }
+      ]
+    },
+    "16": {
+      "title": "EMOM Endurance Finale",
+      "description": "EMOM ultime avec exercices composés",
+      "focus": ["endurance", "full-body", "puissance"],
+      "blocks": [
+        {
+          "name": "Échauffement",
+          "exercises": [
+            { "name": "Jumping jacks rapides", "instructions": "Rythme soutenu, bras tendus" },
+            {
+              "name": "Inchworms avec pompe et rotation",
+              "instructions": "Inchworm, pompe, rotation en T bras au ciel"
+            },
+            { "name": "Fentes sautées légères", "instructions": "Petits sauts pour activer les jambes" }
+          ]
+        },
+        {
+          "name": "EMOM 20 minutes",
+          "exercises": [
+            { "name": "Burpees avec pompe", "instructions": "Burpee complet avec pompe et saut" },
+            { "name": "Pike push-ups", "instructions": "Position V inversé, descente contrôlée" },
+            { "name": "Squats sautés", "instructions": "Squat profond, saut maximal, amortir en silence" },
+            { "name": "Mountain climbers croisés", "instructions": "Genou vers coude opposé, rythme rapide" }
+          ]
+        },
+        {
+          "name": "Retour au calme final",
+          "exercises": [
+            { "name": "Respiration 4-7-8", "instructions": "Inspirer 4s, bloquer 7s, expirer 8s — 5 cycles" },
+            { "name": "Étirement ischio-jambiers", "instructions": "Assis, jambes tendues, pencher le buste" },
+            { "name": "Child's pose", "instructions": "Genoux écartés, bras devant, relâcher complètement" }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/utils/programLocale.test.ts
+++ b/src/utils/programLocale.test.ts
@@ -1,0 +1,155 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import { localizedProgramFields } from './programLocale.ts';
+
+// Minimal stub matching the slice of i18next's TFunction the helper actually
+// invokes. The helper calls `t(key, options)`; we look up `options.defaultValue`
+// or pull from a fake i18n catalog keyed by the same composite key.
+function makeT(catalog: Record<string, unknown>): TFunction {
+  return ((key: string, options?: { defaultValue?: unknown; returnObjects?: boolean }) => {
+    if (key in catalog) return catalog[key];
+    return options?.defaultValue ?? key;
+  }) as unknown as TFunction;
+}
+
+describe('localizedProgramFields', () => {
+  it('returns DB values verbatim for non-fixed programs (passthrough)', () => {
+    const t = makeT({});
+    const program = {
+      slug: 'my-ai-program',
+      title: 'My AI Program',
+      description: 'Generated for me',
+      goals: ['Get strong'],
+      is_fixed: false,
+    };
+    expect(localizedProgramFields(program, t)).toEqual({
+      title: 'My AI Program',
+      description: 'Generated for me',
+      goals: ['Get strong'],
+    });
+  });
+
+  it('returns DB values when neither is_fixed nor isFixed is set', () => {
+    const t = makeT({});
+    const program = {
+      slug: 'whatever',
+      title: 'X',
+      description: 'Y',
+      goals: ['Z'],
+    };
+    expect(localizedProgramFields(program, t)).toEqual({
+      title: 'X',
+      description: 'Y',
+      goals: ['Z'],
+    });
+  });
+
+  it('overrides DB values with i18n entries for fixed programs (snake_case is_fixed)', () => {
+    const t = makeT({
+      'programs_data:cardio-express.title': 'Cardio Express EN',
+      'programs_data:cardio-express.description': 'Short and intense',
+      'programs_data:cardio-express.goals': ['Improve cardio', 'Maximize time'],
+    });
+    const program = {
+      slug: 'cardio-express',
+      title: 'Cardio Express',
+      description: 'Sessions courtes',
+      goals: ['Améliorer le cardio', 'Maximiser le temps'],
+      is_fixed: true,
+    };
+    expect(localizedProgramFields(program, t)).toEqual({
+      title: 'Cardio Express EN',
+      description: 'Short and intense',
+      goals: ['Improve cardio', 'Maximize time'],
+    });
+  });
+
+  it('overrides DB values for fixed programs flagged with camelCase isFixed (active program shape)', () => {
+    const t = makeT({
+      'programs_data:debutant-4-semaines.title': 'Beginner 4 weeks',
+      'programs_data:debutant-4-semaines.goals': ['Discover basics'],
+    });
+    const activeProgram = {
+      slug: 'debutant-4-semaines',
+      title: 'Débutant 4 semaines',
+      goals: ['Découvrir'],
+      isFixed: true,
+    };
+    const result = localizedProgramFields(activeProgram, t);
+    expect(result.title).toBe('Beginner 4 weeks');
+    expect(result.goals).toEqual(['Discover basics']);
+  });
+
+  it('falls back to DB values when an i18n key is missing for a fixed program', () => {
+    const t = makeT({
+      'programs_data:remise-en-forme.title': 'Get back in shape',
+      // description and goals intentionally absent
+    });
+    const program = {
+      slug: 'remise-en-forme',
+      title: 'Remise en forme',
+      description: 'Programme complet',
+      goals: ['Retrouver la forme'],
+      is_fixed: true,
+    };
+    expect(localizedProgramFields(program, t)).toEqual({
+      title: 'Get back in shape',
+      description: 'Programme complet',
+      goals: ['Retrouver la forme'],
+    });
+  });
+
+  it('treats an empty i18n title as missing and keeps the DB title', () => {
+    const t = makeT({
+      'programs_data:cardio-express.title': '',
+      'programs_data:cardio-express.goals': ['x'],
+    });
+    const program = {
+      slug: 'cardio-express',
+      title: 'Cardio Express',
+      description: null,
+      goals: ['y'],
+      is_fixed: true,
+    };
+    expect(localizedProgramFields(program, t).title).toBe('Cardio Express');
+  });
+
+  it('returns null description when neither i18n nor DB provide one', () => {
+    const t = makeT({});
+    const program = {
+      slug: 'cardio-express',
+      title: 'Cardio Express',
+      description: null,
+      goals: [],
+      is_fixed: true,
+    };
+    expect(localizedProgramFields(program, t).description).toBeNull();
+  });
+
+  it('handles null/undefined goals on the input', () => {
+    const t = makeT({});
+    const program = {
+      slug: 'unknown',
+      title: 'X',
+      description: 'D',
+      // goals omitted
+      is_fixed: false,
+    };
+    expect(localizedProgramFields(program, t).goals).toEqual([]);
+  });
+
+  it('falls back to DB goals when the i18n entry is not an array', () => {
+    const t = makeT({
+      'programs_data:cardio-express.title': 'Cardio Express',
+      'programs_data:cardio-express.goals': 'not-an-array',
+    });
+    const program = {
+      slug: 'cardio-express',
+      title: 'X',
+      description: null,
+      goals: ['db-goal'],
+      is_fixed: true,
+    };
+    expect(localizedProgramFields(program, t).goals).toEqual(['db-goal']);
+  });
+});

--- a/src/utils/programLocale.ts
+++ b/src/utils/programLocale.ts
@@ -1,0 +1,50 @@
+import type { TFunction } from 'i18next';
+
+export interface LocalizedProgramFields {
+  title: string;
+  description: string | null;
+  goals: string[];
+}
+
+interface ProgramFieldsInput {
+  slug: string;
+  title: string;
+  description?: string | null;
+  goals?: string[] | null;
+  /** snake_case from DB rows. */
+  is_fixed?: boolean;
+  /** camelCase from the active-program RPC. */
+  isFixed?: boolean;
+}
+
+// The 3 seed programs were inserted in migration 002 with French-only
+// title/description/goals columns. The localised content lives instead
+// in src/i18n/locales/{fr,en}/programs_data.json under the `programs_data`
+// namespace (see src/data/programContent.ts comment for the convention).
+// AI-generated user programs already store locale-native content in the
+// DB (Claude generates in the user's locale), so they're returned as-is.
+//
+// Falls back to the DB row values when a key is missing — defensive,
+// the i18n entries should always exist for fixed programs.
+export function localizedProgramFields(program: ProgramFieldsInput, t: TFunction): LocalizedProgramFields {
+  const fixed = program.is_fixed ?? program.isFixed ?? false;
+  const fallbackTitle = program.title;
+  const fallbackDescription = program.description ?? null;
+  const fallbackGoals = program.goals ?? [];
+
+  if (!fixed) {
+    return { title: fallbackTitle, description: fallbackDescription, goals: fallbackGoals };
+  }
+
+  const title = t(`programs_data:${program.slug}.title`, { defaultValue: fallbackTitle });
+  const descriptionRaw = t(`programs_data:${program.slug}.description`, {
+    defaultValue: fallbackDescription ?? '',
+  });
+  const goalsRaw = t(`programs_data:${program.slug}.goals`, {
+    returnObjects: true,
+    defaultValue: fallbackGoals,
+  });
+  const description = typeof descriptionRaw === 'string' && descriptionRaw.length > 0 ? descriptionRaw : null;
+  const goals = Array.isArray(goalsRaw) ? (goalsRaw as string[]) : fallbackGoals;
+  return { title, description, goals };
+}

--- a/src/utils/programLocale.ts
+++ b/src/utils/programLocale.ts
@@ -36,7 +36,7 @@ export function localizedProgramFields(program: ProgramFieldsInput, t: TFunction
     return { title: fallbackTitle, description: fallbackDescription, goals: fallbackGoals };
   }
 
-  const title = t(`programs_data:${program.slug}.title`, { defaultValue: fallbackTitle });
+  const titleRaw = t(`programs_data:${program.slug}.title`, { defaultValue: fallbackTitle });
   const descriptionRaw = t(`programs_data:${program.slug}.description`, {
     defaultValue: fallbackDescription ?? '',
   });
@@ -44,6 +44,7 @@ export function localizedProgramFields(program: ProgramFieldsInput, t: TFunction
     returnObjects: true,
     defaultValue: fallbackGoals,
   });
+  const title = typeof titleRaw === 'string' && titleRaw.length > 0 ? titleRaw : fallbackTitle;
   const description = typeof descriptionRaw === 'string' && descriptionRaw.length > 0 ? descriptionRaw : null;
   const goals = Array.isArray(goalsRaw) ? (goalsRaw as string[]) : fallbackGoals;
   return { title, description, goals };

--- a/src/utils/sessionLocale.test.ts
+++ b/src/utils/sessionLocale.test.ts
@@ -1,0 +1,213 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import type { Session } from '../types/session.ts';
+import { localizedSessionData } from './sessionLocale.ts';
+
+function makeT(catalog: Record<string, unknown>): TFunction {
+  return ((key: string, options?: { defaultValue?: unknown }) => {
+    if (key in catalog) return catalog[key];
+    return options?.defaultValue ?? null;
+  }) as unknown as TFunction;
+}
+
+const baseSession: Session = {
+  date: '2026-05-06',
+  title: 'Découverte Full-Body',
+  description: 'Premiers mouvements',
+  estimatedDuration: 25,
+  focus: ['full-body', 'mobilité'],
+  blocks: [
+    {
+      type: 'warmup',
+      name: 'Échauffement',
+      exercises: [
+        { name: 'Jumping jacks', duration: 30, instructions: 'Rythme soutenu' },
+        { name: 'Cercles épaules', duration: 30, instructions: 'Mouvement contrôlé' },
+      ],
+    },
+    {
+      type: 'classic',
+      name: 'Renforcement bas du corps',
+      restBetweenExercises: 30,
+      exercises: [{ name: 'Squats', sets: 3, reps: 12, restBetweenSets: 60, instructions: 'Dos droit' }],
+    },
+  ],
+};
+
+describe('localizedSessionData', () => {
+  it('returns the DB session unchanged for an unknown program slug (AI-generated programs)', () => {
+    const t = makeT({});
+    const result = localizedSessionData('user-ai-program', 1, baseSession, t);
+    expect(result).toBe(baseSession); // identity, no clone
+  });
+
+  it('returns the DB session unchanged when no i18n entry exists for that fixed program/order', () => {
+    const t = makeT({}); // catalog empty
+    const result = localizedSessionData('cardio-express', 99, baseSession, t);
+    expect(result).toEqual(baseSession);
+  });
+
+  it('overrides title, description and focus when i18n provides them', () => {
+    const t = makeT({
+      'sessions_data:debutant-4-semaines.1': {
+        title: 'Discovery Full-Body',
+        description: 'First moves',
+        focus: ['full-body', 'mobility'],
+      },
+    });
+    const result = localizedSessionData('debutant-4-semaines', 1, baseSession, t);
+    expect(result.title).toBe('Discovery Full-Body');
+    expect(result.description).toBe('First moves');
+    expect(result.focus).toEqual(['full-body', 'mobility']);
+  });
+
+  it('preserves DB structural fields (sets, reps, duration, restBetween*, type) under i18n merge', () => {
+    const t = makeT({
+      'sessions_data:debutant-4-semaines.1': {
+        title: 'Discovery Full-Body',
+        blocks: [
+          {
+            name: 'Warm-up',
+            exercises: [
+              { name: 'Jumping jacks EN', instructions: 'Steady pace' },
+              { name: 'Shoulder circles', instructions: 'Controlled' },
+            ],
+          },
+          {
+            name: 'Lower-body strength',
+            exercises: [{ name: 'Squats', instructions: 'Back straight' }],
+          },
+        ],
+      },
+    });
+    const result = localizedSessionData('debutant-4-semaines', 1, baseSession, t);
+    // Block names overridden
+    expect(result.blocks[0].name).toBe('Warm-up');
+    expect(result.blocks[1].name).toBe('Lower-body strength');
+    // Block types unchanged
+    expect(result.blocks[0].type).toBe('warmup');
+    expect(result.blocks[1].type).toBe('classic');
+    // Exercise names/instructions overridden
+    const warmup = result.blocks[0] as { exercises: { name: string; instructions: string; duration: number }[] };
+    expect(warmup.exercises[0].name).toBe('Jumping jacks EN');
+    expect(warmup.exercises[0].instructions).toBe('Steady pace');
+    expect(warmup.exercises[0].duration).toBe(30); // structural, untouched
+    // Classic block keeps sets/reps/rest from DB
+    const classic = result.blocks[1] as {
+      restBetweenExercises: number;
+      exercises: { sets: number; reps: number; restBetweenSets: number }[];
+    };
+    expect(classic.restBetweenExercises).toBe(30);
+    expect(classic.exercises[0].sets).toBe(3);
+    expect(classic.exercises[0].reps).toBe(12);
+    expect(classic.exercises[0].restBetweenSets).toBe(60);
+  });
+
+  it('leaves DB blocks intact when i18n has fewer blocks than DB', () => {
+    const t = makeT({
+      'sessions_data:cardio-express.1': {
+        title: 'Cardio',
+        blocks: [{ name: 'Warm-up only' }], // only 1 block, DB has 2
+      },
+    });
+    const result = localizedSessionData('cardio-express', 1, baseSession, t);
+    expect(result.blocks[0].name).toBe('Warm-up only');
+    expect(result.blocks[1].name).toBe('Renforcement bas du corps'); // DB FR preserved
+  });
+
+  it('leaves DB exercises intact when i18n has fewer exercises than DB inside a block', () => {
+    const t = makeT({
+      'sessions_data:cardio-express.1': {
+        title: 'Cardio',
+        blocks: [
+          {
+            name: 'Warm-up',
+            exercises: [{ name: 'Jumping jacks EN', instructions: 'Steady pace' }],
+            // i18n has only 1 exercise, DB has 2
+          },
+        ],
+      },
+    });
+    const result = localizedSessionData('cardio-express', 1, baseSession, t);
+    const warmup = result.blocks[0] as { exercises: { name: string; instructions: string }[] };
+    expect(warmup.exercises[0].name).toBe('Jumping jacks EN');
+    expect(warmup.exercises[1].name).toBe('Cercles épaules'); // DB FR preserved
+  });
+
+  it('merges superset pairs without losing structural fields', () => {
+    const supersetSession: Session = {
+      ...baseSession,
+      blocks: [
+        {
+          type: 'superset',
+          name: 'Pectoraux & dos',
+          sets: 3,
+          restBetweenSets: 60,
+          pairs: [
+            {
+              exercises: [
+                { name: 'Pompes', reps: 10, instructions: 'Coudes serrés' },
+                { name: 'Tractions', reps: 8, instructions: 'Mouvement complet' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const t = makeT({
+      'sessions_data:remise-en-forme.3': {
+        title: 'Chest & back',
+        blocks: [
+          {
+            name: 'Chest & back',
+            pairs: [
+              {
+                exercises: [
+                  { name: 'Push-ups', instructions: 'Elbows tight' },
+                  { name: 'Pull-ups', instructions: 'Full range' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const result = localizedSessionData('remise-en-forme', 3, supersetSession, t);
+    const block = result.blocks[0] as {
+      type: 'superset';
+      name: string;
+      sets: number;
+      restBetweenSets: number;
+      pairs: { exercises: { name: string; instructions: string; reps: number }[] }[];
+    };
+    expect(block.type).toBe('superset');
+    expect(block.name).toBe('Chest & back');
+    expect(block.sets).toBe(3); // structural, untouched
+    expect(block.restBetweenSets).toBe(60);
+    expect(block.pairs[0].exercises[0].name).toBe('Push-ups');
+    expect(block.pairs[0].exercises[0].reps).toBe(10);
+    expect(block.pairs[0].exercises[1].name).toBe('Pull-ups');
+  });
+
+  it('does not mutate the input DB session', () => {
+    const t = makeT({
+      'sessions_data:cardio-express.1': {
+        title: 'Cardio',
+        blocks: [{ name: 'Warm-up EN' }],
+      },
+    });
+    const original = JSON.parse(JSON.stringify(baseSession)) as Session;
+    localizedSessionData('cardio-express', 1, baseSession, t);
+    expect(baseSession).toEqual(original);
+  });
+
+  it('falls back to DB title when i18n title is empty string', () => {
+    const t = makeT({
+      'sessions_data:cardio-express.1': {
+        title: '',
+      },
+    });
+    const result = localizedSessionData('cardio-express', 1, baseSession, t);
+    expect(result.title).toBe('Découverte Full-Body');
+  });
+});

--- a/src/utils/sessionLocale.ts
+++ b/src/utils/sessionLocale.ts
@@ -1,0 +1,128 @@
+import type { TFunction } from 'i18next';
+import type { Block, Session } from '../types/session.ts';
+
+interface I18nAlternative {
+  name?: string;
+  equipment?: string;
+  instructions?: string;
+}
+
+interface I18nExercise {
+  name?: string;
+  instructions?: string;
+  alternative?: I18nAlternative;
+}
+
+interface I18nPair {
+  exercises?: I18nExercise[];
+}
+
+interface I18nBlock {
+  name?: string;
+  exercises?: I18nExercise[];
+  pairs?: I18nPair[];
+}
+
+interface I18nSession {
+  title?: string;
+  description?: string;
+  focus?: string[];
+  blocks?: I18nBlock[];
+}
+
+function isI18nSession(value: unknown): value is I18nSession {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Merge a DB exercise with its localised counterpart. Structural fields
+// (sets, reps, duration, bilateral, mode, etc.) come from the DB. Only
+// `name`, `instructions` and `alternative.{name,equipment,instructions}`
+// are overridden when an i18n entry is present.
+function mergeExercise<T extends { name: string; instructions?: string; alternative?: unknown }>(
+  dbEx: T,
+  i18nEx: I18nExercise | undefined,
+): T {
+  if (!i18nEx) return dbEx;
+  const merged: T = { ...dbEx };
+  if (typeof i18nEx.name === 'string' && i18nEx.name.length > 0) {
+    (merged as { name: string }).name = i18nEx.name;
+  }
+  if (typeof i18nEx.instructions === 'string' && i18nEx.instructions.length > 0) {
+    (merged as { instructions?: string }).instructions = i18nEx.instructions;
+  }
+  if (i18nEx.alternative && dbEx.alternative && typeof dbEx.alternative === 'object') {
+    const dbAlt = dbEx.alternative as { name: string; equipment?: string; instructions?: string };
+    const altMerged = { ...dbAlt };
+    if (typeof i18nEx.alternative.name === 'string') altMerged.name = i18nEx.alternative.name;
+    if (typeof i18nEx.alternative.equipment === 'string') altMerged.equipment = i18nEx.alternative.equipment;
+    if (typeof i18nEx.alternative.instructions === 'string') altMerged.instructions = i18nEx.alternative.instructions;
+    (merged as { alternative?: unknown }).alternative = altMerged;
+  }
+  return merged;
+}
+
+function mergeBlock(dbBlock: Block, i18nBlock: I18nBlock | undefined): Block {
+  if (!i18nBlock) return dbBlock;
+  const result: Block = { ...dbBlock };
+  if (typeof i18nBlock.name === 'string' && i18nBlock.name.length > 0) {
+    result.name = i18nBlock.name;
+  }
+  if (result.type === 'superset') {
+    if (Array.isArray(i18nBlock.pairs)) {
+      result.pairs = result.pairs.map((dbPair, idx) => {
+        const i18nPair = i18nBlock.pairs?.[idx];
+        if (!i18nPair?.exercises) return dbPair;
+        return {
+          ...dbPair,
+          exercises: dbPair.exercises.map((dbEx, exIdx) => mergeExercise(dbEx, i18nPair.exercises?.[exIdx])),
+        };
+      });
+    }
+    return result;
+  }
+  if ('exercises' in result && Array.isArray(result.exercises) && Array.isArray(i18nBlock.exercises)) {
+    // Block is one of the variants whose `exercises` field is mutable; we
+    // type-cast through unknown because TS can't narrow across the union.
+    const dbExs = result.exercises as { name: string; instructions?: string; alternative?: unknown }[];
+    const i18nExs = i18nBlock.exercises;
+    (result as unknown as { exercises: typeof dbExs }).exercises = dbExs.map((dbEx, idx) =>
+      mergeExercise(dbEx, i18nExs[idx]),
+    );
+  }
+  return result;
+}
+
+const FIXED_PROGRAM_SLUGS = new Set(['debutant-4-semaines', 'remise-en-forme', 'cardio-express']);
+
+// Fixed (seed) programs were inserted in migration 002 with French-only
+// session_data JSONB. The localised content lives in
+// src/i18n/locales/{fr,en}/sessions_data.json keyed by
+// `<programSlug>.<sessionOrder>`. AI-generated user programs already store
+// locale-native content, so they're returned as-is.
+//
+// Only the translatable fields are overridden — structural fields (sets,
+// reps, durations, etc.) always come from the DB so the runtime engine
+// stays in sync with the data the user actually completed.
+export function localizedSessionData(
+  programSlug: string,
+  sessionOrder: number,
+  dbSession: Session,
+  t: TFunction,
+): Session {
+  if (!FIXED_PROGRAM_SLUGS.has(programSlug)) return dbSession;
+
+  const raw = t(`sessions_data:${programSlug}.${sessionOrder}`, {
+    returnObjects: true,
+    defaultValue: null,
+  });
+  if (!isI18nSession(raw)) return dbSession;
+
+  const out: Session = { ...dbSession };
+  if (typeof raw.title === 'string' && raw.title.length > 0) out.title = raw.title;
+  if (typeof raw.description === 'string' && raw.description.length > 0) out.description = raw.description;
+  if (Array.isArray(raw.focus)) out.focus = raw.focus.filter((f): f is string => typeof f === 'string');
+  if (Array.isArray(raw.blocks)) {
+    out.blocks = dbSession.blocks.map((dbBlock, idx) => mergeBlock(dbBlock, raw.blocks?.[idx]));
+  }
+  return out;
+}


### PR DESCRIPTION
Batch de fixes remontés pendant la passe de test sur émulateurs Android + iOS, regroupés par instruction du PM.

## Bugs corrigés

**1. Modale "Ajouter un repas" alignée en bas** (Android + iOS)

\`NutritionPage.tsx\`: \`flex items-end sm:items-center\` faisait coller la modale au bas de l'écran sur mobile (style bottom-sheet) — ressenti comme un défaut visuel. Passé à \`items-center\` avec padding \`p-4\` et coins \`rounded-2xl\` partout.

**2. Tags d'objectifs affichaient \`goal.<texte>\`**

\`ProgramPage.tsx\`: les goals seedés en DB sont déjà du texte FR (\`'Découvrir les exercices de base'\`), mais le rendu faisait \`t(\`goal.\${goal}\`)\` — ce qui fabriquait une clé i18n inexistante. i18next renvoyant la clé quand manquante, on voyait \`goal.Découvrir les exercices de base\` à l'écran. Drop le \`t()\`, les goals sont rendus tels quels (et localisés via le mécanisme du point 3).

**3. Programmes fixes (et leurs sessions) FR-only**

Les 3 programmes seed (\`debutant-4-semaines\`, \`remise-en-forme\`, \`cardio-express\`) ont été insérés FR-only en migration 002. Pour un user EN, l'app affichait "Débutant 4 semaines" / "Découverte Full-Body" / des noms d'exercices en français.

**Solution propre, pas de migration DB** :
- Le contenu localisé vit dans \`src/i18n/locales/{fr,en}/programs_data.json\` (étendu avec \`title\`, \`description\`, \`goals[]\`) et \`sessions_data.json\` (nouveau, ~520 strings × 2 locales).
- Deux helpers (\`localizedProgramFields\`, \`localizedSessionData\`) fusionnent l'i18n sur le DB row au render.
- **Les champs structuraux (sets, reps, duration, type, mode) viennent toujours du DB** — le moteur Player reste en sync avec ce que l'user complète.
- Les programmes IA générés (non-fixed) sont passés tels quels (Claude génère déjà dans la locale du user).
- 40 sessions traduites, 139 blocks, ~520 strings exercice.

## Tests

- \`programLocale.test.ts\` : 10 tests (passthrough, override par champ, fixed dual-key, fallbacks, empty-string)
- \`sessionLocale.test.ts\` : 8 tests (identity unknown slug, override title/focus, structural preservation, shorter-arrays fallback, superset, no-mutation, empty-title)
- Suite globale : **488 tests** (+18, was 470)
- JSON FR/EN parfaitement symétriques (slugs, sessions, blocks, exercices, pair structures vérifiés)

## Architecture choisie

Pas de migration DB. La table \`programs\` reste avec ses colonnes \`title/description/goals\` FR. Le i18n vit côté code (convention déjà en place pour le reste du contenu fixed cf. \`programContent.ts\`). Cohérent et minimal.

## Test plan
- [x] Lint, build, 488 tests pass
- [x] Web local (\`npm run dev\`): toggle FR/EN sur \`/programmes\`, \`/programme/<slug>\`, Home ; goals/title/description/sessions/blocks/exercices basculent en entier.
- [x] Build native + sync Android + iOS effectués pour test sur émulateurs.
- [ ] Tester sur émulateur Android le flow programme + lancement séance — toggle FR/EN.
- [ ] Tester sur simulateur iOS le même flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)