### PR TITLE
fix(ui): 3 fixes from TestFlight exploratory pass

### DIFF
--- a/src/components/BrandHeader.tsx
+++ b/src/components/BrandHeader.tsx
@@ -63,7 +63,7 @@ export function BrandHeader() {
   const isTrackingActive = pathname === '/suivi' || pathname === '/decouvrir/suivi';
 
   return (
-    <header className="pl-safe pr-safe px-4 sm:px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
+    <header className="relative z-50 pl-safe pr-safe px-4 sm:px-6 md:px-10 lg:px-14 py-4 border-b border-divider">
       <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
         <Link to="/" aria-label={`Wan2Fit — ${t('home')}`} className="flex items-center gap-2.5 shrink-0">
           <img src="/logo-wan2fit.png" alt="" className="w-7 h-7 md:w-8 md:h-8 shrink-0" />

--- a/src/components/Formats.tsx
+++ b/src/components/Formats.tsx
@@ -39,27 +39,30 @@ export function Formats() {
               to={`/formats/${format.slug}`}
               className="format-card rounded-2xl overflow-hidden flex flex-col transition-transform hover:scale-[1.01]"
             >
-              {/* Image — text stays white (over image) */}
+              {/* Image — only the duration badge sits over it now. Title +
+                  subtitle moved into the content block below so the contrast
+                  stays correct in both light and dark themes (the previous
+                  white-on-image overlay relied on a `--color-surface`
+                  gradient that becomes near-white in light mode and washed
+                  out the text). */}
               <div className="relative h-28 overflow-hidden">
                 <img
                   src={format.image}
                   alt={t('formats.img_alt', { name: td(`${format.slug}.name`) })}
                   className="w-full h-full object-cover object-[50%_30%]"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-surface via-surface/40 to-transparent" />
-                <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between">
-                  <div>
-                    <h2 className="font-bold text-white text-base drop-shadow-sm">{td(`${format.slug}.name`)}</h2>
-                    <p className="text-xs text-white/60">{td(`${format.slug}.subtitle`)}</p>
-                  </div>
-                  <span className="text-xs font-bold text-white bg-white/15 backdrop-blur-sm px-2.5 py-1 rounded-full shrink-0">
-                    {format.duration} min
-                  </span>
-                </div>
+                <span className="absolute top-3 right-3 text-xs font-bold text-white bg-black/50 backdrop-blur-sm px-2.5 py-1 rounded-full">
+                  {format.duration} min
+                </span>
               </div>
 
               {/* Content (below image) */}
               <div className="p-4 flex-1 flex flex-col gap-3">
+                <div>
+                  <h2 className="font-bold text-heading text-base">{td(`${format.slug}.name`)}</h2>
+                  <p className="text-xs text-muted mt-0.5">{td(`${format.slug}.subtitle`)}</p>
+                </div>
+
                 {/* Intensity dots */}
                 <div
                   className="flex items-center gap-1.5"

--- a/src/i18n/locales/en/landing_programs.json
+++ b/src/i18n/locales/en/landing_programs.json
@@ -7,7 +7,7 @@
     "eyebrow": "AI programs",
     "title": "A tailored plan that fits you.",
     "subtitle": "3 questions, your complete plan in 30 seconds. Your frequency, your goal, your level — the AI builds the program. And each cycle adjusts so you don't burn out.",
-    "cta_primary": "Create my free program",
+    "cta_primary": "Create my program",
     "cta_secondary": "Browse the standard programs",
     "visual_list_alt": "Wan2Fit programs list",
     "visual_goal_alt": "Choose your training goal",
@@ -28,7 +28,7 @@
   "final_cta": {
     "title": "Launch your plan in 30 seconds.",
     "subtitle": "Create a free account, answer 3 questions, your program is ready.",
-    "cta_primary": "Create my free program",
+    "cta_primary": "Create my program",
     "cta_secondary": "Browse the standard programs"
   }
 }

--- a/src/i18n/locales/fr/landing_programs.json
+++ b/src/i18n/locales/fr/landing_programs.json
@@ -7,7 +7,7 @@
     "eyebrow": "Programmes IA",
     "title": "Un plan sur-mesure, qui s'adapte à toi.",
     "subtitle": "3 questions, ton plan complet en 30 secondes. Ta fréquence, ton objectif, ton niveau — l'IA assemble le programme. Et chaque semaine s'ajuste pour ne pas t'épuiser.",
-    "cta_primary": "Créer mon programme gratuit",
+    "cta_primary": "Créer mon programme",
     "cta_secondary": "Voir les programmes types",
     "visual_list_alt": "Liste des programmes Wan2Fit",
     "visual_goal_alt": "Choix de l'objectif d'entraînement",
@@ -28,7 +28,7 @@
   "final_cta": {
     "title": "Lance ton plan en 30 secondes.",
     "subtitle": "Crée un compte gratuit, réponds à 3 questions, ton programme est prêt.",
-    "cta_primary": "Créer mon programme gratuit",
+    "cta_primary": "Créer mon programme",
     "cta_secondary": "Découvrir les programmes types"
   }
 }


### PR DESCRIPTION
3 bugs UX remontés pendant le test exploratoire TestFlight (PR #223 build 10101).

## Bugs corrigés

**1. Format cards illisibles en light mode**

Sur \`/formats\`, le titre + subtitle de chaque format card étaient en \`text-white\` sur un gradient qui fade vers \`--color-surface\`. En light mode, surface est quasi-blanc → texte blanc washed out. Solution : déplacer titre + subtitle dans le block contenu sous l'image, en \`text-heading\` / \`text-muted\` (theme-aware). Seul le badge "30-38 min" reste sur l'image avec un \`bg-black/50 backdrop-blur-sm\`.

**2. NavDropdown chevauche les sticky headers de page**

\`BrandHeader\` n'avait pas de stacking context, donc le \`z-50\` du dropdown menu vivait dans le contexte root et entrait en compétition avec chaque header sticky \`z-10\` des pages internes (Formats, Recettes, etc.). Ajout de \`relative z-50\` sur \`<header>\` pour créer un stacking context au-dessus des sticky headers de pages.

**3. CTA "Créer mon programme gratuit" trompeur**

La génération IA des programmes est une feature Premium, seul le signup est gratuit. Drop "gratuit" → "Créer mon programme" / "Create my program" — honnête dans les 2 flows (signed-out → signup gratuit, signed-in → paywall si pas premium).

## Test plan
- [x] Lint, build, 496 tests pass
- [ ] Web localhost — toggle theme + check /formats lisibilité
- [ ] Web localhost — ouvrir un dropdown header sur /formats → ne chevauche plus
- [ ] Web localhost — /decouvrir/programmes → CTA correct
- [ ] Mobile TestFlight : pas re-built dans cette PR (3 fixes UI, on batche avec le prochain lot d'exploratoire). Re-build manuel quand on a accumulé d'autres fixes mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)