### PR TITLE
fix(native): hide pricing & subscription CTAs on iOS/Android (3.1.3(b))

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10103
-        versionName "1.1.3"
+        versionCode 10104
+        versionName "1.1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10103;
+				CURRENT_PROJECT_VERSION = 10104;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10103;
+				CURRENT_PROJECT_VERSION = 10104;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/PremiumPromoPage.tsx
+++ b/src/components/PremiumPromoPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useSubscription } from '../hooks/useSubscription.ts';
+import { isNative } from '../lib/capacitor.ts';
+import { NativeUpgradeWall } from './auth/NativeUpgradeWall.tsx';
 import { PricingCards } from './PricingCards.tsx';
 import { ScreenshotCarousel } from './ScreenshotCarousel.tsx';
 
@@ -16,6 +18,15 @@ export function PremiumPromoPage() {
     title: t('premium.page_title'),
     description: t('premium.page_description'),
   });
+
+  // Apple guideline 3.1.3(b): on native, swap the whole marketing page
+  // (which includes Tarifs anchor + PricingCards + Stripe CTA) for the
+  // multiplatform-service wall. Premium users keep their normal view —
+  // the page still serves as a "thank you" + feature recap surface for
+  // them.
+  if (isNative() && !isPremium) {
+    return <NativeUpgradeWall />;
+  }
 
   return (
     <div className="space-y-0">

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useSubscription } from '../hooks/useSubscription.ts';
+import { isNative } from '../lib/capacitor.ts';
 import { formatDate } from '../utils/date.ts';
+import { NativeUpgradeWall } from './auth/NativeUpgradeWall.tsx';
 
 const PRICE_IDS = {
   monthly: import.meta.env.VITE_STRIPE_PRICE_MONTHLY as string | undefined,
@@ -61,6 +63,14 @@ export function PricingCards() {
     const err = await manageSubscription();
     if (err) setError(err);
   };
+
+  // Apple guideline 3.1.3(b) — on the native iOS/Android shells we must
+  // not expose any pricing, plan selector, or in-app purchase CTA. Render
+  // the multiplatform-service wall instead. Premium users still see their
+  // status below, so this gate only applies to non-premium native users.
+  if (isNative() && !isPremium) {
+    return <NativeUpgradeWall />;
+  }
 
   // Already premium — simplified view
   if (isPremium) {

--- a/src/components/auth/NativeUpgradeWall.tsx
+++ b/src/components/auth/NativeUpgradeWall.tsx
@@ -1,0 +1,74 @@
+import { Crown, ExternalLink } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { openWebPricingPage } from '../../lib/native-upgrade.ts';
+
+interface NativeUpgradeWallProps {
+  // Optional overrides — defaults cover the generic "Premium gating" case.
+  title?: string;
+  body?: string;
+}
+
+// Apple guideline 3.1.3(b) — Multiplatform Service.
+//
+// The iOS/Android shells must NOT show a price, a "Buy" button, or a CTA
+// that leads to a price screen still inside the app. This component is the
+// single place we render when a user tries to reach a paid feature on
+// native: it explains the situation in neutral language and opens
+// wan2fit.fr in SafariViewController (Capacitor Browser) when the user is
+// ready to subscribe. The subscription itself happens entirely on the web.
+export function NativeUpgradeWall({ title, body }: NativeUpgradeWallProps) {
+  const { t } = useTranslation('common');
+  const [opening, setOpening] = useState(false);
+
+  const handleOpen = async () => {
+    setOpening(true);
+    try {
+      await openWebPricingPage();
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-6">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-brand/10">
+          <Crown className="w-8 h-8 text-brand" aria-hidden="true" />
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="font-display text-2xl font-bold text-heading">
+            {title ?? t('native_upgrade.title', { defaultValue: 'Cette fonctionnalité fait partie de Premium' })}
+          </h2>
+          <p className="text-sm text-subtle leading-relaxed">
+            {body ??
+              t('native_upgrade.body', {
+                defaultValue:
+                  "Gère ton abonnement sur wan2fit.fr depuis n'importe quel navigateur. Une fois ton compte Premium activé, toutes les fonctionnalités sont disponibles ici sans rien à refaire.",
+              })}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleOpen}
+          disabled={opening}
+          className="btn-primary inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl font-semibold text-white w-full sm:w-auto disabled:opacity-60"
+        >
+          <ExternalLink className="w-4 h-4" aria-hidden="true" />
+          {opening
+            ? t('native_upgrade.opening', { defaultValue: 'Ouverture…' })
+            : t('native_upgrade.cta', { defaultValue: 'Continuer sur wan2fit.fr' })}
+        </button>
+
+        <p className="text-xs text-faint leading-relaxed">
+          {t('native_upgrade.legal_note', {
+            defaultValue:
+              "L'abonnement Premium est géré par WAN SOFT sur wan2fit.fr. Aucune souscription n'a lieu dans cette application.",
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/native-upgrade.ts
+++ b/src/lib/native-upgrade.ts
@@ -44,3 +44,18 @@ export async function openWebUpgrade(priceId: string): Promise<string | null> {
   });
   return null;
 }
+
+// Apple guideline 3.1.3(b) Multiplatform Service: the iOS/Android app must
+// never display prices or purchase CTAs. When the user shows interest in
+// premium without having picked a plan yet, we open wan2fit.fr/tarifs in
+// SafariViewController so they discover and buy the subscription on the
+// web. No magic link here — the user re-authenticates on the website if
+// needed; we don't want to leak a single-use link for a price page that
+// doesn't have a hardcoded priceId yet.
+export async function openWebPricingPage(): Promise<void> {
+  const { Browser } = await import('@capacitor/browser');
+  await Browser.open({
+    url: 'https://wan2fit.fr/tarifs',
+    presentationStyle: 'popover',
+  });
+}


### PR DESCRIPTION
## Context

Apple App Review flagged version 1.0 (Guideline 2.1(b) Performance — App Completeness) because the iOS shell exposed subscription content (Tarifs page, Premium CTAs) without a matching In-App Purchase. Wan2Fit's business model is multiplatform: premium is sold and managed only on wan2fit.fr via Stripe, and the native apps are a free alternative client. That qualifies for the canonical 3.1.3(b) Multiplatform Service pattern — we just have to make sure nothing in the native UI looks like an in-app sale.

## What this PR does

| File | Change |
|---|---|
| `src/lib/native-upgrade.ts` | New `openWebPricingPage()` helper — opens https://wan2fit.fr/tarifs in SafariViewController (iOS) / Chrome Custom Tab (Android) via `@capacitor/browser`. No magic link, no priceId — the user picks the plan on the web. |
| `src/components/auth/NativeUpgradeWall.tsx` (new) | Single source of truth for the "premium gating on native" UI. Neutral copy (no price, no "Buy", no plan selector). Single CTA opens the web pricing page. |
| `src/components/PricingCards.tsx` | Early-return `<NativeUpgradeWall />` when `isNative() && !isPremium`. Premium users keep their status block. |
| `src/components/PremiumPromoPage.tsx` | Early-return `<NativeUpgradeWall />` when `isNative() && !isPremium`. |
| Version bump 1.1.3 → 1.1.4 (versionCode 10104) | Native version that goes back to TestFlight + Play after this fix. |

## What is NOT in this PR (intentional, documented)

- **Per-feature Premium teasers** in `EndScreen`, `SeancesPage`, `ProgramList`, `home/ConnectedContent`: still link to `/premium`. On native that route now resolves to `<NativeUpgradeWall />` via `PremiumPromoPage`, so no price is ever shown — but the "Premium" name badges stay visible. Apple has historically accepted feature name badges. If a future review flags them, we'll hide on native too.
- **Legal page (CGV/Privacy)** still mentions the `9,99 €` and `99,99 €` tariffs. That is a French legal transparency requirement (CGV must disclose pricing) and lives in a dedicated legal surface, not a purchase CTA. Apple accepts this pattern.

## Validation

- ✅ Lint clean (Biome, 323 files).
- ✅ Tests pass (496/496).
- ✅ Production build succeeds (`NODE_ENV=production npm run build` produces a clean `dist/`).
- ✅ Bundle still embeds `https://pipbhkaaqsltnvprmzrl.supabase.co` (prod).

## Test plan

- [ ] Locally toggle `isNative()` to true and visit `/tarifs` → see the wall, no price.
- [ ] Same on `/premium` → wall, no marketing/pricing content.
- [ ] Premium user on native → still sees their active subscription status on `/tarifs`.
- [ ] `<NativeUpgradeWall />` button opens `https://wan2fit.fr/tarifs` in SafariViewController.
- [ ] Build 1.1.4 / 10104 archived, uploaded to TestFlight, replaces the build attached to the Apple Review submission.
- [ ] Resolution Center reply sent to Apple referencing 3.1.3(b) Multiplatform Service.

## Related PRs

- #225 `fix(ai+cors)` — backend prerequisites (already in flight, CI green).
- #226 `chore(native): wire signing config + bump 1.1.3` — companion native build pipeline fixes. This PR conflicts on `package.json` and `build.gradle` (version numbers) — trivial to resolve in #226's favor merging first, then rebasing this branch onto develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)