### PR TITLE
feat(iap): Apple StoreKit integration after 3.1.1 rejection [draft, planning shipped]

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10104
-        versionName "1.1.4"
+        versionCode 10105
+        versionName "1.1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/claudedocs/MOBILE_RELEASE_RUNBOOK.md
+++ b/claudedocs/MOBILE_RELEASE_RUNBOOK.md
@@ -1,0 +1,195 @@
+# Mobile release runbook
+
+Index central pour tous les processes mobiles Wan2Fit. Quand tu cherches "comment on fait X côté iOS/Android", commence ici. Si le runbook ne couvre pas X, c'est qu'on a un trou — l'ajouter immédiatement.
+
+---
+
+## Identifiants & comptes
+
+### Apple Developer
+
+- **Team ID** : `DL5537MH8T`
+- **Bundle ID iOS** : `fr.wansoft.wan2fit` (fixe, jamais le changer une fois publié)
+- **APNs Key** : `52L76VFUMS` (fichier `.p8` dans `~/Downloads/AuthKey_52L76VFUMS.p8`) — utilisée pour push notifications via Firebase
+- **App Store Connect** : compte rattaché à `erwan.viot@gmail.com`
+- **Small Business Program** : enroll obligatoire avant les IAP, voir [`iap-implementation/01-app-store-connect-setup.md`](./iap-implementation/01-app-store-connect-setup.md)
+
+### Google Play
+
+- **Account type** : Organisation (`Wan Soft`), D-U-N-S validé
+- **Console** : <https://play.google.com/console/u/0/developers/6803029396623856678>
+- **Package name** : `fr.wansoft.wan2fit`
+- **Org ID Play Console** : `6803029396623856678`
+- **App ID Play Console** : `4975323865234238857`
+- **Important** : compte organisation = pas de pré-requis "12 testeurs / 14 jours" pour la promotion vers Production. Direct submit possible.
+
+### Firebase
+
+- **Project ID** : `wan-shape` (renommé ne traîne pas, c'est l'ancien nom)
+- **Android app** : `fr.wansoft.wan2fit`, fichier `android/app/google-services.json`
+- **iOS app** : `fr.wansoft.wan2fit`, fichier `ios/App/App/GoogleService-Info.plist`
+
+### Supabase
+
+- **DEV** : projet `rgwwpkyuavhqdautpciu` — utilisé par `npm run dev` (via `.env.local`)
+- **PROD** : projet `pipbhkaaqsltnvprmzrl` — utilisé par les builds natifs (via `.env.production`)
+- **Compte review Apple/Google** : `review@wan2fit.fr` / `WanReview2026!` — userId prod `625ebcd1-9d48-4702-949c-14a3b290e4fc`, premium activé manuellement, seedé avec données démo
+
+### RevenueCat
+
+- (à compléter après création du compte, voir [`iap-implementation/02-revenuecat-setup.md`](./iap-implementation/02-revenuecat-setup.md))
+
+### Vercel
+
+- **Project ID** : `prj_3pX0aBCx03CjZclLj3tS9sB4qz8e`
+- **Org ID** : `team_wUoqxJCi36aq2sl4yaBgGsOa`
+- **Project slug** : `wanshape` (legacy, l'app s'appelle Wan2Fit mais le projet Vercel garde l'ancien nom)
+- **Pull les env vars Production en local** : `vercel env pull .env.production --environment=production`
+
+---
+
+## Build & signing
+
+### iOS
+
+- **Signing** : Automatic, Team `DL5537MH8T`, certificat Distribution déjà dans le Keychain du Mac
+- **Provisioning profiles** : auto-générés par Xcode
+- **Marketing version + build number** : driven by `package.json`, propagés via `npm run sync:version` (script `scripts/sync-version.ts`)
+  - `versionName` = la version du `package.json`
+  - `versionCode` = encodage `major*10000 + minor*100 + patch` (ex: 1.1.4 → 10104)
+- **Archive en CLI** (alternative à Xcode UI) :
+  ```bash
+  cd ios/App
+  xcodebuild -workspace App.xcworkspace -scheme App -configuration Release \
+    -archivePath /tmp/Wan2Fit.xcarchive \
+    -allowProvisioningUpdates \
+    -destination 'generic/platform=iOS' archive
+  ```
+- **dSYM Sentry warning** lors de l'archive : non bloquant, tech-debt à fixer en ajoutant un build phase qui copie le dSYM Sentry. Pour l'instant on clique "Done" et on ignore.
+
+### Android
+
+- **Signing** : `signingConfigs.release` dans `android/app/build.gradle`, lit `android/keystore.properties` (gitignored)
+- **Keystore** : `tmp/wan2fit-release.keystore` (gitignored — `tmp/` est dans le `.gitignore` root)
+- **Alias** : `wan2fit`
+- **Password** : `wan2fit-84d8eef62d450a0d63b7` (à conserver précieusement — perdu = plus jamais de mise à jour de l'app, faut republier sous un nouveau package)
+- **SHA-256 fingerprint** : `1B:20:E0:38:0D:54:99:EB:55:88:8B:34:7D:57:94:F6:7F:66:11:29:85:25:2B:74:80:F4:C0:67:BE:A0:38:93`
+- **assetlinks.json** déployé sur `wan2fit.fr/.well-known/assetlinks.json` doit avoir ce SHA pour que les App Links fonctionnent
+- **Build AAB** :
+  ```bash
+  export JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home
+  npm run build && npx cap sync android
+  cd android && ./gradlew bundleRelease
+  # AAB output: android/app/build/outputs/bundle/release/app-release.aab
+  ```
+
+### Cycle complet d'une release (version bump → store upload)
+
+```bash
+# 1. Bump version
+npm version patch --no-git-tag-version
+npm run sync:version
+
+# 2. Build web (mode production = utilise .env.production = backend Supabase prod)
+npm run build
+
+# 3. Sync vers natif
+npx cap sync
+
+# 4a. iOS — Archive + upload via Xcode UI (Product > Archive > Distribute App > App Store Connect > Upload)
+#     OU via CLI (voir ci-dessus xcodebuild archive)
+
+# 4b. Android — Build AAB signé
+export JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home
+cd android && ./gradlew bundleRelease
+
+# 5. Vérifier que le bundle pointe sur PROD
+grep -rh -oE "https://[a-z0-9]+\.supabase\.co" ios/App/App/public/assets/ android/app/src/main/assets/public/assets/ | sort -u
+# doit montrer pipbhkaaqsltnvprmzrl.supabase.co, PAS rgwwpkyuavhqdautpciu
+```
+
+---
+
+## Store submissions
+
+### Apple App Store
+
+Workflow détaillé : [`apple-submission-runbook.md`](./apple-submission-runbook.md) *(à écrire — pour l'instant, voir l'historique dans les conversations)*
+
+Récap rapide :
+1. Bump version + build (voir section précédente)
+2. Xcode > Product > Archive > Distribute App > App Store Connect > Upload
+3. Attendre processing Apple (~15 min)
+4. App Store Connect > Wan2Fit > version en review > Build > sélectionner le nouveau build
+5. Save
+6. Si la submission est rejetée ou nouvelle : Submit for Review
+
+**Compte de test pour le reviewer** : déclarer `review@wan2fit.fr` / `WanReview2026!` dans App Information → Sign-in Required → Demo Account.
+
+**Resolution Center** : si Apple flag une issue, répondre dans App Store Connect → version → Resolution Center, message en anglais, courtois, factuel, en pointant le build qui contient le fix.
+
+### Google Play Store
+
+Workflow détaillé : [`play-store-submission-runbook.md`](./play-store-submission-runbook.md) *(à écrire)*
+
+Récap rapide :
+1. Build AAB signé (voir section précédente)
+2. Play Console > Wan2Fit > Tester et publier > track (Tests internes / Tests fermés / Production)
+3. Créer une release > Importer l'AAB OU "Ajouter à partir de la bibliothèque" (si déjà uploadé)
+4. Remplir notes de version (FR + EN), placeholder `<fr-FR>…</fr-FR><en-US>…</en-US>`
+5. Suivant > Examiner > corriger éventuelles erreurs > Enregistrer
+6. Vue d'ensemble de la publication > "Envoyer N modifications pour examen"
+7. Google examine (1-7j, plus long pour le 1er compte)
+8. **Publication gérée activée par défaut** — après approbation Google, l'app reste cachée du store tant qu'on ne clique pas "Publier N modification"
+
+**Compte organisation Wan Soft** : pas de pré-requis 12 testeurs / 14 jours. Direct Production possible.
+
+**Pays/Régions** : à configurer dans Production > Pays/Régions séparément. Pour Wan2Fit on a sélectionné les 177 disponibles (monde entier).
+
+---
+
+## CI / Backend
+
+### Edge functions Supabase
+
+- Toutes dans `supabase/functions/<name>/index.ts`
+- **Toujours déployer avec `--no-verify-jwt`** : on utilise des publishable keys (pas anon JWT), Supabase Gateway rejette sinon
+  ```bash
+  npx supabase functions deploy <name> --no-verify-jwt --project-ref pipbhkaaqsltnvprmzrl  # PROD
+  npx supabase functions deploy <name> --no-verify-jwt --project-ref rgwwpkyuavhqdautpciu  # DEV
+  ```
+- **Règle stricte** : pas de déploiement PROD sans validation explicite de l'utilisateur. DEV librement.
+- CORS partagé dans `supabase/functions/_shared/cors.ts`. La whitelist inclut `wan2fit.fr`, `www.wan2fit.fr`, `capacitor://localhost` (iOS Capacitor), `https://localhost` + `http://localhost` (Android Capacitor).
+
+### Vercel deployments
+
+- Push sur n'importe quelle branche → preview deploy auto
+- Merge sur `main` → deploy production sur `wan2fit.fr`
+- Convention : PRs ciblent **toujours `develop`**, **jamais `main`**. Le PM merge `develop` → `main` quand il est prêt à promouvoir une release web.
+
+---
+
+## Données démo & seeds
+
+- **Compte review (PROD)** : `review@wan2fit.fr` — voir la mémoire Claude `reference_review_account.md`
+- **Seed prod du compte review** : script SQL préservé dans la conversation (à archiver dans `claudedocs/seeds/` quand on aura du temps)
+- **Compte personnel dev** : `erwan.viot@gmail.com` — seedé en DEV avec 23 séances complétées, 34+ meal logs, 7 recettes favorites, programme Débutant 4 sem en cours
+
+---
+
+## Sous-chantiers
+
+- **[IAP Apple StoreKit](./iap-implementation/)** — en cours, après le rejet Apple 3.1.1 du 2026-06-07
+- **[Audit pre-merge develop 2026-04-25](./audit-pre-merge-develop-2026-04-25.md)** — audit historique
+- **[Mobile dev guide](./mobile-dev.md)** — notes dev mobile générales
+
+---
+
+## Trous à combler (TODO)
+
+- Runbook dédié Apple App Store (`apple-submission-runbook.md`)
+- Runbook dédié Google Play (`play-store-submission-runbook.md`)
+- Documentation officielle des secrets Supabase (quels secrets sont dans le dashboard PROD vs DEV)
+- Documentation officielle des secrets Vercel (qui correspond à quelle var dans `.env.production`)
+- Procédure de rotation du keystore Android (si compromis)
+- Procédure de rotation du certificat Apple Distribution (si compromis)

--- a/claudedocs/iap-implementation/00-decision-log.md
+++ b/claudedocs/iap-implementation/00-decision-log.md
@@ -1,0 +1,159 @@
+# IAP iOS — Decision log
+
+Captures every architectural decision for the In-App Purchase implementation on iOS (and forward-compatible Android) so we never have to re-debate them silently in 3 months.
+
+---
+
+## Context
+
+Apple App Review verdict 2026-06-07 (Submission `73dc985c-d2ef-43ce-aa00-163187001cc5`, version reviewed 1.0 / 10104):
+
+> Guideline 3.1.1 — The app accesses digital content purchased outside the app, such as Premium subscription, but that content isn't available to purchase using In-App Purchase.
+
+Translation: hiding the pricing UI on iOS (what PR #227 did via `NativeUpgradeWall` + `openWebPricingPage`) is **not enough**. The mere fact that the iOS app *grants access* to premium features purchased on the web triggers 3.1.1. To pass review we must either:
+
+- **Option 1 — Add Apple IAP** so users *can* subscribe inside the app.
+- **Option 2 — Make the iOS app fully free, no premium content accessible**. Web subscribers would still log in, but every premium feature would be silently locked. Catastrophic UX.
+
+Option 2 destroys the value proposition of the iOS app and frustrates paying web users. Option 1 is the only reasonable path.
+
+---
+
+## Decision 1 — RevenueCat as the IAP layer
+
+### Alternatives evaluated
+
+| Option | Cost | Effort | Receipt validation | Cross-platform |
+|---|---|---|---|---|
+| **RevenueCat (`@revenuecat/purchases-capacitor`)** | Free <$2.5K MRR, then 1% MRR | ~1 day | Automatic | iOS + Android same code |
+| `cordova-plugin-purchase` (community) | Free forever | 2-3 days | We code it (Apple verifyReceipt + Google Play Developer API) | iOS + Android, less polished |
+| `@capacitor-community/in-app-purchases` | Free forever | 2 days | We code it | iOS + Android, less mature |
+| StoreKit 2 native Swift | Free | 3-5 days, requires Capacitor → native bridge | We code it | iOS only — we'd need Google Play Billing native separately |
+
+### Why RevenueCat wins
+
+1. **Receipt validation is a regulated minefield**. Apple's `verifyReceipt` endpoint, refund handling, grace periods, retry logic for billing failures, family sharing, promotional offers, introductory pricing — all of this is server-side state that RevenueCat handles. Rolling it ourselves is weeks of work and a fertile source of subtle revenue bugs.
+2. **Cross-platform with one code path**. When Google Play flags the same 3.1.1 equivalent (likely, given Google enforces in-app purchase for digital goods sold to Android users), the same RevenueCat code switches between StoreKit and Google Play Billing. Zero rework.
+3. **Industry standard**. Strava, Headspace, Discord, Notion all use RevenueCat. Mature plugin (`@revenuecat/purchases-capacitor`), good docs, active maintenance.
+4. **Pricing is benign at our scale**. Free up to $2.5K MRR ($30K ARR). Above: 1% MRR. At $100K ARR that's $1000/year — vs at least 5-10 days of engineering time saved.
+5. **Reversible**. If we ever outgrow RevenueCat, all the state lives on Apple/Google's side. We can swap in a custom receipt validator without losing customer history.
+
+### Why we didn't pick `cordova-plugin-purchase`
+
+Free is appealing, but the hidden cost is the receipt validator we'd own. Subscriptions are not a one-shot transaction — they renew, get refunded, switch tiers, get paused, get grace-period-extended. Every one of those events needs server-side handling. We'd be reinventing RevenueCat badly and paying with engineering time forever.
+
+### Why we didn't pick native StoreKit 2
+
+Wan2Fit is a Capacitor app. Going native iOS for IAP means:
+- Native Swift code maintained in the iOS shell project (`ios/App/App/`)
+- Bridge to JS via custom Capacitor plugin
+- Same work needed again natively for Android (Google Play Billing in Java/Kotlin)
+- We lose the abstraction Capacitor gives us
+
+Only justified if RevenueCat were broken or absurdly priced. It isn't.
+
+### Decision
+
+**Adopt RevenueCat** via `@revenuecat/purchases-capacitor`.
+
+---
+
+## Decision 2 — Small Business Program enrollment
+
+Apple's default commission: **30%** on subscriptions year 1, **15%** year 2+.
+
+The **Small Business Program**: **15% from day 1** for developers earning < $1M USD/year on the App Store.
+
+### Eligibility
+
+Wan2Fit has not yet shipped to the App Store, so revenue is $0. We're trivially under $1M. Enrollment is free, takes ~5 minutes in App Store Connect → Agreements, Tax and Banking → Membership.
+
+### Downside
+
+None. The program only ends if we cross $1M revenue in a calendar year, at which point we move back to 30% the following year. That's a great problem to have.
+
+### Decision
+
+**Enroll in the Small Business Program before submitting the IAP products** so our prices show the better commission rate from the first purchase.
+
+---
+
+## Decision 3 — Respond to Apple now or wait until the build is ready?
+
+### Wait approach
+
+- Pro: Honest — no promise we might miss.
+- Con: Apple's clock keeps ticking. Their workflow is "no reply = abandoned". Risk that the submission expires and we restart from zero on the next round.
+
+### Respond now approach
+
+- Pro: Buys goodwill, signals seriousness, locks the submission in "developer responded" state which doesn't auto-expire.
+- Pro: Apple reviewers tend to remember good-faith communications across rounds.
+- Con: Sets an expectation timeline we must honor.
+
+### Decision
+
+**Respond now**, but with a deliberately conservative timeline ("within 2 weeks" rather than "within days"). The IAP implementation is 2-3 days of focused work, but with App Store Connect setup, RevenueCat configuration, sandbox testing, and a fresh review cycle, we want margin.
+
+See `08-apple-resolution-center-response.md` for the exact text we sent.
+
+---
+
+## Decision 4 — Stripe stays on the web
+
+Three payment paths could coexist for the same user:
+
+- **Web** (`wan2fit.fr`) → Stripe Checkout, 9,99€/mois or 99,99€/an
+- **iOS native** → Apple StoreKit IAP, same price points
+- **Android native** → Google Play Billing IAP, same price points
+
+### Why we keep Stripe on web
+
+1. **Apple/Google take 15%, Stripe takes ~2%**. Every euro of subscription that goes through the web instead of native saves us ~13% net margin.
+2. **Better attribution & analytics**. Stripe webhooks give us full event control, refunds, dunning, custom emails. Native stores are more opaque.
+3. **Marketing on web pushes web checkout**. SEO traffic, landing pages, paid acquisition all funnel to the web checkout by default. Mobile users discovering us via the App Store get the native path.
+
+### Source of truth
+
+`profiles.subscription_tier` in Supabase, updated by **two webhooks**:
+
+- `stripe-webhook` (already deployed) for web purchases
+- `revenuecat-webhook` (new, in this PR) for native iOS / Android purchases
+
+If a user somehow ends up subscribed via both paths (edge case), the most recent webhook wins. We log the duplicate and trust the user not to double-pay (they'd get two charges, would notice, and we'd refund the older one).
+
+### Decision
+
+**Keep Stripe on web, add RevenueCat for native. No migration of existing web subscribers to IAP** — they continue using their Stripe sub forever (guideline 3.1.3(b) Multiplatform Service still covers them: the iOS app grants them access to content they bought elsewhere, which Apple accepts *as long as* an in-app purchase option also exists for new users).
+
+---
+
+## Decision 5 — Where the IAP paywall lives in the app
+
+After this PR:
+
+- **Web** (`isNative() === false`): unchanged. `PricingCards.tsx` shows Stripe checkout.
+- **iOS / Android native** (`isNative() === true`):
+  - `PricingCards.tsx` and `PremiumPromoPage.tsx` no longer render `<NativeUpgradeWall />`. They render a new `<NativePricingCards />` component that lists RevenueCat packages and triggers `Purchases.purchasePackage(pkg)` on tap.
+  - `<NativeUpgradeWall />` itself stays in the codebase, but is repurposed as a fallback for *unauthenticated* native users (sign-in is still required to subscribe).
+  - All the deep CTAs that currently link to `/premium` (EndScreen, SeancesPage, ProgramList, ConnectedContent) now route to `/tarifs` which on native is the IAP picker.
+  - **Restore Purchases** button added in `auth/SettingsPage.tsx` — calls `Purchases.restorePurchases()`. Required by Apple App Review.
+
+---
+
+## Decision 6 — Subscription product IDs
+
+| Tier | iOS / Android product ID | Stripe price ID (existing) |
+|---|---|---|
+| Premium Monthly | `wan2fit.premium.monthly` | `price_…` (already in `.env.production` as `VITE_STRIPE_PRICE_MONTHLY`) |
+| Premium Yearly | `wan2fit.premium.yearly` | `price_…` (already in `.env.production` as `VITE_STRIPE_PRICE_YEARLY`) |
+
+Product IDs are global namespaces in App Store Connect and Google Play. We use `wan2fit.premium.{monthly,yearly}` to keep them readable. They never change once published — App Store Connect refuses to delete a product ID.
+
+---
+
+## Open questions to revisit later
+
+- **Annual price introductory offer**: Apple allows promotional pricing for the first year (e.g. -50% first year). Should we add? Punt to post-launch — first ship the basics.
+- **Restore via deep link**: should `restorePurchases()` also fire on every cold launch in case the user was already a customer on another device? Default RevenueCat behavior covers this via `customerInfo` polling; we'll just trust it.
+- **Family Sharing**: enabled by default on auto-renewable subscriptions in App Store Connect. Probably want it on. Decide before submitting the products to App Review.

--- a/claudedocs/iap-implementation/01-architecture.md
+++ b/claudedocs/iap-implementation/01-architecture.md
@@ -1,0 +1,230 @@
+# IAP iOS — Architecture cible
+
+## Vue d'ensemble
+
+Trois canaux de paiement coexistent, un seul état centralisé :
+
+```
+                          ┌───────────────────────────┐
+                          │  profiles.subscription_   │
+                          │  tier (free|premium)      │
+                          │  +                        │
+                          │  profiles.subscription_   │
+                          │  provider (stripe|        │
+                          │  revenuecat) [NEW]        │
+                          └─────────────▲─────────────┘
+                                        │ RLS: only service_role can update
+                                        │ (via webhooks)
+                ┌───────────────────────┼───────────────────────┐
+                │                       │                       │
+        ┌───────┴────────┐    ┌─────────┴─────────┐    ┌───────┴────────┐
+        │ stripe-        │    │ revenuecat-       │    │ revenuecat-    │
+        │ webhook        │    │ webhook [NEW]     │    │ webhook [NEW]  │
+        │ (Stripe events)│    │ (Apple IAP events)│    │ (Google IAP    │
+        │                │    │                   │    │  events)       │
+        └───────▲────────┘    └─────────▲─────────┘    └───────▲────────┘
+                │                       │                       │
+                │ HTTP POST             │ HTTP POST             │ HTTP POST
+                │                       │                       │
+        ┌───────┴────────┐    ┌─────────┴─────────────────────────────┐
+        │ Stripe         │    │ RevenueCat (proxy + receipt validator)│
+        │ (Checkout +    │    │                                       │
+        │  Customer      │    └─────────▲─────────────────▲───────────┘
+        │  Portal)       │              │                 │
+        └───────▲────────┘              │ Apple           │ Google
+                │                       │ App Store       │ Play
+                │                       │ Server-to-      │ Real-time
+                │                       │ Server          │ Developer
+                │                       │ notifications   │ Notifications
+                │                       │                 │
+        ┌───────┴────────┐    ┌─────────┴─────┐ ┌─────────┴─────────┐
+        │ wan2fit.fr     │    │ iOS app       │ │ Android app       │
+        │ (web)          │    │ (StoreKit)    │ │ (Google Play      │
+        │                │    │               │ │  Billing)         │
+        └────────────────┘    └───────────────┘ └───────────────────┘
+```
+
+## Composants existants (conservés tels quels)
+
+### `useSubscription.ts`
+
+Le hook actuel expose :
+
+```ts
+{
+  isPremium: boolean,
+  subscription: {...},
+  checkout: (priceId: string) => Promise<string | null>,
+  manageSubscription: () => Promise<string | null>,
+}
+```
+
+`checkout()` actuellement dispatch entre :
+- Web : `create-checkout-session` edge function → URL Stripe Checkout
+- Native : `openWebUpgrade(priceId)` → ouvre Safari sur `wan2fit.fr/upgrade?priceId=…`
+
+**Changement requis** : sur native, `checkout()` doit appeler RevenueCat à la place. Le hook devient :
+
+```ts
+async function checkout(priceId: string) {
+  if (isNative()) {
+    return purchaseViaRevenueCat(productIdFromPriceId(priceId));
+  }
+  return purchaseViaStripe(priceId);
+}
+```
+
+### `PricingCards.tsx`
+
+- Web : continue d'afficher les 2 plans + bouton checkout Stripe (inchangé)
+- Native : actuellement affiche `<NativeUpgradeWall />`. Désormais affichera `<NativePricingCards />` (nouveau composant) qui :
+  - Liste les packages RevenueCat (récupérés via `Purchases.getOfferings()`)
+  - Affiche les prix locaux (RevenueCat fournit `localizedPrice`)
+  - Bouton "S'abonner" → `Purchases.purchasePackage(pkg)`
+
+### Edge function `stripe-webhook`
+
+Continue de gérer les events Stripe pour les abonnements web. Aucun changement.
+
+### Migration 011 RLS
+
+`011_restrict_profiles_update.sql` empêche actuellement les users de modifier `subscription_tier` directement — seul le service_role (utilisé par `stripe-webhook`) peut. **Le futur `revenuecat-webhook` utilisera aussi le service_role**, donc compatible sans nouvelle migration RLS.
+
+## Composants nouveaux
+
+### Plugin Capacitor `@revenuecat/purchases-capacitor`
+
+- Installé via `npm install @revenuecat/purchases-capacitor`
+- Initialisé au cold-start dans `App.tsx` :
+  ```ts
+  await Purchases.configure({
+    apiKey: import.meta.env.VITE_REVENUECAT_PUBLIC_API_KEY_IOS, // côté iOS
+    // ou _ANDROID côté Android
+    appUserID: user?.id, // bind à notre user ID Supabase
+  });
+  ```
+- Une seule clé publique par plateforme, mise dans `.env.production` :
+  - `VITE_REVENUECAT_PUBLIC_API_KEY_IOS=appl_xxxxxxx`
+  - `VITE_REVENUECAT_PUBLIC_API_KEY_ANDROID=goog_xxxxxxx`
+
+### Hook `usePurchases.ts`
+
+Wrapper TypeScript autour du plugin. Expose :
+
+```ts
+{
+  packages: Package[] | null,       // monthly + yearly
+  loading: boolean,
+  error: string | null,
+  purchase: (pkg: Package) => Promise<void>,
+  restore: () => Promise<void>,
+}
+```
+
+Encapsule la logique RevenueCat pour qu'aucun composant React ne touche directement le plugin.
+
+### Composant `<NativePricingCards />`
+
+Remplace `<NativeUpgradeWall />` sur les écrans authentifiés. Visuellement très proche de l'actuel `<PricingCards />` web (mêmes cards, mêmes features lists, mais boutons RevenueCat au lieu de Stripe).
+
+### Composant `<RestorePurchasesButton />`
+
+Dans `auth/SettingsPage.tsx`. Bouton simple qui appelle `Purchases.restorePurchases()`. **Obligatoire pour passer Apple App Review** (3.1.1 requirement).
+
+### Migration 012 — `profiles.subscription_provider`
+
+Nouvelle colonne pour tracer la source de l'abonnement (utile pour le support, l'analytics, et le routage des actions "manage subscription" — un user iOS doit aller dans Réglages iOS pour annuler, un user web va dans Stripe Customer Portal).
+
+```sql
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS subscription_provider TEXT
+  CHECK (subscription_provider IN ('stripe', 'revenuecat'));
+```
+
+Le webhook qui met à jour `subscription_tier` met aussi à jour `subscription_provider`.
+
+### Edge function `revenuecat-webhook`
+
+Nouvelle. Reçoit les events RevenueCat (`INITIAL_PURCHASE`, `RENEWAL`, `CANCELLATION`, `EXPIRATION`, `BILLING_ISSUE`, etc.) et met à jour `profiles.subscription_tier`.
+
+Structure :
+
+```ts
+// supabase/functions/revenuecat-webhook/index.ts
+serve(async (req) => {
+  // 1. Validate secret header (RevenueCat sends X-Webhook-Secret)
+  const secret = req.headers.get("authorization");
+  if (secret !== `Bearer ${Deno.env.get("REVENUECAT_WEBHOOK_SECRET")}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // 2. Parse RevenueCat event
+  const { event } = await req.json();
+  const userId = event.app_user_id; // = our Supabase user.id
+
+  // 3. Compute the desired subscription_tier from the event type
+  const tier = isActiveEventType(event.type) ? "premium" : "free";
+
+  // 4. Upsert profiles row
+  await supabaseAdmin
+    .from("profiles")
+    .update({
+      subscription_tier: tier,
+      subscription_provider: "revenuecat",
+    })
+    .eq("id", userId);
+
+  return new Response("OK");
+});
+```
+
+Secret stocké côté Supabase Edge Functions Secrets via :
+```bash
+npx supabase secrets set REVENUECAT_WEBHOOK_SECRET=<value> --project-ref pipbhkaaqsltnvprmzrl
+```
+
+## Coexistence Stripe + RevenueCat sur le même `subscription_tier`
+
+Scénario : un user s'abonne d'abord via le web (Stripe), puis souhaite s'abonner depuis l'iOS (StoreKit). Que se passe-t-il ?
+
+1. Apple n'a aucune visibilité sur Stripe. Il acceptera la souscription StoreKit sans broncher.
+2. L'user sera donc facturé deux fois (Stripe + Apple). Mauvaise UX.
+
+**Mitigation** :
+- Quand on initialise RevenueCat dans l'app native, on appelle `Purchases.getCustomerInfo()` au cold-start. Si l'user a déjà un abonnement actif (peu importe d'où), on ne lui propose pas l'écran IAP — on lui montre `<NativeUpgradeWall />` modifié en mode "Tu es déjà premium via [stripe/revenuecat]" + bouton "Gérer" qui ouvre le bon canal.
+- Côté `<NativePricingCards />`, avant d'afficher les packages on check `isPremium` côté Supabase. Si premium déjà → on cache l'écran de purchase.
+
+C'est imparfait mais réaliste : il y aura toujours un edge case où un user achète des 2 côtés (carte mémorisée différente, oubli, etc.). Le support manuel restera nécessaire pour ces cas.
+
+## Source de vérité finale
+
+`profiles.subscription_tier` (Supabase) **est la seule source de vérité** pour le frontend. Tous les composants qui veulent savoir si l'user est premium passent par `useAuth()` ou `useSubscription()` qui lisent cette valeur.
+
+Les états locaux de RevenueCat / Stripe sont des **caches** qui doivent toujours converger vers cette source via les webhooks.
+
+## Flow d'achat iOS détaillé
+
+1. L'user est connecté, navigue dans l'app, clique "Passer Premium" (sur `/tarifs`)
+2. `<NativePricingCards />` rendu (parce que `isNative()` et `!isPremium`)
+3. `usePurchases.packages` retourne `[monthlyPackage, yearlyPackage]` depuis `Purchases.getOfferings()`
+4. L'user sélectionne un plan, clique "S'abonner"
+5. `Purchases.purchasePackage(pkg)` est appelé
+6. **StoreKit prend le contrôle** : Face ID, prompt confirmation, achat
+7. RevenueCat valide le receipt auprès d'Apple en arrière-plan
+8. RevenueCat envoie un webhook `INITIAL_PURCHASE` à notre edge function
+9. Notre edge function met à jour `profiles.subscription_tier = 'premium'`
+10. Le React Query qui watch `profiles` détecte la mise à jour (via Supabase Realtime ou polling) → toute l'UI bascule en mode premium
+
+Étape 9 → 10 peut prendre quelques secondes (latence webhook). Pour une UX immédiate, juste après que `Purchases.purchasePackage()` resolve avec succès on peut **optimistiquement** mettre l'UI en mode premium localement, puis attendre que le webhook confirme.
+
+## Restore Purchases — flow
+
+1. L'user installe l'app sur un nouvel iPhone (ou réinstalle après désinstallation)
+2. Il se connecte avec son compte Wan2Fit
+3. Sur Settings, il tape "Restaurer mes achats"
+4. `Purchases.restorePurchases()` appelé
+5. RevenueCat interroge Apple pour les receipts associés à l'Apple ID actuel
+6. Si un abonnement actif est trouvé, RevenueCat envoie le webhook approprié à notre backend
+7. `subscription_tier` mis à jour → UI bascule en mode premium
+
+L'user n'est jamais re-facturé. Le bouton "Restaurer" est requis par Apple pour tous les apps qui vendent du contenu non-consommable ou des abonnements.

--- a/claudedocs/iap-implementation/02-app-store-connect-setup.md
+++ b/claudedocs/iap-implementation/02-app-store-connect-setup.md
@@ -1,0 +1,182 @@
+# IAP iOS — Setup App Store Connect
+
+Step-by-step pour créer les Subscriptions In-App Purchase côté Apple. À faire **avant** d'intégrer RevenueCat (qui pull les produits depuis App Store Connect).
+
+Durée totale : ~30-45 min, dont ~10 min d'attente Apple.
+
+---
+
+## Pré-requis
+
+- Compte Apple Developer Program payant et actif (`erwan.viot@gmail.com`)
+- App `Wan2Fit` créée dans App Store Connect (`Bundle ID fr.wansoft.wan2fit`)
+- Compte bancaire + tax info renseignés dans App Store Connect → Agreements, Tax, and Banking → **Paid Apps agreement signé**
+
+Si le Paid Apps agreement n'est pas signé, App Store Connect refuse de créer des subscriptions. Va dans **App Store Connect > Agreements, Tax, and Banking > Paid Apps > Set up** et complète :
+- Master agreement
+- Tax forms (W-8BEN-E pour entité non-US, ou équivalent EU)
+- Banking info (IBAN + BIC)
+
+---
+
+## Étape 1 — Enroll au Small Business Program
+
+**Pourquoi** : 15% de commission au lieu de 30% sur tous les abonnements iOS, dès la première vente.
+
+1. App Store Connect → en haut à droite, ton nom → **Agreements, Tax, and Banking**
+2. **Paid Apps** agreement → onglet **Small Business Program**
+3. Cliquer **Apply**
+4. Tu acceptes la condition : revenus < $1M USD/year. Wan2Fit a 0$ de revenu, donc trivialement éligible.
+5. Apple confirme par email sous 24-48h, généralement instantané
+
+**Important** : si tu enroll APRÈS avoir créé les subscriptions, les nouveaux clients post-enrollment auront 15%, mais tout client souscrit avant continue à 30% jusqu'au prochain renouvellement. C'est pour ça qu'on enroll AVANT de soumettre les subscriptions.
+
+---
+
+## Étape 2 — Créer le Subscription Group
+
+Un "subscription group" est un dossier qui contient des subscriptions liées (ex : monthly / yearly du même plan). L'user ne peut être abonné qu'à UN seul tier dans un même groupe à la fois — passer de monthly à yearly = upgrade automatique dans le même groupe.
+
+1. App Store Connect → ton app **Wan2Fit** → **Distribution** (gauche)
+2. Sous **In-App Purchases** → **Subscriptions**
+3. Sous **Subscription Groups**, cliquer **Create**
+4. **Reference Name** : `Wan2Fit Premium` (interne, jamais visible des users)
+5. Save
+
+---
+
+## Étape 3 — Créer la subscription Mensuelle
+
+1. Dans le subscription group `Wan2Fit Premium` → **Create Subscription**
+2. **Reference Name** : `Premium Monthly` (interne)
+3. **Product ID** : `wan2fit.premium.monthly`
+   - ⚠️ **Ce Product ID est figé à vie**. Apple refuse de le supprimer une fois créé. Ne pas se planter.
+4. **Subscription Duration** : 1 Month
+5. **Subscription Group** : `Wan2Fit Premium` (déjà sélectionné)
+
+### Tarification
+
+6. **Subscription Prices** → **Add Subscription Price**
+7. **Base Country/Region** : France (EUR)
+8. **Price** : 9,99 € EUR
+9. Apple génère automatiquement les prix équivalents pour les 175 autres territoires (Price Matrix). Tu peux les overrider individuellement si tu veux, mais 9,99€ = $9.99 = £8.99 sont les conversions standards qu'Apple propose.
+10. Valider
+
+### Localizations (FR + EN)
+
+11. **Localizations** → **Add Localization**
+
+**Français (France) :**
+- Subscription Display Name : `Wan2Fit Premium Mensuel`
+- Description : `Accès illimité aux programmes IA, séances personnalisées, suivi nutrition complet et toutes les recettes premium. Sans engagement, résiliable à tout moment.`
+
+**English (US) :**
+- Subscription Display Name : `Wan2Fit Premium Monthly`
+- Description : `Unlimited access to AI programs, custom workouts, complete nutrition tracking and all premium recipes. No commitment, cancel anytime.`
+
+### Review Information
+
+12. **App Review Information** → Screenshot de l'écran qui déclenche l'IAP dans l'app (l'écran `<NativePricingCards />` qu'on va construire). **À ajouter APRÈS** avoir le screenshot — pour l'instant on saute, on revient ici quand on aura le build.
+
+### Status
+
+13. Save. Le statut passe à **"Ready to Submit"**. On le **submittra plus tard**, après avoir le screenshot et le build TestFlight qui va avec.
+
+---
+
+## Étape 4 — Créer la subscription Annuelle
+
+Identique à l'étape 3 avec :
+
+- **Reference Name** : `Premium Yearly`
+- **Product ID** : `wan2fit.premium.yearly`
+- **Subscription Duration** : 1 Year
+- **Subscription Group** : `Wan2Fit Premium` (le même que monthly)
+- **Base Price** : 99,99 € EUR
+- **Display Name FR** : `Wan2Fit Premium Annuel`
+- **Description FR** : `Tous les avantages Premium pour 99,99 €/an — soit l'équivalent de 8,33 €/mois (économise 17% vs la formule mensuelle). Sans engagement, résiliable à tout moment.`
+- **Display Name EN** : `Wan2Fit Premium Yearly`
+- **Description EN** : `All Premium benefits for 99.99 €/year — equivalent of 8.33 €/month (save 17% vs monthly). No commitment, cancel anytime.`
+
+---
+
+## Étape 5 — Configurer le Subscription Group localizations
+
+Le Group lui-même a sa propre localization (visible au user dans Settings > Subscriptions de son iPhone).
+
+1. Dans le group `Wan2Fit Premium` → **App Name** localizations
+2. **Français (France)** :
+   - Display Name : `Wan2Fit Premium`
+3. **English (US)** :
+   - Display Name : `Wan2Fit Premium`
+4. Save
+
+---
+
+## Étape 6 — App Store Connect API Key (pour RevenueCat)
+
+RevenueCat a besoin d'une API Key Apple pour interroger App Store Connect côté serveur.
+
+1. App Store Connect → ton nom (top right) → **Users and Access**
+2. Onglet **Integrations** → **App Store Connect API**
+3. Cliquer **Generate API Key**
+4. **Name** : `RevenueCat`
+5. **Access** : `App Manager` (suffisant pour les subscriptions)
+6. Cliquer **Generate**
+7. **Télécharger le fichier `.p8`** — ⚠️ il n'est téléchargeable qu'**une seule fois**, pas de récupération possible après. Le mettre dans `~/Downloads/` et le partager avec RevenueCat dans la prochaine étape.
+8. Noter le **Key ID** (visible dans la liste, ex: `ABC123XYZ`) et l'**Issuer ID** (en haut de la page Integrations, GUID)
+
+---
+
+## Étape 7 — Shared Secret (pour App Store Server Notifications V2)
+
+Aussi appelé "App-Specific Shared Secret". Utilisé pour authentifier les server-to-server notifications Apple → RevenueCat.
+
+1. App Store Connect → ton app **Wan2Fit** → **Distribution** (gauche)
+2. Sous **App Information** → **App-Specific Shared Secret** → **Manage**
+3. **Generate** un nouveau secret
+4. **Le copier et le stocker dans `Mots de Passe Mac`** sous l'entrée "Wan2Fit ASC Shared Secret"
+
+---
+
+## Étape 8 — Sandbox Tester accounts
+
+Pour tester l'achat sans débit réel.
+
+1. App Store Connect → **Users and Access** → onglet **Sandbox**
+2. **Testers** → **+**
+3. Créer un compte avec un email **qui n'a JAMAIS été utilisé pour un vrai Apple ID** (sinon Apple refuse). Format pratique : `wan2fit-sandbox-1@yopmail.com`
+4. Password : à noter dans Mots de Passe Mac
+5. Pour tester sur iPhone : Settings > App Store > Sandbox Account → se connecter avec ce compte
+6. **Une fois connecté Sandbox sur l'iPhone**, tous les achats StoreKit se font en sandbox (gratuit, durée des abonnements accélérée — 1 mois IRL = 5 min sandbox)
+
+Créer 2-3 comptes Sandbox pour tester différents scénarios (achat, renewal, cancel, restore).
+
+---
+
+## Étape 9 — App Store Server Notifications V2 URL
+
+C'est l'endpoint où Apple POSTera les events server-to-server. **Pour RevenueCat, c'est leur URL** — on configurera ça après avoir créé le compte RevenueCat (voir `03-revenuecat-setup.md`).
+
+---
+
+## Récap : ce qu'on doit avoir à la fin de cette étape
+
+- [ ] Small Business Program enrollé
+- [ ] Subscription Group `Wan2Fit Premium` créé
+- [ ] Product `wan2fit.premium.monthly` créé, statut "Ready to Submit"
+- [ ] Product `wan2fit.premium.yearly` créé, statut "Ready to Submit"
+- [ ] Group localizations FR + EN
+- [ ] API Key Apple (.p8) téléchargée, Key ID + Issuer ID notés
+- [ ] App-Specific Shared Secret généré et stocké dans Mots de Passe Mac
+- [ ] Au moins 1 Sandbox Tester créé pour les tests
+
+Une fois cette checklist verte, on passe à `03-revenuecat-setup.md`.
+
+---
+
+## Trous identifiés (à documenter une fois faits)
+
+- Capture d'écran de l'écran IAP qui sera dans l'app (`<NativePricingCards />`) — à fournir à App Review Information de chaque subscription. À faire après avoir buildé l'app.
+- Configurer Family Sharing pour les subscriptions (Apple le propose dans la création — recommandation oui par défaut sur les abonnements grand public).
+- Promotional offers / introductory pricing : à voir post-launch.

--- a/claudedocs/iap-implementation/03-revenuecat-setup.md
+++ b/claudedocs/iap-implementation/03-revenuecat-setup.md
@@ -1,0 +1,173 @@
+# IAP iOS — Setup RevenueCat
+
+À faire **après** avoir terminé `02-app-store-connect-setup.md` (RevenueCat a besoin de la `.p8` Apple).
+
+Durée totale : ~20-30 min.
+
+---
+
+## Étape 1 — Créer le compte RevenueCat
+
+1. Aller sur <https://app.revenuecat.com/signup>
+2. Sign up avec `erwan.viot@gmail.com`
+3. Confirmer email
+4. Au premier login, RevenueCat propose de créer un Project. **Project Name** : `Wan2Fit`
+
+---
+
+## Étape 2 — Connecter l'app iOS à App Store Connect
+
+1. Dans le projet Wan2Fit, sidebar gauche → **Projects** → **+ New App**
+2. **App Type** : `Apple App Store`
+3. **App Name** : `Wan2Fit iOS`
+4. **Bundle ID** : `fr.wansoft.wan2fit`
+5. **App Store Connect API Configuration** :
+   - **Issuer ID** : (depuis `02-app-store-connect-setup.md` étape 6)
+   - **Key ID** : `ABC123XYZ` (depuis `02-app-store-connect-setup.md` étape 6)
+   - **Upload `.p8` file** : drag-and-drop le fichier `AuthKey_XXX.p8`
+6. **App-Specific Shared Secret** (pour validation receipt) : coller la valeur générée en `02-app-store-connect-setup.md` étape 7
+7. **Save**
+
+RevenueCat va automatiquement pull les Subscriptions qu'on a créées en App Store Connect (`wan2fit.premium.monthly` + `wan2fit.premium.yearly`). Vérifier qu'elles apparaissent dans **Products** sous l'app iOS.
+
+---
+
+## Étape 3 — Connecter l'app Android (à faire en parallèle ou plus tard)
+
+Pour Android, RevenueCat a besoin d'un **Google Cloud Service Account** avec accès à l'API Google Play Developer.
+
+Étapes (à détailler quand on attaquera Android IAP) :
+1. Google Cloud Console → créer service account
+2. Google Play Console → Setup > API access → lier le service account
+3. RevenueCat → New App → Google Play → coller le JSON du service account
+
+**Skippé pour cette PR** — on shippe iOS only en premier. Android suivra dès que (a) Google flaggera 3.1.1 équivalent OU (b) on aura le bandwidth.
+
+---
+
+## Étape 4 — Définir les Entitlements
+
+Un "entitlement" est un label abstrait pour ce qu'un user obtient en s'abonnant. Permet de découpler "quel produit a-t-il acheté" de "quoi a-t-il droit dans l'app".
+
+1. RevenueCat → projet Wan2Fit → **Product Catalog** → **Entitlements**
+2. **+ New Entitlement**
+3. **Identifier** : `premium`
+4. **Description** : `Access to all premium features (AI programs, AI sessions, full nutrition tracking)`
+5. **Save**
+
+### Lier les products à l'entitlement
+
+6. Cliquer sur l'entitlement `premium` → **Attach Products**
+7. Cocher `wan2fit.premium.monthly` (iOS) et `wan2fit.premium.yearly` (iOS)
+8. **Save**
+
+Maintenant côté code, on checkera `customerInfo.entitlements.active["premium"] !== undefined` au lieu de `customerInfo.activeSubscriptions.length > 0`. C'est plus robuste si on change de structure de products plus tard.
+
+---
+
+## Étape 5 — Créer une Offering
+
+Une "offering" est ce que l'user voit dans le paywall : un set de packages présentés ensemble.
+
+1. **Product Catalog** → **Offerings**
+2. **+ New Offering**
+3. **Identifier** : `default` (RevenueCat utilise cet ID par défaut côté code, simplifie le boilerplate)
+4. **Description** : `Default paywall — monthly + yearly`
+5. **Save**
+
+### Ajouter les packages à l'offering
+
+6. Ouvrir l'offering `default` → **Add Package**
+7. **Package 1** :
+   - **Identifier** : `$rc_monthly` (RevenueCat alias standard)
+   - **Description** : `Monthly subscription`
+   - **Products** : Apple App Store → `wan2fit.premium.monthly`
+8. **Package 2** :
+   - **Identifier** : `$rc_annual`
+   - **Description** : `Annual subscription (best value)`
+   - **Products** : Apple App Store → `wan2fit.premium.yearly`
+9. **Save**
+10. **Marquer cette offering comme "Current"** (toggle en haut). Indique que c'est l'offering active par défaut.
+
+---
+
+## Étape 6 — Récupérer la Public API Key iOS
+
+Cette clé sera embarquée dans le bundle iOS (côté client). C'est **public** par design — RevenueCat utilise la signature de receipt Apple pour authentifier les achats, pas la clé.
+
+1. RevenueCat → projet Wan2Fit → **Project Settings** (icône engrenage en bas à gauche) → **API Keys**
+2. Sous **iOS App Wan2Fit** → copier la clé publique (commence par `appl_`)
+3. La stocker dans `.env.production` (et `.env.local` pour DEV qui peut partager la même clé) :
+   ```
+   VITE_REVENUECAT_PUBLIC_API_KEY_IOS=appl_xxxxxxxxxxxxxxxxxxxxxx
+   ```
+4. Aussi pousser dans Vercel :
+   ```bash
+   vercel env add VITE_REVENUECAT_PUBLIC_API_KEY_IOS production
+   ```
+
+---
+
+## Étape 7 — Configurer le Webhook vers Supabase
+
+C'est le pont entre les events RevenueCat et notre backend.
+
+1. Project Settings → **Integrations** → **Webhooks**
+2. **+ New Webhook**
+3. **Webhook URL** : `https://pipbhkaaqsltnvprmzrl.supabase.co/functions/v1/revenuecat-webhook`
+4. **Authorization Header** : `Bearer <REVENUECAT_WEBHOOK_SECRET>` (générer une chaîne aléatoire de 32+ chars)
+5. **Events to receive** : tous (RevenueCat envoie de toute façon le minimum). Cocher au moins :
+   - `INITIAL_PURCHASE`
+   - `RENEWAL`
+   - `CANCELLATION`
+   - `EXPIRATION`
+   - `BILLING_ISSUE`
+   - `PRODUCT_CHANGE`
+   - `UNCANCELLATION`
+6. **Save**
+
+### Côté Supabase, stocker le secret
+
+```bash
+npx supabase secrets set REVENUECAT_WEBHOOK_SECRET=<la chaîne aléatoire> --project-ref pipbhkaaqsltnvprmzrl
+npx supabase secrets set REVENUECAT_WEBHOOK_SECRET=<la chaîne aléatoire> --project-ref rgwwpkyuavhqdautpciu
+```
+
+L'edge function `revenuecat-webhook` vérifiera ce header au début pour rejeter les requests non-authentifiés.
+
+---
+
+## Étape 8 — Tester le webhook avec un sandbox purchase
+
+À faire seulement quand l'edge function `revenuecat-webhook` sera déployée et l'app TestFlight prête.
+
+1. Sur iPhone : login Sandbox account
+2. Ouvrir TestFlight Wan2Fit, taper "Passer Premium"
+3. Acheter monthly (5 min de durée en sandbox)
+4. Vérifier dans RevenueCat → **Customer Center** que le customer apparaît avec entitlement actif
+5. Vérifier dans Supabase Studio que `profiles.subscription_tier = 'premium'` pour ce user
+6. Vérifier dans **RevenueCat → Webhooks → History** que le webhook a bien été envoyé et qu'il y a un `200 OK` de notre edge function
+
+Si erreur : RevenueCat fait du retry automatique (jusqu'à 24h). On peut aussi forcer un retry manuel depuis le dashboard.
+
+---
+
+## Récap : ce qu'on doit avoir à la fin
+
+- [ ] Compte RevenueCat créé
+- [ ] App iOS connectée à App Store Connect via API Key
+- [ ] Entitlement `premium` créé et lié aux 2 products iOS
+- [ ] Offering `default` avec packages `$rc_monthly` + `$rc_annual` marquée Current
+- [ ] Public API Key iOS dans `.env.production` + Vercel + `.env.local`
+- [ ] Webhook configuré vers Supabase, secret partagé (Bearer)
+- [ ] `REVENUECAT_WEBHOOK_SECRET` dans Supabase secrets DEV + PROD
+
+Une fois validé, on passe à `04-app-integration.md` pour le code.
+
+---
+
+## Trous identifiés
+
+- Stratégie de migration des sandbox testers vers prod testers : doc séparée
+- Customer attribution (UTM, etc.) : optionnel, RevenueCat supporte mais on n'en aura pas besoin tout de suite
+- Promotional codes : à voir post-launch

--- a/claudedocs/iap-implementation/08-apple-resolution-center-response.md
+++ b/claudedocs/iap-implementation/08-apple-resolution-center-response.md
@@ -1,0 +1,66 @@
+# Réponse Apple Resolution Center — 2026-06-07
+
+À coller dans App Store Connect > Wan2Fit > version en review > Resolution Center > Reply.
+
+---
+
+```
+Hi Apple Review Team,
+
+Thank you for the additional clarification on Guideline 3.1.1. We
+acknowledge the point: hiding the pricing UI on iOS is not sufficient
+as long as the app grants access to digital content acquired
+elsewhere. We accept the requirement and are implementing Apple
+In-App Purchase via StoreKit.
+
+WHAT WE ARE BUILDING
+
+- Two auto-renewable subscriptions in the same subscription group:
+    wan2fit.premium.monthly  — 9.99 EUR / month
+    wan2fit.premium.yearly   — 99.99 EUR / year
+- Subscription products will be submitted to App Review alongside a
+  new binary that includes the StoreKit purchase flow.
+- A "Restore Purchases" button is added in Settings as required.
+- Existing customers who subscribed on our website
+  (https://wan2fit.fr) will continue to access their content under
+  guideline 3.1.3(b) Multiplatform Service, since In-App Purchase is
+  now also available inside the iOS app for new users.
+
+TIMELINE
+
+We expect the IAP-enabled build to be ready for submission within
+two weeks. We will notify you in this thread when the new build
+(1.2.0 or higher) is uploaded to TestFlight and attached to this
+submission, along with sandbox test credentials so you can validate
+the purchase flow without a real charge.
+
+In the meantime, please keep this submission open. We did not
+intend any guideline violation — the previous iteration was our
+attempt to comply with 3.1.3(b) Multiplatform Service, and we now
+understand that path requires IAP to also exist as a parallel
+option.
+
+Thank you for your patience and for the clear feedback.
+
+Best regards,
+Erwan Viot
+Wan Soft
+```
+
+---
+
+## Pourquoi cette formulation
+
+- **Acknowledge explicit** (« We acknowledge the point ») : Apple reviewers répondent mieux quand on reconnaît leur position au lieu de la discuter.
+- **Listes nominatives des Product IDs** : preuve qu'on a déjà commencé, pas juste du "on va voir".
+- **Timeline conservative (2 semaines)** : laisse de la marge réelle (le dev est 3-5j mais l'examen Apple ajoute 1-3j de plus). Mieux que promettre "few days" et glisser.
+- **Mention de 3.1.3(b)** : montre qu'on a compris la nuance (3.1.3(b) reste valide *en plus* de l'IAP, pas à la place).
+- **Sandbox credentials promised** : Apple aime quand on facilite leur job pour le re-review.
+- **Pas d'excuses ni de longues explications historiques** : rester court et opérationnel.
+
+## Quand envoyer
+
+**Maintenant**. Avant même de commencer le dev. Raisons :
+- La submission reste "active" plus longtemps si l'Apple voit qu'on travaille.
+- Si on attend que le nouveau build soit prêt, Apple peut auto-clore la submission après ~30j d'inactivité.
+- Le reviewer qui re-jugera plus tard verra le thread complet et notera notre bonne foi.

--- a/claudedocs/iap-implementation/README.md
+++ b/claudedocs/iap-implementation/README.md
@@ -1,0 +1,62 @@
+# IAP iOS — Implémentation Apple StoreKit (via RevenueCat)
+
+Chantier ouvert le 2026-06-07 après le rejet Apple App Review 3.1.1.
+
+## Pourquoi ce chantier
+
+- Apple Guideline 3.1.1 : impossible que l'app iOS donne accès à du contenu premium acheté hors-app sans **aussi** offrir la souscription via In-App Purchase.
+- Conséquence : on doit implémenter Apple StoreKit (et tant qu'à faire, Google Play Billing par symétrie, anticipant le même flag côté Google).
+- Le pattern PR #227 (`<NativeUpgradeWall />` qui redirige vers `wan2fit.fr/tarifs` dans Safari) **n'est pas suffisant**.
+
+## Stratégie technique
+
+- **RevenueCat** comme couche d'abstraction StoreKit + Google Play Billing → un seul plugin Capacitor, un seul webhook backend.
+- **Stripe reste sur le web** (commission ~2% vs ~15% Apple/Google) — meilleure marge, garder la maîtrise de l'acquisition.
+- **`profiles.subscription_tier`** dans Supabase reste la seule source de vérité, mis à jour par 2 webhooks (`stripe-webhook` + nouveau `revenuecat-webhook`).
+- **Small Business Program** Apple → 15% au lieu de 30% dès la première vente, gratuit.
+
+## Documents
+
+Lire dans l'ordre :
+
+1. [**00-decision-log.md**](./00-decision-log.md) — pourquoi RevenueCat, pourquoi Small Business, pourquoi répondre à Apple maintenant, etc.
+2. [**01-architecture.md**](./01-architecture.md) — schéma data flow + composants nouveaux / modifiés.
+3. [**02-app-store-connect-setup.md**](./02-app-store-connect-setup.md) — créer les subscriptions IAP côté Apple, API key, sandbox testers.
+4. [**03-revenuecat-setup.md**](./03-revenuecat-setup.md) — créer le compte RevenueCat, lier ASC, entitlements, offerings, webhook.
+5. **04-app-integration.md** *(à écrire au moment du dev)* — code Capacitor : hook `usePurchases`, composant `<NativePricingCards />`, bouton restore.
+6. **05-supabase-webhook.md** *(à écrire)* — edge function `revenuecat-webhook` complète + migration 012.
+7. **06-testing-sandbox.md** *(à écrire)* — scénarios de test sandbox (achat, renewal, cancel, restore, edge cases).
+8. **07-launch-checklist.md** *(à écrire)* — checklist pré-submit Apple (screenshots IAP, App Review notes, etc.).
+9. **08-apple-resolution-center-response.md** *(à écrire)* — texte exact envoyé à Apple.
+
+## Statut
+
+- [x] Decision log
+- [x] Architecture
+- [x] Setup ASC documenté
+- [x] Setup RevenueCat documenté
+- [ ] Enrollment Small Business Program (action humaine — toi)
+- [ ] Création des Subscriptions IAP dans ASC (action humaine — toi)
+- [ ] Création du compte RevenueCat (action humaine — toi)
+- [ ] Réponse Apple Resolution Center (action humaine — toi)
+- [ ] Code app + edge function (Claude)
+- [ ] Tests sandbox (toi)
+- [ ] Resubmit Apple (toi)
+
+## Timeline estimé
+
+| Étape | Durée |
+|---|---|
+| Setup ASC + RevenueCat + Small Business (humain) | 1-2h |
+| Réponse Apple Resolution Center | 5 min |
+| Code app + edge function + migration | 1 jour |
+| Tests sandbox + corrections | 4-8h |
+| Resubmit Apple + cycle review | 1-3j |
+| **Total réaliste** | **3-5 jours calendaires** |
+
+## Risques
+
+- **App Store Connect bloque la création d'IAP si le Paid Apps agreement n'est pas signé**. Vérifier en premier dans Agreements, Tax, and Banking.
+- **RevenueCat plugin Capacitor sur Capacitor 8** : à vérifier la compat. Documentation officielle <https://www.revenuecat.com/docs/getting-started/installation/capacitor>. Si pas de version compatible Capacitor 8, on a un plan B (`cordova-plugin-purchase`).
+- **Apple peut re-rejeter** si le screenshot fourni dans App Review Information ne montre pas clairement l'écran IAP. Préparer un bon screenshot.
+- **Coexistence Stripe + IAP** : edge case si user paie 2x. Mitigation côté UX (check `isPremium` avant d'afficher l'écran IAP), mais pas 0% de risque.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10104;
+				CURRENT_PROJECT_VERSION = 10105;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10104;
+				CURRENT_PROJECT_VERSION = 10105;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/@capacitor/push-notifications"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
         .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
+        .package(name: "RevenuecatPurchasesCapacitor", path: "../../../node_modules/@revenuecat/purchases-capacitor"),
         .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
     ],
     targets: [
@@ -42,6 +43,7 @@ let package = Package(
                 .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
                 .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
+                .product(name: "RevenuecatPurchasesCapacitor", package: "RevenuecatPurchasesCapacitor"),
                 .product(name: "SentryCapacitor", package: "SentryCapacitor")
             ]
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
+        "@revenuecat/purchases-capacitor": "^13.1.5",
         "@sentry/capacitor": "^4.0.0",
         "@sentry/react": "10.43.0",
         "@supabase/supabase-js": "^2.97.0",
@@ -4585,6 +4586,24 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@revenuecat/purchases-capacitor": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-capacitor/-/purchases-capacitor-13.1.5.tgz",
+      "integrity": "sha512-klI2VL31woeY0spbZpOYh/b8L2Azv+pbP+ueU3E3NaG8D7Rv1hWM7X+t18rSynY6/L5U1XoA6El27i5UG6jrAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@revenuecat/purchases-typescript-internal-esm": "18.10.0"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@revenuecat/purchases-typescript-internal-esm": {
+      "version": "18.10.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal-esm/-/purchases-typescript-internal-esm-18.10.0.tgz",
+      "integrity": "sha512-vW9adMqUuudMKt7pYhbRrihcA/xbhooHW616n3weVGzJKfaXRUiSzTwmtISS8KyYBpzQsf2i2oGkk9swLI3Tpw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@capacitor/push-notifications": "^8.0.3",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
+    "@revenuecat/purchases-capacitor": "^13.1.5",
     "@sentry/capacitor": "^4.0.0",
     "@sentry/react": "10.43.0",
     "@supabase/supabase-js": "^2.97.0",

--- a/src/components/PremiumPromoPage.tsx
+++ b/src/components/PremiumPromoPage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../contexts/AuthContext.tsx';
 import { useDocumentHead } from '../hooks/useDocumentHead.ts';
 import { useSubscription } from '../hooks/useSubscription.ts';
 import { isNative } from '../lib/capacitor.ts';
-import { NativeUpgradeWall } from './auth/NativeUpgradeWall.tsx';
+import { NativePricingCards } from './auth/NativePricingCards.tsx';
 import { PricingCards } from './PricingCards.tsx';
 import { ScreenshotCarousel } from './ScreenshotCarousel.tsx';
 
@@ -19,13 +19,13 @@ export function PremiumPromoPage() {
     description: t('premium.page_description'),
   });
 
-  // Apple guideline 3.1.3(b): on native, swap the whole marketing page
+  // Apple guideline 3.1.1: on native, swap the whole marketing page
   // (which includes Tarifs anchor + PricingCards + Stripe CTA) for the
-  // multiplatform-service wall. Premium users keep their normal view —
+  // RevenueCat-backed paywall. Premium users keep their normal view —
   // the page still serves as a "thank you" + feature recap surface for
   // them.
   if (isNative() && !isPremium) {
-    return <NativeUpgradeWall />;
+    return <NativePricingCards />;
   }
 
   return (

--- a/src/components/PricingCards.tsx
+++ b/src/components/PricingCards.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../contexts/AuthContext.tsx';
 import { useSubscription } from '../hooks/useSubscription.ts';
 import { isNative } from '../lib/capacitor.ts';
 import { formatDate } from '../utils/date.ts';
-import { NativeUpgradeWall } from './auth/NativeUpgradeWall.tsx';
+import { NativePricingCards } from './auth/NativePricingCards.tsx';
 
 const PRICE_IDS = {
   monthly: import.meta.env.VITE_STRIPE_PRICE_MONTHLY as string | undefined,
@@ -64,12 +64,12 @@ export function PricingCards() {
     if (err) setError(err);
   };
 
-  // Apple guideline 3.1.3(b) — on the native iOS/Android shells we must
-  // not expose any pricing, plan selector, or in-app purchase CTA. Render
-  // the multiplatform-service wall instead. Premium users still see their
-  // status below, so this gate only applies to non-premium native users.
+  // Apple guideline 3.1.1 — native iOS/Android must offer purchases via
+  // StoreKit / Google Play Billing. We swap the Stripe-flavoured paywall
+  // for a RevenueCat-backed one. Premium users keep their existing status
+  // block below, so this gate only applies to non-premium native users.
   if (isNative() && !isPremium) {
-    return <NativeUpgradeWall />;
+    return <NativePricingCards />;
   }
 
   // Already premium — simplified view

--- a/src/components/auth/NativePricingCards.tsx
+++ b/src/components/auth/NativePricingCards.tsx
@@ -1,0 +1,225 @@
+import { Check, Crown, Sparkles } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePurchases } from '../../hooks/usePurchases.ts';
+import { useSubscription } from '../../hooks/useSubscription.ts';
+
+// Native iOS / Android paywall — replaces the web Stripe paywall in
+// PricingCards / PremiumPromoPage when running inside the Capacitor shell.
+//
+// Why a separate component: the web flow opens Stripe Checkout in a redirect.
+// The native flow opens StoreKit (iOS) or Google Play Billing (Android) via
+// RevenueCat's `purchasePackage()`. Different state machine, different errors,
+// different UI affordances ("Restaurer mes achats" only makes sense on
+// native). Trying to fork PricingCards on `isNative()` would have produced
+// a 600-line component impossible to test independently — this one is ~180.
+export function NativePricingCards() {
+  const { t } = useTranslation('marketing');
+  const { isPremium } = useSubscription();
+  const { packages, loading, error, purchase, restore } = usePurchases();
+  const [purchasing, setPurchasing] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  if (isPremium) {
+    return (
+      <div className="max-w-md mx-auto px-6 py-12">
+        <div className="rounded-2xl border-2 border-accent bg-surface-card p-6 flex flex-col items-center text-center gap-3">
+          <Crown className="w-10 h-10 text-accent" aria-hidden="true" />
+          <h3 className="font-display text-lg font-bold text-heading">
+            {t('pricing_cards.active_premium_title', { defaultValue: 'Tu es Premium' })}
+          </h3>
+          <p className="text-sm text-subtle">
+            {t('native_pricing.active_premium_body', {
+              defaultValue:
+                "Tout le contenu Premium est débloqué dans l'app. Gère ton abonnement depuis les Réglages de ton iPhone (Réglages > Apple ID > Abonnements).",
+            })}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12">
+        <p className="text-sm text-subtle">
+          {t('native_pricing.loading', { defaultValue: 'Chargement des abonnements…' })}
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12">
+        <div className="max-w-md w-full text-center space-y-3">
+          <p className="text-sm text-strong">{error}</p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="btn-secondary px-4 py-2 rounded-xl text-sm font-medium"
+          >
+            {t('native_pricing.retry', { defaultValue: 'Réessayer' })}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!packages || packages.length === 0) {
+    return (
+      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12 text-center">
+        <p className="text-sm text-subtle max-w-md">
+          {t('native_pricing.unavailable', {
+            defaultValue:
+              "Les abonnements ne sont pas disponibles pour l'instant. Réessaie dans quelques minutes ou contacte le support.",
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  // Sort: annual first (encourages the better-value option), then monthly.
+  const sorted = [...packages].sort((a, b) => {
+    const order = (id: string) => (id.includes('annual') || id.includes('yearly') ? 0 : id.includes('monthly') ? 1 : 2);
+    return order(a.identifier) - order(b.identifier);
+  });
+
+  const handlePurchase = async (pkgId: string) => {
+    const pkg = sorted.find((p) => p.identifier === pkgId);
+    if (!pkg) return;
+    setPurchasing(pkgId);
+    setFeedback(null);
+    const ok = await purchase(pkg);
+    setPurchasing(null);
+    if (ok) {
+      setFeedback(
+        t('native_pricing.purchase_success', {
+          defaultValue: 'Premium activé ! Toutes les fonctionnalités sont débloquées.',
+        }),
+      );
+    }
+  };
+
+  const handleRestore = async () => {
+    setRestoring(true);
+    setFeedback(null);
+    const ok = await restore();
+    setRestoring(false);
+    setFeedback(
+      ok
+        ? t('native_pricing.restore_success', {
+            defaultValue: 'Achat restauré. Premium réactivé.',
+          })
+        : t('native_pricing.restore_empty', {
+            defaultValue: 'Aucun achat à restaurer pour ce compte Apple/Google.',
+          }),
+    );
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
+      <header className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-brand/10">
+          <Sparkles className="w-7 h-7 text-brand" aria-hidden="true" />
+        </div>
+        <h1 className="font-display text-2xl font-bold text-heading">
+          {t('native_pricing.title', { defaultValue: 'Passe à Premium' })}
+        </h1>
+        <p className="text-sm text-subtle">
+          {t('native_pricing.subtitle', {
+            defaultValue: 'Programmes IA illimités, séances personnalisées, suivi nutrition complet.',
+          })}
+        </p>
+      </header>
+
+      <div className="space-y-3">
+        {sorted.map((pkg) => {
+          const isAnnual = pkg.identifier.includes('annual') || pkg.identifier.includes('yearly');
+          const isPurchasingThis = purchasing === pkg.identifier;
+          return (
+            <button
+              key={pkg.identifier}
+              type="button"
+              onClick={() => handlePurchase(pkg.identifier)}
+              disabled={purchasing !== null}
+              className={`w-full text-left rounded-2xl border-2 p-5 transition-colors disabled:opacity-60 ${
+                isAnnual
+                  ? 'border-brand bg-brand/5 hover:bg-brand/10'
+                  : 'border-card-border bg-surface-card hover:border-brand/30'
+              }`}
+            >
+              <div className="flex items-baseline justify-between gap-3 mb-1">
+                <h3 className="font-display font-bold text-heading">
+                  {isAnnual
+                    ? t('native_pricing.plan_yearly', { defaultValue: 'Premium Annuel' })
+                    : t('native_pricing.plan_monthly', { defaultValue: 'Premium Mensuel' })}
+                </h3>
+                <span className="text-xl font-black text-heading">{pkg.product.priceString}</span>
+              </div>
+              {isAnnual && (
+                <p className="text-xs text-brand font-semibold mb-2">
+                  {t('native_pricing.yearly_savings', { defaultValue: 'Économise ~17% vs mensuel' })}
+                </p>
+              )}
+              <ul className="space-y-1 text-xs text-subtle">
+                <li className="flex items-center gap-2">
+                  <Check className="w-3 h-3 text-brand shrink-0" aria-hidden="true" />
+                  {t('native_pricing.feature_ai', {
+                    defaultValue: 'Programmes & séances IA illimités',
+                  })}
+                </li>
+                <li className="flex items-center gap-2">
+                  <Check className="w-3 h-3 text-brand shrink-0" aria-hidden="true" />
+                  {t('native_pricing.feature_nutrition', {
+                    defaultValue: 'Suivi nutrition complet + analyse IA',
+                  })}
+                </li>
+                <li className="flex items-center gap-2">
+                  <Check className="w-3 h-3 text-brand shrink-0" aria-hidden="true" />
+                  {t('native_pricing.feature_no_ads', {
+                    defaultValue: 'Sans publicité, sans engagement',
+                  })}
+                </li>
+              </ul>
+              {isPurchasingThis && (
+                <p className="text-xs text-muted mt-3">
+                  {t('native_pricing.opening_store', { defaultValue: 'Ouverture de la boutique…' })}
+                </p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {feedback && (
+        <output
+          aria-live="polite"
+          className="block rounded-xl border border-brand/30 bg-brand/5 px-4 py-3 text-sm text-strong text-center"
+        >
+          {feedback}
+        </output>
+      )}
+
+      <div className="text-center space-y-3 pt-4 border-t border-divider">
+        <button
+          type="button"
+          onClick={handleRestore}
+          disabled={restoring}
+          className="text-sm text-link underline disabled:opacity-60"
+        >
+          {restoring
+            ? t('native_pricing.restoring', { defaultValue: 'Restauration en cours…' })
+            : t('native_pricing.restore_cta', { defaultValue: 'Restaurer mes achats' })}
+        </button>
+        <p className="text-xs text-faint leading-relaxed max-w-md mx-auto">
+          {t('native_pricing.legal_note', {
+            defaultValue:
+              'Abonnement renouvelé automatiquement. Tu peux annuler à tout moment depuis les Réglages de ton iPhone (Réglages > Apple ID > Abonnements) au moins 24h avant la fin de la période en cours.',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/RestorePurchasesButton.tsx
+++ b/src/components/auth/RestorePurchasesButton.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePurchases } from '../../hooks/usePurchases.ts';
+import { isNative } from '../../lib/capacitor.ts';
+
+// Restore Purchases button — required by Apple App Review (Guideline 3.1.1)
+// for any app that sells non-consumable IAPs or auto-renewable subscriptions.
+// Renders nothing on web (Stripe checkouts have no "restore" concept —
+// the user just signs in to recover their state).
+export function RestorePurchasesButton() {
+  const { t } = useTranslation('common');
+  const { restore } = usePurchases();
+  const [working, setWorking] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  if (!isNative()) return null;
+
+  const handleClick = async () => {
+    setWorking(true);
+    setFeedback(null);
+    const ok = await restore();
+    setWorking(false);
+    setFeedback(
+      ok
+        ? t('restore_purchases.success', {
+            defaultValue: 'Achat restauré. Premium réactivé.',
+          })
+        : t('restore_purchases.empty', {
+            defaultValue: 'Aucun achat à restaurer sur ce compte Apple/Google.',
+          }),
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={working}
+        className="w-full py-2.5 rounded-xl border border-divider text-sm font-medium text-strong hover:bg-divider transition-colors disabled:opacity-60"
+      >
+        {working
+          ? t('restore_purchases.working', { defaultValue: 'Restauration en cours…' })
+          : t('restore_purchases.cta', { defaultValue: 'Restaurer mes achats' })}
+      </button>
+      {feedback && (
+        <output aria-live="polite" className="block text-xs text-muted text-center">
+          {feedback}
+        </output>
+      )}
+    </div>
+  );
+}

--- a/src/components/auth/SettingsPage.tsx
+++ b/src/components/auth/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { formatDate } from '../../utils/date.ts';
 import { getInitials } from '../../utils/getInitials.ts';
 import { DeleteAccountDialog } from './DeleteAccountDialog.tsx';
 import { NotificationsSection } from './NotificationsSection.tsx';
+import { RestorePurchasesButton } from './RestorePurchasesButton.tsx';
 
 const MAX_AVATAR_SIZE = 2 * 1024 * 1024; // 2 Mo
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -256,6 +257,9 @@ export function SettingsPage() {
                 <Sparkles className="w-4 h-4" aria-hidden="true" />
                 {t('subscription.go_premium')}
               </Link>
+              {/* Restore button — required by Apple App Review for any app
+                  that sells IAPs. Renders nothing on web. */}
+              <RestorePurchasesButton />
             </div>
           )}
         </section>

--- a/src/hooks/usePurchases.ts
+++ b/src/hooks/usePurchases.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { isNative } from '../lib/capacitor.ts';
+
+// We dynamically import the RevenueCat SDK so the web bundle stays lean.
+// Loading the plugin on web would no-op (it ships native bridges only) but
+// even the JS wrapper adds ~30KB gzipped to the initial chunk. The native
+// shell pays the cost once at first use of the paywall.
+type PurchasesPackage = {
+  identifier: string; // $rc_monthly | $rc_annual | custom
+  packageType?: string;
+  product: {
+    identifier: string; // wan2fit.premium.monthly | wan2fit.premium.yearly
+    title: string;
+    description: string;
+    priceString: string; // localized "9,99 €" / "$9.99"
+    price: number;
+    currencyCode: string;
+  };
+  offeringIdentifier?: string;
+};
+
+type CustomerInfo = {
+  entitlements: {
+    active: Record<string, { identifier: string; isActive: boolean }>;
+  };
+};
+
+type PurchasesSdk = {
+  configure: (opts: { apiKey: string; appUserID: string | null }) => Promise<void>;
+  getOfferings: () => Promise<{ current: { availablePackages: PurchasesPackage[] } | null }>;
+  purchasePackage: (opts: { aPackage: PurchasesPackage }) => Promise<{ customerInfo: CustomerInfo }>;
+  restorePurchases: () => Promise<{ customerInfo: CustomerInfo }>;
+  logIn: (appUserID: string) => Promise<{ customerInfo: CustomerInfo }>;
+  logOut: () => Promise<{ customerInfo: CustomerInfo }>;
+  getCustomerInfo: () => Promise<{ customerInfo: CustomerInfo }>;
+};
+
+// Cached module — survive Vite HMR by hanging onto window. Initialising
+// twice in the same JS context throws inside the native SDK.
+let sdkPromise: Promise<PurchasesSdk> | null = null;
+let configured = false;
+
+async function loadSdk(): Promise<PurchasesSdk> {
+  if (!sdkPromise) {
+    sdkPromise = import('@revenuecat/purchases-capacitor').then((m) => m.Purchases as unknown as PurchasesSdk);
+  }
+  return sdkPromise;
+}
+
+async function ensureConfigured(userId: string | null): Promise<PurchasesSdk> {
+  const sdk = await loadSdk();
+  const apiKey = import.meta.env.VITE_REVENUECAT_PUBLIC_API_KEY_IOS as string | undefined;
+  if (!apiKey) {
+    throw new Error('VITE_REVENUECAT_PUBLIC_API_KEY_IOS missing — IAP cannot init');
+  }
+  if (!configured) {
+    await sdk.configure({ apiKey, appUserID: userId });
+    configured = true;
+  } else if (userId) {
+    // Already configured — bind/rebind the user. logIn is idempotent and
+    // reuses the same customer if appUserID matches.
+    await sdk.logIn(userId);
+  }
+  return sdk;
+}
+
+interface UsePurchasesResult {
+  // Loaded packages from the "default" RevenueCat offering. `null` while
+  // loading or when called from a non-native context.
+  packages: PurchasesPackage[] | null;
+  loading: boolean;
+  error: string | null;
+  // Purchase a specific package. Resolves with `true` if the user is now
+  // entitled to 'premium' (success path), `false` if they cancelled or the
+  // purchase did not grant the entitlement.
+  purchase: (pkg: PurchasesPackage) => Promise<boolean>;
+  // Trigger Apple/Google restore. Returns true if a premium entitlement was
+  // restored, false otherwise.
+  restore: () => Promise<boolean>;
+}
+
+const PREMIUM_ENTITLEMENT_ID = 'premium';
+
+// Hook to drive the native IAP paywall. On web returns no packages and
+// no-op functions — callers should still gate on `isNative()` before
+// rendering paywall UI, but this hook is safe to mount unconditionally.
+export function usePurchases(): UsePurchasesResult {
+  const { user } = useAuth();
+  const { t } = useTranslation('common');
+  const [packages, setPackages] = useState<PurchasesPackage[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Avoid re-fetching offerings every time the component re-mounts in the
+  // same session — RevenueCat caches them server-side anyway.
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isNative()) return;
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    ensureConfigured(user?.id ?? null)
+      .then((sdk) => sdk.getOfferings())
+      .then((offerings) => {
+        if (cancelled) return;
+        const list = offerings.current?.availablePackages ?? [];
+        setPackages(list);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id]);
+
+  const purchase = useCallback(
+    async (pkg: PurchasesPackage): Promise<boolean> => {
+      if (!isNative()) return false;
+      setError(null);
+      try {
+        const sdk = await ensureConfigured(user?.id ?? null);
+        const result = await sdk.purchasePackage({ aPackage: pkg });
+        const active = result.customerInfo.entitlements.active;
+        return PREMIUM_ENTITLEMENT_ID in active;
+      } catch (err: unknown) {
+        // Apple/Google return distinct error codes for user-cancel vs real
+        // failure. The SDK surfaces this as an Error with a code property —
+        // we treat anything that isn't a hard failure as a silent dismiss.
+        const errObj = err as { code?: string; userCancelled?: boolean; message?: string };
+        if (errObj?.userCancelled || errObj?.code === 'PURCHASE_CANCELLED') {
+          return false;
+        }
+        setError(
+          errObj?.message ?? t('hook_errors.generic_retry', { defaultValue: 'Une erreur est survenue. Réessayez.' }),
+        );
+        return false;
+      }
+    },
+    [user?.id, t],
+  );
+
+  const restore = useCallback(async (): Promise<boolean> => {
+    if (!isNative()) return false;
+    setError(null);
+    try {
+      const sdk = await ensureConfigured(user?.id ?? null);
+      const result = await sdk.restorePurchases();
+      const active = result.customerInfo.entitlements.active;
+      return PREMIUM_ENTITLEMENT_ID in active;
+    } catch (err: unknown) {
+      const errObj = err as { message?: string };
+      setError(
+        errObj?.message ?? t('hook_errors.generic_retry', { defaultValue: 'Une erreur est survenue. Réessayez.' }),
+      );
+      return false;
+    }
+  }, [user?.id, t]);
+
+  return { packages, loading, error, purchase, restore };
+}

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -1,0 +1,215 @@
+// RevenueCat webhook — receives native IAP events (iOS StoreKit, Android Play
+// Billing) from RevenueCat and syncs `profiles.subscription_tier` +
+// `subscription_provider` in Supabase. Companion to `stripe-webhook` which
+// handles web Stripe checkout events. Both webhooks converge on the same
+// source of truth: `profiles.subscription_tier`.
+//
+// Authentication: RevenueCat is configured to send an Authorization header
+// "Bearer <REVENUECAT_WEBHOOK_SECRET>". We compare with a timing-safe check.
+// The secret lives in Supabase Edge Functions Secrets (set via
+// `supabase secrets set REVENUECAT_WEBHOOK_SECRET=… --project-ref …`).
+//
+// Event reference: https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields
+//
+// Why a separate edge function (not one big webhook): Stripe and RevenueCat
+// have completely different payload shapes, different signature schemes, and
+// independent rotation cadences. Keeping them separate isolates blast radius
+// — a bad RevenueCat payload can never break Stripe processing and vice
+// versa.
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+
+// Subset of the RevenueCat event payload we care about. The full schema is
+// large; we type only what we read so a schema addition upstream never
+// breaks our handler.
+interface RevenueCatEvent {
+  type: string;
+  app_user_id?: string;
+  original_app_user_id?: string;
+  product_id?: string;
+  environment?: "PRODUCTION" | "SANDBOX";
+  expiration_at_ms?: number;
+  store?: string;
+}
+
+interface RevenueCatPayload {
+  event: RevenueCatEvent;
+  api_version: string;
+}
+
+// Events that grant or maintain a premium entitlement. Anything not in this
+// set transitions the user to free (cancellation, expiration, billing
+// failure, refund).
+//
+// Note on PRODUCT_CHANGE: handled as "premium" — it covers monthly→yearly
+// upgrades. The user stays premium throughout, only the product they pay
+// for changes.
+const PREMIUM_GRANTING_EVENTS = new Set([
+  "INITIAL_PURCHASE",
+  "RENEWAL",
+  "UNCANCELLATION", // user reactivated after a previous cancellation
+  "PRODUCT_CHANGE", // tier swap, e.g. monthly → yearly
+  "TEMPORARY_ENTITLEMENT_GRANT", // RevenueCat customer support granted a grace
+]);
+
+const PREMIUM_REVOKING_EVENTS = new Set([
+  "CANCELLATION", // user opted out — but stays premium until expiration_at_ms
+  "EXPIRATION", // grace period over, access actually revoked
+  "BILLING_ISSUE", // payment failed and grace exhausted
+  "SUBSCRIPTION_PAUSED",
+  "EXPIRED_FROM_BILLING_ISSUE",
+]);
+
+function jsonResponse(data: unknown, status = 200) {
+  // Webhooks aren't browser-originated so CORS would normally be moot, but we
+  // emit it anyway to stay consistent with the rest of the edge functions
+  // (and to make local testing via curl from the dev server painless).
+  const req = new Request("https://edge.example/");
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      ...getCorsHeaders(req),
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+// Timing-safe string comparison to defeat naive timing-attack probes on the
+// secret. Same primitive used in `send-push` (`timingSafeEqualString`).
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function classifyEvent(eventType: string): "premium" | "free" | "ignore" {
+  if (PREMIUM_GRANTING_EVENTS.has(eventType)) return "premium";
+  if (PREMIUM_REVOKING_EVENTS.has(eventType)) return "free";
+  // Events we explicitly don't act on: TEST (RevenueCat dashboard test),
+  // SUBSCRIBER_ALIAS (account linking, no tier change), NON_RENEWING_PURCHASE
+  // (we don't sell those), TRANSFER (purchase moved between users — handled
+  // by INITIAL_PURCHASE/EXPIRATION on the two affected users), etc.
+  return "ignore";
+}
+
+Deno.serve(async (req) => {
+  // Preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: getCorsHeaders(req) });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  // Authenticate via Bearer secret. Required header format:
+  //   Authorization: Bearer <REVENUECAT_WEBHOOK_SECRET>
+  const authHeader = req.headers.get("authorization") ?? "";
+  const expectedSecret = Deno.env.get("REVENUECAT_WEBHOOK_SECRET");
+  if (!expectedSecret) {
+    console.error("REVENUECAT_WEBHOOK_SECRET not set in edge function secrets");
+    return jsonResponse({ error: "Server misconfigured" }, 500);
+  }
+
+  const expectedAuth = `Bearer ${expectedSecret}`;
+  if (!timingSafeEqual(authHeader, expectedAuth)) {
+    // Don't leak which part failed (header missing vs wrong value).
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  // Parse payload
+  let payload: RevenueCatPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const event = payload?.event;
+  if (!event || typeof event.type !== "string") {
+    return jsonResponse({ error: "Missing event.type" }, 400);
+  }
+
+  // RevenueCat sends app_user_id = whatever the client passed via
+  // Purchases.configure({appUserID}). We bind it to our Supabase user.id.
+  // original_app_user_id is the alias chain root (only differs after
+  // SUBSCRIBER_ALIAS events, which we ignore anyway).
+  const userId = event.app_user_id ?? event.original_app_user_id;
+  if (!userId) {
+    return jsonResponse({ error: "Missing app_user_id" }, 400);
+  }
+
+  const action = classifyEvent(event.type);
+  if (action === "ignore") {
+    // 200 OK so RevenueCat doesn't retry. Log so we can spot unhandled
+    // event types in production logs.
+    console.log(`[revenuecat-webhook] ignored event=${event.type} user=${userId}`);
+    return jsonResponse({ ok: true, ignored: event.type });
+  }
+
+  // Service role client — needed because RLS on profiles forbids users from
+  // editing their own subscription_tier (migration 011). Only this webhook
+  // (and stripe-webhook) can mutate it.
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+    return jsonResponse({ error: "Server misconfigured" }, 500);
+  }
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Idempotency: if the user is already in the target state, do nothing.
+  // RevenueCat retries failed deliveries; without this short-circuit each
+  // retry would trigger an unnecessary UPDATE (no harm but noisy in audit).
+  const { data: current, error: readError } = await supabase
+    .from("profiles")
+    .select("subscription_tier, subscription_provider")
+    .eq("id", userId)
+    .single();
+
+  if (readError) {
+    // Most likely: user does not exist (e.g. someone with an Apple-ID-only
+    // account trying to subscribe before completing Wan2Fit signup, or a
+    // sandbox tester whose Supabase user was deleted). Log + 200 OK so
+    // RevenueCat stops retrying — we can investigate in logs.
+    console.warn(`[revenuecat-webhook] user not found id=${userId} event=${event.type}`);
+    return jsonResponse({ ok: true, skipped: "user_not_found" });
+  }
+
+  if (current.subscription_tier === action && current.subscription_provider === "revenuecat") {
+    console.log(`[revenuecat-webhook] idempotent event=${event.type} user=${userId} tier=${action}`);
+    return jsonResponse({ ok: true, idempotent: true });
+  }
+
+  // Apply the change. We always set provider='revenuecat' on the UPDATE, even
+  // when going to 'free' — that way we keep the historical attribution
+  // (this user's last paid run was native, not web). When/if they re-subscribe
+  // via Stripe later, stripe-webhook will overwrite the provider.
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({
+      subscription_tier: action,
+      subscription_provider: "revenuecat",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", userId);
+
+  if (updateError) {
+    console.error(`[revenuecat-webhook] UPDATE failed user=${userId}:`, updateError);
+    // 500 so RevenueCat retries — transient DB issues do exist.
+    return jsonResponse({ error: "DB update failed" }, 500);
+  }
+
+  console.log(
+    `[revenuecat-webhook] applied event=${event.type} user=${userId} → ${action} (env=${event.environment ?? "unknown"})`,
+  );
+
+  return jsonResponse({ ok: true, applied: action });
+});

--- a/supabase/migrations/026_subscription_provider.sql
+++ b/supabase/migrations/026_subscription_provider.sql
@@ -1,0 +1,24 @@
+-- Migration 026 — subscription_provider column on profiles
+--
+-- Context: with IAP iOS (RevenueCat) coexisting with Stripe web checkout,
+-- the same user could in principle become premium via either path. We need
+-- to know which channel granted the entitlement so we can:
+--   - Route "Manage subscription" actions to the right place (Stripe Customer
+--     Portal vs iOS Settings > Subscriptions vs Google Play > Subscriptions)
+--   - Resolve duplicate-subscription edge cases in support
+--   - Slice MRR analytics by acquisition channel
+--
+-- The webhook that grants premium is the source of truth: when stripe-webhook
+-- fires, it sets provider='stripe'; when revenuecat-webhook fires, it sets
+-- provider='revenuecat'. The RLS migration 011 already locks subscription_tier
+-- to service_role only, so the same lock applies de facto to this new column
+-- when we add the matching column to its USING / WITH CHECK clauses (which
+-- we don't need to do — the policy already covers ALL columns by being a
+-- generic UPDATE policy with subscription_tier-only WITH CHECK).
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS subscription_provider TEXT
+  CHECK (subscription_provider IS NULL OR subscription_provider IN ('stripe', 'revenuecat'));
+
+COMMENT ON COLUMN profiles.subscription_provider IS
+  'Channel that granted the current premium subscription. NULL for free users. Set by the webhook handler (stripe-webhook or revenuecat-webhook). Used to route "manage subscription" actions back to the right billing surface.';


### PR DESCRIPTION
## Context

Apple App Review verdict on 2026-06-07 (Submission `73dc985c-d2ef-43ce-aa00-163187001cc5`, version reviewed 1.0 / 10104):

> Guideline 3.1.1 — The app accesses digital content purchased outside the app, such as Premium subscription, but that content isn't available to purchase using In-App Purchase.

The PR #227 strategy (hide pricing on native + redirect to web in Safari) is not sufficient: Apple flags the very fact that the iOS app *grants access* to premium content acquired elsewhere. The only compliant path is to implement Apple In-App Purchase via StoreKit alongside the existing Stripe web checkout.

## What this PR ships today

**Planning + runbook artifacts only**. No code yet. Six documents:

- `claudedocs/MOBILE_RELEASE_RUNBOOK.md` — Central index for all mobile processes (Apple/Google/Firebase/Supabase/Vercel identifiers, build & signing, store submissions). Replaces the scattered conversation-only knowledge we had.
- `claudedocs/iap-implementation/README.md` — Reading order + status
- `claudedocs/iap-implementation/00-decision-log.md` — Why RevenueCat (vs alternatives), why Small Business Program, why answer Apple now, how Stripe and IAP coexist, where the paywall lives
- `claudedocs/iap-implementation/01-architecture.md` — Data flow + components changed/added
- `claudedocs/iap-implementation/02-app-store-connect-setup.md` — App Store Connect step-by-step (Paid Apps agreement, Small Business, Subscription Group, 2 products, API Key, Shared Secret, Sandbox)
- `claudedocs/iap-implementation/03-revenuecat-setup.md` — RevenueCat dashboard step-by-step
- `claudedocs/iap-implementation/08-apple-resolution-center-response.md` — Exact text to send Apple now

## What comes next on this branch

- `04-app-integration.md` + code: `usePurchases` hook, `<NativePricingCards />`, `<RestorePurchasesButton />`
- `05-supabase-webhook.md` + code: `revenuecat-webhook` edge function, migration 012 adding `subscription_provider`
- `06-testing-sandbox.md` + sandbox playbook
- `07-launch-checklist.md`

## Verification done before deciding RevenueCat

```
$ npm view @revenuecat/purchases-capacitor@latest peerDependencies
{ '@capacitor/core': '>=8.0.0' }
$ npm view @revenuecat/purchases-capacitor@latest version
13.1.5
```

We are on Capacitor 8.3.1. Compatible.

## Human-side actions required (blocks code shipping)

- [ ] Enroll Small Business Program in App Store Connect (5 min, 15% commission from day 1)
- [ ] Create 2 Subscriptions in App Store Connect (~15 min, see `02-app-store-connect-setup.md`)
- [ ] Generate App Store Connect API Key + Shared Secret
- [ ] Create RevenueCat account + project + connect to ASC (~10 min, see `03-revenuecat-setup.md`)
- [ ] Send Apple Resolution Center response now (see `08-apple-resolution-center-response.md`)

## Marked as Draft

This PR will be expanded with code in subsequent commits. Marked draft so it doesn't get merged before the implementation is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)