### PR TITLE
chore(release-config): substitute external-setup placeholders

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -2,7 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": ["TODO_APPLE_TEAM_ID.fr.wansoft.wan2fit"],
+        "appIDs": ["DL5537MH8T.fr.wansoft.wan2fit"],
         "components": [
           { "/": "/reset-password" },
           { "/": "/auth/callback*" },


### PR DESCRIPTION
PR cumulative pour les substitutions de placeholders qui dépendent de paramétrages externes (Apple Dev, Google Play keystore, etc.). Évite de spammer la CI avec une PR par TODO.

## Substitutions courantes

- ✅ **Apple Team ID** \`DL5537MH8T\` → \`public/.well-known/apple-app-site-association\` (commit \`a7ec383\`)
- ⏳ Android release keystore SHA-256 → \`public/.well-known/assetlinks.json\`

## Pourquoi une seule PR
Chaque substitution est triviale et indépendante (1 ligne par fichier statique servi par Vercel, pas de logique applicative). Grouper évite de spammer la CI et garde la traçabilité du paramétrage en un seul endroit.

## Test plan (à compléter au fil des commits)
- [x] AASA JSON syntactically valid
- [ ] AASA résolu correctement par swcd au déploiement (\`curl https://wan2fit.fr/.well-known/apple-app-site-association\`)
- [ ] Apple AASA Validator OK (https://branch.io/resources/aasa-validator/)
- [ ] Android assetlinks.json validé via Digital Asset Links API quand le SHA sera ajouté

🤖 Generated with [Claude Code](https://claude.com/claude-code)