### PR TITLE
fix(security): migrate Supabase auth tokens to Keychain / EncryptedSharedPreferences

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':aparajita-capacitor-secure-storage')
     implementation project(':capacitor-community-keep-awake')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':aparajita-capacitor-secure-storage'
+project(':aparajita-capacitor-secure-storage').projectDir = new File('../node_modules/@aparajita/capacitor-secure-storage/android')
+
 include ':capacitor-community-keep-awake'
 project(':capacitor-community-keep-awake').projectDir = new File('../node_modules/@capacitor-community/keep-awake/android')
 

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
       }
     },
     {
+      "identity" : "keychain-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/evgenyneu/keychain-swift.git",
+      "state" : {
+        "revision" : "265806607b45687a3d646e4c9837c31c90f202e8",
+        "version" : "21.0.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
+        .package(name: "AparajitaCapacitorSecureStorage", path: "../../../node_modules/@aparajita/capacitor-secure-storage"),
         .package(name: "CapacitorCommunityKeepAwake", path: "../../../node_modules/@capacitor-community/keep-awake"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
@@ -30,6 +31,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "AparajitaCapacitorSecureStorage", package: "AparajitaCapacitorSecureStorage"),
                 .product(name: "CapacitorCommunityKeepAwake", package: "CapacitorCommunityKeepAwake"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wan2fit",
       "version": "1.1.1",
       "dependencies": {
+        "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "^8.1.0",
@@ -62,6 +63,22 @@
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.0.18",
         "xcode": "^3.0.1"
+      }
+    },
+    "node_modules/@aparajita/capacitor-secure-storage": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-secure-storage/-/capacitor-secure-storage-8.0.0.tgz",
+      "integrity": "sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/android": "^8.0.2",
+        "@capacitor/app": "^8.0.0",
+        "@capacitor/core": "^8.0.2",
+        "@capacitor/ios": "^8.0.2",
+        "@capacitor/keyboard": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "seed:recipes": "tsx scripts/seed-recipes.ts"
   },
   "dependencies": {
+    "@aparajita/capacitor-secure-storage": "^8.0.0",
     "@capacitor-community/keep-awake": "^8.0.1",
     "@capacitor/android": "^8.3.1",
     "@capacitor/app": "^8.1.0",

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -10,6 +10,13 @@ type OnboardingState = 'loading' | 'pending' | 'done';
 // NSUserDefaults / SharedPreferences) so a WebView storage purge doesn't
 // re-prompt the user.
 //
+// We intentionally use the plain (unencrypted) Preferences store here, NOT
+// the new SecureStorage adapter that supabase-storage.ts uses for auth
+// tokens. The onboarding flag is a non-sensitive boolean ("1"/null) — no
+// security gain to encrypting it, and Keychain entries don't survive an
+// app uninstall on iOS, so a reinstall would unnecessarily re-prompt the
+// user with the carousel.
+//
 // Web: returns 'done' immediately. The onboarding is intentionally
 // native-only — Apple App Reviewers care that the iOS first launch
 // pitches the value of the app, the PWA gets it via wan2fit.fr's home.

--- a/src/lib/supabase-storage.test.ts
+++ b/src/lib/supabase-storage.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the secure-storage plugin. Each test wires up `getItem` / `setItem` /
+// `removeItem` as it needs them. The plugin exports the public methods on
+// `SecureStorage` (named export from the package).
+const mockSecGetItem = vi.fn();
+const mockSecSetItem = vi.fn();
+const mockSecRemoveItem = vi.fn();
+vi.mock('@aparajita/capacitor-secure-storage', () => ({
+  SecureStorage: {
+    getItem: (...args: unknown[]) => mockSecGetItem(...args),
+    setItem: (...args: unknown[]) => mockSecSetItem(...args),
+    removeItem: (...args: unknown[]) => mockSecRemoveItem(...args),
+  },
+}));
+
+// Mock the legacy Preferences plugin.
+const mockPrefGet = vi.fn();
+const mockPrefRemove = vi.fn();
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: (...args: unknown[]) => mockPrefGet(...args),
+    remove: (...args: unknown[]) => mockPrefRemove(...args),
+  },
+}));
+
+// `getSupabaseStorage()` short-circuits to undefined on web (returns the
+// default localStorage adapter to Supabase). For tests we force the native
+// branch to exercise the secure adapter.
+const mockIsNative = vi.fn();
+vi.mock('./capacitor.ts', () => ({
+  isNative: () => mockIsNative(),
+}));
+
+import { getSupabaseStorage } from './supabase-storage.ts';
+
+describe('getSupabaseStorage', () => {
+  beforeEach(() => {
+    mockSecGetItem.mockReset();
+    mockSecSetItem.mockReset();
+    mockSecRemoveItem.mockReset();
+    mockPrefGet.mockReset();
+    mockPrefRemove.mockReset();
+    mockIsNative.mockReset();
+    mockSecSetItem.mockResolvedValue(undefined);
+    mockSecRemoveItem.mockResolvedValue(undefined);
+    mockPrefRemove.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined on web (Supabase keeps its default localStorage)', () => {
+    mockIsNative.mockReturnValue(false);
+    expect(getSupabaseStorage()).toBeUndefined();
+  });
+
+  describe('native adapter', () => {
+    beforeEach(() => {
+      mockIsNative.mockReturnValue(true);
+    });
+
+    it('reads directly from secure storage when the key is already migrated', async () => {
+      mockSecGetItem.mockResolvedValue('jwt-from-keychain');
+      const adapter = getSupabaseStorage();
+      const value = await adapter!.getItem('sb-xxx-auth-token');
+      expect(value).toBe('jwt-from-keychain');
+      // Migration path must NOT be invoked for already-secure keys.
+      expect(mockPrefGet).not.toHaveBeenCalled();
+      expect(mockSecSetItem).not.toHaveBeenCalled();
+    });
+
+    it('migrates a legacy Preferences token into secure storage on first read', async () => {
+      mockSecGetItem.mockResolvedValue(null);
+      mockPrefGet.mockResolvedValue({ value: 'legacy-jwt' });
+      const adapter = getSupabaseStorage();
+      const value = await adapter!.getItem('sb-xxx-auth-token');
+      expect(value).toBe('legacy-jwt');
+      expect(mockSecSetItem).toHaveBeenCalledWith('sb-xxx-auth-token', 'legacy-jwt');
+      expect(mockPrefRemove).toHaveBeenCalledWith({ key: 'sb-xxx-auth-token' });
+    });
+
+    it('returns null when neither secure nor legacy store has the key (fresh install / signed-out)', async () => {
+      mockSecGetItem.mockResolvedValue(null);
+      mockPrefGet.mockResolvedValue({ value: null });
+      const adapter = getSupabaseStorage();
+      const value = await adapter!.getItem('sb-xxx-auth-token');
+      expect(value).toBeNull();
+      expect(mockSecSetItem).not.toHaveBeenCalled();
+      expect(mockPrefRemove).not.toHaveBeenCalled();
+    });
+
+    it('swallows migration errors and returns null instead of throwing', async () => {
+      mockSecGetItem.mockResolvedValue(null);
+      mockPrefGet.mockResolvedValue({ value: 'legacy-jwt' });
+      mockSecSetItem.mockRejectedValue(new Error('keychain unavailable'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const adapter = getSupabaseStorage();
+      const value = await adapter!.getItem('sb-xxx-auth-token');
+      expect(value).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('writes via secure storage on setItem and wipes any stale legacy copy', async () => {
+      const adapter = getSupabaseStorage();
+      await adapter!.setItem('sb-xxx-auth-token', 'fresh-jwt');
+      expect(mockSecSetItem).toHaveBeenCalledWith('sb-xxx-auth-token', 'fresh-jwt');
+      expect(mockPrefRemove).toHaveBeenCalledWith({ key: 'sb-xxx-auth-token' });
+    });
+
+    it('removes via secure storage on removeItem and wipes any stale legacy copy', async () => {
+      const adapter = getSupabaseStorage();
+      await adapter!.removeItem('sb-xxx-auth-token');
+      expect(mockSecRemoveItem).toHaveBeenCalledWith('sb-xxx-auth-token');
+      expect(mockPrefRemove).toHaveBeenCalledWith({ key: 'sb-xxx-auth-token' });
+    });
+
+    it('still resolves setItem when the legacy cleanup throws (defensive try/catch)', async () => {
+      mockPrefRemove.mockRejectedValue(new Error('preferences gone'));
+      const adapter = getSupabaseStorage();
+      await expect(adapter!.setItem('sb-xxx-auth-token', 'fresh-jwt')).resolves.toBeUndefined();
+      expect(mockSecSetItem).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/supabase-storage.ts
+++ b/src/lib/supabase-storage.ts
@@ -58,7 +58,7 @@ async function migrateLegacyKey(key: string): Promise<string | null> {
     const { value: legacy } = await Preferences.get({ key });
     if (legacy === null || legacy === undefined) return null;
     const { SecureStorage } = await loadSecureStorage();
-    await SecureStorage.set(key, legacy);
+    await SecureStorage.setItem(key, legacy);
     await Preferences.remove({ key });
     return legacy;
   } catch (err) {
@@ -70,15 +70,20 @@ async function migrateLegacyKey(key: string): Promise<string | null> {
 const secureStorageAdapter: StorageAdapter = {
   async getItem(key) {
     const { SecureStorage } = await loadSecureStorage();
-    const value = await SecureStorage.get(key);
-    if (typeof value === 'string') return value;
-    if (value !== null && value !== undefined) return String(value);
+    // `getItem` is the plugin's low-level string-only accessor (mirrors
+    // the `StorageLikeAsync` interface). It bypasses the JSON / Date
+    // round-trip that `get()` does and returns string | null verbatim,
+    // which is exactly what Supabase's storage adapter expects.
+    const value = await SecureStorage.getItem(key);
+    if (value !== null) return value;
     // Cold start after upgrade: token may still be in @capacitor/preferences.
     return migrateLegacyKey(key);
   },
   async setItem(key, value) {
     const { SecureStorage } = await loadSecureStorage();
-    await SecureStorage.set(key, value);
+    // `setItem` is the string-only sibling of `set` — same rationale as
+    // `getItem` above (no JSON encoding, no convertDate magic).
+    await SecureStorage.setItem(key, value);
     // Defensive: if a stale legacy copy exists (mid-migration crash, etc.)
     // wipe it so the secure copy is the unique source of truth from now on.
     try {
@@ -91,7 +96,7 @@ const secureStorageAdapter: StorageAdapter = {
   },
   async removeItem(key) {
     const { SecureStorage } = await loadSecureStorage();
-    await SecureStorage.remove(key);
+    await SecureStorage.removeItem(key);
     try {
       const { Preferences } = await loadPreferences();
       await Preferences.remove({ key });

--- a/src/lib/supabase-storage.ts
+++ b/src/lib/supabase-storage.ts
@@ -1,10 +1,20 @@
 import { isNative } from './capacitor.ts';
 
 // Supabase auth storage interface (sync OR async).
-// On native, WebView localStorage can be wiped silently by the OS, so we
-// persist auth tokens in @capacitor/preferences (KV backed by NSUserDefaults
-// on iOS and SharedPreferences on Android — both stable across app launches).
-// On web we return undefined so Supabase falls back to its built-in
+//
+// On native, the previous implementation persisted tokens in
+// `@capacitor/preferences`, which is backed by `NSUserDefaults` (iOS) and
+// `SharedPreferences` (Android) — neither encrypted at rest. Auth tokens
+// were therefore readable through:
+//   - iOS: an unencrypted iTunes/Finder backup, an MDM scrape, an app
+//     extension running in the same group.
+//   - Android: an `adb backup` on a USB-debug device, Google's auto
+//     cloud-backup, any rooted device.
+//
+// We now use `@aparajita/capacitor-secure-storage` which wraps Keychain
+// Services on iOS and EncryptedSharedPreferences on Android — both
+// encrypted at rest with hardware-backed keys when available. On web we
+// still return undefined so Supabase falls back to its built-in
 // localStorage adapter (no behaviour change for the PWA).
 type StorageAdapter = {
   getItem: (key: string) => Promise<string | null>;
@@ -12,32 +22,85 @@ type StorageAdapter = {
   removeItem: (key: string) => Promise<void>;
 };
 
-// Lazy-loaded native module so the web bundle never imports
-// @capacitor/preferences (matches the dynamic-import pattern in capacitor.ts).
-let preferencesPromise: Promise<typeof import('@capacitor/preferences')> | null = null;
-function loadPreferences() {
+// Lazy-loaded native modules so the web bundle never imports either plugin.
+// SecureStorage handles current reads/writes; Preferences is kept around
+// only for the one-shot legacy migration on first read after upgrade.
+type SecureStorageModule = typeof import('@aparajita/capacitor-secure-storage');
+type PreferencesModule = typeof import('@capacitor/preferences');
+
+let secureStoragePromise: Promise<SecureStorageModule> | null = null;
+let preferencesPromise: Promise<PreferencesModule> | null = null;
+
+function loadSecureStorage(): Promise<SecureStorageModule> {
+  if (!secureStoragePromise) {
+    secureStoragePromise = import('@aparajita/capacitor-secure-storage');
+  }
+  return secureStoragePromise;
+}
+
+function loadPreferences(): Promise<PreferencesModule> {
   if (!preferencesPromise) {
     preferencesPromise = import('@capacitor/preferences');
   }
   return preferencesPromise;
 }
 
-const capacitorPreferencesAdapter: StorageAdapter = {
-  async getItem(key) {
+// One-shot lazy migration: when the first read for `key` happens after the
+// upgrade, look in the legacy Preferences store; if a value is found there,
+// copy it into secure storage and erase the legacy copy. Idempotent and
+// self-healing — after the first successful read, all subsequent calls go
+// straight to secure storage. Per-key (not bulk) so we don't scan
+// Preferences (which has no `keys()` method everywhere) — the supabase
+// auth client only ever stores ~1-2 keys per project anyway.
+async function migrateLegacyKey(key: string): Promise<string | null> {
+  try {
     const { Preferences } = await loadPreferences();
-    const { value } = await Preferences.get({ key });
-    return value;
+    const { value: legacy } = await Preferences.get({ key });
+    if (legacy === null || legacy === undefined) return null;
+    const { SecureStorage } = await loadSecureStorage();
+    await SecureStorage.set(key, legacy);
+    await Preferences.remove({ key });
+    return legacy;
+  } catch (err) {
+    console.warn('[supabase-storage] legacy migration failed for', key, err);
+    return null;
+  }
+}
+
+const secureStorageAdapter: StorageAdapter = {
+  async getItem(key) {
+    const { SecureStorage } = await loadSecureStorage();
+    const value = await SecureStorage.get(key);
+    if (typeof value === 'string') return value;
+    if (value !== null && value !== undefined) return String(value);
+    // Cold start after upgrade: token may still be in @capacitor/preferences.
+    return migrateLegacyKey(key);
   },
   async setItem(key, value) {
-    const { Preferences } = await loadPreferences();
-    await Preferences.set({ key, value });
+    const { SecureStorage } = await loadSecureStorage();
+    await SecureStorage.set(key, value);
+    // Defensive: if a stale legacy copy exists (mid-migration crash, etc.)
+    // wipe it so the secure copy is the unique source of truth from now on.
+    try {
+      const { Preferences } = await loadPreferences();
+      await Preferences.remove({ key });
+    } catch {
+      // Preferences plugin may eventually be removed — not a problem,
+      // the secure write above already succeeded.
+    }
   },
   async removeItem(key) {
-    const { Preferences } = await loadPreferences();
-    await Preferences.remove({ key });
+    const { SecureStorage } = await loadSecureStorage();
+    await SecureStorage.remove(key);
+    try {
+      const { Preferences } = await loadPreferences();
+      await Preferences.remove({ key });
+    } catch {
+      // ignore
+    }
   },
 };
 
 export function getSupabaseStorage(): StorageAdapter | undefined {
-  return isNative() ? capacitorPreferencesAdapter : undefined;
+  return isNative() ? secureStorageAdapter : undefined;
 }


### PR DESCRIPTION
Ferme le finding 🔴 CRITICAL de l'audit du 2026-05-06 : tokens Supabase au repos non chiffrés sur device.

## Avant
\`@capacitor/preferences\` écrit dans :
- iOS : \`NSUserDefaults\` (plist non chiffré, leak via backup iTunes/Finder non chiffré, MDM scrape, app extensions partagées).
- Android : \`SharedPreferences\` (leak via \`adb backup\`, Google auto cloud-backup, device rooté).

## Après
\`@aparajita/capacitor-secure-storage@8.0.0\` (Capacitor 8 explicit, mainteneur reconnu, deps minimales) wraps :
- iOS : **Keychain Services** avec \`whenUnlocked\` accessibility (default).
- Android : **EncryptedSharedPreferences** avec hardware-backed keys quand dispo (StrongBox / TEE).

## Migration des sessions existantes
Lazy + idempotente, pas de wipe brutal :
- \`getItem(key)\` lit d'abord SecureStorage. Si null, fallback sur Preferences, copie dans SecureStorage, delete de Preferences.
- \`setItem\` / \`removeItem\` wipe défensivement la copie legacy au passage.
- Per-key (pas de bulk-scan) : Supabase auth ne stocke que ~1-2 keys par projet, pas la peine de scanner toute la KV.

## Validation
- ✅ Lint, build, 488 tests pass
- ✅ \`npm run build:native\` + \`npx cap sync android/ios\` propage le plugin (ajout dans \`CapApp-SPM/Package.swift\` + \`capacitor.{settings,build}.gradle\`)
- ✅ Test sur émulateur Android : utilisateur connecté avant le rebuild reste connecté après — la migration depuis Preferences marche end-to-end.
- ⚠️ iOS pas testé sur device physique (simulateur ne supporte pas les push, mais le storage Keychain est OK sur simulateur — à valider quand on aura un iPhone branché pour TestFlight).

## Test plan additionnel
- [ ] Re-test après TestFlight installation : un user fresh-install voit son login persister entre relaunches.
- [ ] Vérifier dans Apple Configurator / iTunes backup d'un device test que le token Supabase n'apparaît pas (vs avant where il était dans le plist en clair).
- [ ] Sur Android, \`adb shell run-as fr.wansoft.wan2fit cat shared_prefs/CapacitorStorage.xml\` ne doit plus contenir le token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)