### PR TITLE
chore(native): wire release signing config + bump 1.1.3 (10103)

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -52,10 +52,10 @@ captures/
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
 
-# Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+# Keystore files — never commit signing material
+*.jks
+*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'com.android.application'
 
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "fr.wansoft.wan2fit"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -7,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10101
-        versionName "1.1.1"
+        versionCode 10103
+        versionName "1.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,10 +22,23 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            if (keystoreProperties['storeFile']) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (keystoreProperties['storeFile']) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }

--- a/android/keystore.properties.example
+++ b/android/keystore.properties.example
@@ -1,0 +1,4 @@
+storeFile=/Users/erwan/Dev/Projets-Pro/WanShape/tmp/wan2fit-release.keystore
+storePassword=REPLACE_ME
+keyAlias=REPLACE_ME
+keyPassword=REPLACE_ME

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10101;
+				CURRENT_PROJECT_VERSION = 10103;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10101;
+				CURRENT_PROJECT_VERSION = 10103;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -4,7 +4,7 @@
     "target": {
       "namespace": "android_app",
       "package_name": "fr.wansoft.wan2fit",
-      "sha256_cert_fingerprints": ["5C:A9:BC:D1:C9:FD:6B:DB:96:28:E2:AD:49:17:24:C0:91:E9:09:AF:B4:DA:2B:48:95:F1:5B:76:5F:68:08:BB"]
+      "sha256_cert_fingerprints": ["1B:20:E0:38:0D:54:99:EB:55:88:8B:34:7D:57:94:F6:7F:66:11:29:85:25:2B:74:80:F4:C0:67:BE:A0:38:93"]
     }
   }
 ]


### PR DESCRIPTION
## Context

Until now native builds had no signing configuration wired in `build.gradle`, so AAB generation produced unsigned artifacts that could not be uploaded to Play Console. The Android keystore (RSA 2048, generated locally and never committed) was sitting at `tmp/wan2fit-release.keystore` with no plumbing.

Separately, the lack of a `.env.production` file meant Vite was falling back to `.env.local` (pointing at the dev Supabase project) when building native bundles — so every TestFlight / Internal Testing build prior to 1.1.3 was hitting dev instead of prod. The Vercel `vercel env pull` produced the missing file; this PR captures the version bump that piggy-backs on that fix.

## Changes

| File | Why |
|---|---|
| `android/app/build.gradle` | Added `signingConfigs.release` reading from `android/keystore.properties` at project root + wired `buildTypes.release.signingConfig`. Both blocks no-op if `keystore.properties` is missing, so CI without secrets still builds. |
| `android/.gitignore` | Added `*.jks`, `*.keystore`, `keystore.properties` to ensure signing material never lands in git. |
| `android/keystore.properties.example` | New: template documenting required credentials. Real `keystore.properties` stays gitignored. |
| `public/.well-known/assetlinks.json` | Updated SHA-256 fingerprint to match the production upload keystore. Required for Android App Links to resolve `wan2fit.fr` deep links into the installed app. |
| `ios/App/App.xcodeproj/project.pbxproj` | Marketing version 1.1.3 + project version 10103, propagated via `npm run sync:version` (single source of truth driven by `package.json`). |
| `package.json` / `package-lock.json` | Bump 1.1.1 → 1.1.3. **1.1.2 intentionally skipped**: 10102 was already burned on a previous Play Console internal-testing upload, and Play Console refuses duplicate versionCodes. 10103 is the first version code the new build pipeline (correctly pointing at the production Supabase project) ships under. |

## Validation

- ✅ `./gradlew bundleRelease` produces a signed AAB.
- ✅ Bundle embeds `https://pipbhkaaqsltnvprmzrl.supabase.co` (prod), not dev.
- ✅ Manually tested on iPhone TestFlight 1.1.3 with `review@wan2fit.fr` after deploy.

## Test plan

- [x] Local AAB build succeeds with signing applied (verified via `apksigner verify`)
- [ ] Upload 1.1.3 AAB to Play Console > Closed Testing
- [ ] Verify Android App Links open `wan2fit.fr/legal/privacy` directly in the installed app (assetlinks fingerprint matches)
- [ ] Confirm TestFlight 1.1.3 build is processed by App Store Connect

## Related

Companion to PR #225 (`fix(ai+cors): unblock IA generation on web and native`). #225 ships the backend fixes; this PR ships the native build pipeline fixes so the bundles can actually hit the patched edge functions in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)