### PR TITLE
fix: AI generation (502), signup error, iOS input zoom + mid-session screen sleep

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import i18n from '../i18n';
 import { captureEvent, identifyUser, resetAnalytics } from '../lib/analytics.ts';
 import { getAuthRedirectUrl } from '../lib/auth-redirects.ts';
+import { captureException } from '../lib/sentryReport.ts';
 import { supabase } from '../lib/supabase.ts';
 import { sessionEvents } from '../lib/supabaseQuery.ts';
 import type { Profile } from '../types/auth.ts';
@@ -28,10 +29,34 @@ const AuthContext = createContext<AuthContextValue | null>(null);
  * Resolved with the current locale via the `i18n` instance — this runs outside
  * React (signIn/signUp callbacks), hence the direct module import instead of `useTranslation`.
  */
+// Primary match: GoTrue's stable `error.code` (supabase-js v2 surfaces it on
+// AuthApiError). Codes don't drift across GoTrue releases the way the
+// human-readable `message` does — matching the code first is what makes
+// "email déjà utilisé" reliably reach the user instead of the generic
+// fallback. See https://supabase.com/docs/reference/javascript/auth-error-codes
+const SUPABASE_CODE_KEYS: Record<string, string> = {
+  user_already_exists: 'user_already_registered',
+  email_exists: 'user_already_registered',
+  invalid_credentials: 'invalid_credentials',
+  email_not_confirmed: 'email_not_confirmed',
+  weak_password: 'password_too_short',
+  email_address_invalid: 'invalid_email_format',
+  validation_failed: 'invalid_email_format',
+  over_email_send_rate_limit: 'email_rate_limited',
+  over_request_rate_limit: 'rate_limited_short',
+  same_password: 'new_password_same',
+  session_not_found: 'session_missing',
+};
+
+// Fallback match: substring on the human-readable message, for GoTrue
+// responses that don't carry a code (older deployments, edge cases).
 const SUPABASE_ERROR_KEYS: Record<string, string> = {
   'Invalid login credentials': 'invalid_credentials',
   'Email not confirmed': 'email_not_confirmed',
   'User already registered': 'user_already_registered',
+  'already been registered': 'user_already_registered',
+  'already registered': 'user_already_registered',
+  'already in use': 'user_already_registered',
   // Generic prefix that matches GoTrue's "Password should be at least N
   // characters" regardless of N. The client-side isPasswordStrong() catches
   // weak passwords first; this needle only fires if Supabase Cloud config
@@ -44,11 +69,32 @@ const SUPABASE_ERROR_KEYS: Record<string, string> = {
   'Email rate limit exceeded': 'email_rate_limited',
 };
 
-function translateError(message: string | undefined): string | null {
-  if (!message) return null;
-  for (const [needle, key] of Object.entries(SUPABASE_ERROR_KEYS)) {
-    if (message.includes(needle)) return i18n.t(`supabase_errors.${key}`, { ns: 'auth' });
+type SupabaseAuthError = { message?: string; code?: string } | null | undefined;
+
+// Map a Supabase auth error to a localized, user-facing message. Returns null
+// when there is no error. Resolution order: stable `error.code` first, then a
+// substring match on the message, then a generic fallback. When we fall
+// through to generic, the raw error is reported to Sentry (PROD only) so we
+// learn about new GoTrue codes/messages instead of silently swallowing them —
+// the exact failure mode that hid "email déjà utilisé" behind a generic toast.
+function translateError(error: SupabaseAuthError): string | null {
+  if (!error) return null;
+  const { message, code } = error;
+
+  if (code) {
+    const key = SUPABASE_CODE_KEYS[code];
+    if (key) return i18n.t(`supabase_errors.${key}`, { ns: 'auth' });
   }
+
+  if (message) {
+    for (const [needle, key] of Object.entries(SUPABASE_ERROR_KEYS)) {
+      if (message.includes(needle)) return i18n.t(`supabase_errors.${key}`, { ns: 'auth' });
+    }
+  }
+
+  captureException(new Error('Unmapped Supabase auth error'), {
+    contexts: { supabaseAuth: { code: code ?? null, message: message ?? null } },
+  });
   return i18n.t('supabase_errors.generic', { ns: 'auth' });
 }
 
@@ -164,7 +210,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signIn = useCallback(async (email: string, password: string): Promise<{ error: string | null }> => {
     if (!supabase) return { error: i18n.t('errors.auth_unavailable', { ns: 'auth' }) };
     const { error } = await supabase.auth.signInWithPassword({ email, password });
-    return { error: translateError(error?.message) };
+    return { error: translateError(error) };
   }, []);
 
   const signUp = useCallback(
@@ -179,7 +225,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         },
       });
       if (!error) captureEvent('signup_completed');
-      return { error: translateError(error?.message) };
+      return { error: translateError(error) };
     },
     [],
   );
@@ -189,13 +235,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: getAuthRedirectUrl('/reset-password'),
     });
-    return { error: translateError(error?.message) };
+    return { error: translateError(error) };
   }, []);
 
   const updatePassword = useCallback(async (password: string): Promise<{ error: string | null }> => {
     if (!supabase) return { error: i18n.t('errors.auth_unavailable', { ns: 'auth' }) };
     const { error } = await supabase.auth.updateUser({ password });
-    return { error: translateError(error?.message) };
+    return { error: translateError(error) };
   }, []);
 
   // Identify the user in PostHog on every transition to authenticated.

--- a/src/hooks/useWakeLock.test.ts
+++ b/src/hooks/useWakeLock.test.ts
@@ -17,13 +17,29 @@ vi.mock('../lib/capacitor.ts', () => ({
   isNative: () => mockIsNative(),
 }));
 
+// Controllable appStateChange listener so the resume re-assertion path is
+// deterministic in jsdom (the real plugin would bind to visibilitychange).
+type AppStateListener = (state: { isActive: boolean }) => void;
+let appStateListener: AppStateListener | null = null;
+const mockRemoveListener = vi.fn().mockResolvedValue(undefined);
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: (_event: string, cb: AppStateListener) => {
+      appStateListener = cb;
+      return Promise.resolve({ remove: mockRemoveListener });
+    },
+  },
+}));
+
 import { useWakeLock } from './useWakeLock.ts';
 
 describe('useWakeLock', () => {
   beforeEach(() => {
     mockKeepAwake.mockReset().mockResolvedValue(undefined);
     mockAllowSleep.mockReset().mockResolvedValue(undefined);
+    mockRemoveListener.mockClear();
     mockIsNative.mockReset();
+    appStateListener = null;
   });
 
   afterEach(() => {
@@ -59,6 +75,28 @@ describe('useWakeLock', () => {
       await waitFor(() => expect(mockKeepAwake).toHaveBeenCalled());
       // No throw at unmount either.
       expect(() => unmount()).not.toThrow();
+    });
+
+    it('re-asserts keepAwake when the app returns to the foreground mid-session', async () => {
+      renderHook(() => useWakeLock(true));
+      await waitFor(() => expect(mockKeepAwake).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(appStateListener).not.toBeNull());
+
+      // iOS may have re-enabled the idle timer during the interruption —
+      // returning to the foreground must re-apply the lock.
+      appStateListener?.({ isActive: true });
+      await waitFor(() => expect(mockKeepAwake).toHaveBeenCalledTimes(2));
+
+      // Going TO the background must not re-assert.
+      appStateListener?.({ isActive: false });
+      expect(mockKeepAwake).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes the resume listener on unmount', async () => {
+      const { unmount } = renderHook(() => useWakeLock(true));
+      await waitFor(() => expect(appStateListener).not.toBeNull());
+      unmount();
+      await waitFor(() => expect(mockRemoveListener).toHaveBeenCalled());
     });
   });
 

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -26,8 +26,35 @@ export function useWakeLock(active: boolean) {
           // Plugin missing or platform refused — degrade silently.
         });
 
+      // iOS can re-enable the idle timer behind our back when the app is
+      // interrupted mid-session (incoming call, control centre, a trip to
+      // the background and back). keepAwake() above only runs once on
+      // mount, so without this listener the screen could start sleeping
+      // again after such an interruption even though the workout is still
+      // running. Re-assert whenever the app returns to the foreground.
+      let removeResumeListener: (() => void) | null = null;
+      void import('@capacitor/app')
+        .then(({ App }) =>
+          App.addListener('appStateChange', ({ isActive }) => {
+            if (cancelled || !isActive) return;
+            void import('@capacitor-community/keep-awake')
+              .then(({ KeepAwake }) => KeepAwake.keepAwake())
+              .catch(() => {});
+          }),
+        )
+        .then((handle) => {
+          if (!handle) return;
+          if (cancelled) {
+            void handle.remove();
+            return;
+          }
+          removeResumeListener = () => void handle.remove();
+        })
+        .catch(() => {});
+
       return () => {
         cancelled = true;
+        removeResumeListener?.();
         void import('@capacitor-community/keep-awake').then(({ KeepAwake }) => KeepAwake.allowSleep()).catch(() => {});
       };
     }

--- a/src/lib/capacitor.ts
+++ b/src/lib/capacitor.ts
@@ -27,6 +27,23 @@ export async function hideNativeSplash(): Promise<void> {
   }
 }
 
+// iOS WKWebView auto-zooms when an input with font-size < 16px receives
+// focus, and the page can stay stuck above 100% afterwards. Locking the
+// viewport scale suppresses that behaviour. We do this at runtime for the
+// NATIVE shell only: baking `user-scalable=no` into index.html would also
+// disable pinch-zoom for web visitors (an accessibility regression that
+// Android Chrome enforces), whereas inside the app shell a fixed scale is
+// the expected native behaviour.
+export function lockNativeViewportZoom(): void {
+  if (!isNative()) return;
+
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+  if (!meta) return;
+
+  const base = 'width=device-width, initial-scale=1.0, viewport-fit=cover';
+  meta.setAttribute('content', `${base}, maximum-scale=1.0, user-scalable=no`);
+}
+
 export async function syncStatusBarTheme(theme: 'light' | 'dark'): Promise<void> {
   if (!isNative()) return;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,12 @@ import './index.css';
 import './i18n';
 import App from './App.tsx';
 import { initAnalyticsAsync } from './lib/analytics.ts';
-import { isNative } from './lib/capacitor.ts';
+import { isNative, lockNativeViewportZoom } from './lib/capacitor.ts';
 import { initSentryAsync } from './lib/sentryReport.ts';
+
+// Must run before first paint so the WKWebView never gets a chance to
+// apply an input-focus zoom on the unlocked viewport (no-op on web).
+lockNativeViewportZoom();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/supabase/functions/_shared/anthropic.ts
+++ b/supabase/functions/_shared/anthropic.ts
@@ -1,0 +1,150 @@
+// Shared Anthropic call-failure taxonomy for the AI edge functions
+// (generate-session, generate-program).
+//
+// Before this module, every distinct failure of a single Anthropic call —
+// the model breaking out of the forced-JSON format, a 429 rate limit, a 401
+// bad key, an exhausted credit balance, a request timeout — was collapsed
+// into one opaque `502 "Erreur de communication avec l'IA"`. That made
+// production incidents impossible to triage from the client and gave the user
+// no actionable signal. We carry the kind + upstream HTTP status so callers
+// can (a) surface an honest message and (b) decide whether a retry can help.
+
+export type AnthropicErrorKind = "api" | "parse" | "timeout" | "network";
+
+export class AnthropicCallError extends Error {
+  kind: AnthropicErrorKind;
+  /** Upstream HTTP status, only set when kind === "api". */
+  status?: number;
+  /** Truncated upstream detail for server logs (never shown to the user). */
+  detail?: string;
+  constructor(kind: AnthropicErrorKind, message: string, status?: number, detail?: string) {
+    super(message);
+    this.name = "AnthropicCallError";
+    this.kind = kind;
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Perform one Anthropic Messages API call and return the parsed JSON payload.
+ * Throws a typed {@link AnthropicCallError} for every failure mode so the
+ * caller can map it precisely. The assistant prefill is prepended back before
+ * parsing (Anthropic returns only the continuation when the assistant turn is
+ * prefilled).
+ */
+export async function callAnthropicJson(opts: {
+  apiKey: string;
+  model: string;
+  maxTokens: number;
+  systemPrompt: string;
+  messages: { role: string; content: string }[];
+  prefill: string;
+  timeoutMs: number;
+}): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
+  let res: Response;
+  try {
+    res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": opts.apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        max_tokens: opts.maxTokens,
+        system: [
+          { type: "text", text: opts.systemPrompt, cache_control: { type: "ephemeral" } },
+        ],
+        messages: opts.messages,
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs),
+    });
+  } catch (fetchErr) {
+    const isTimeout = fetchErr instanceof DOMException && fetchErr.name === "TimeoutError";
+    console.error("Anthropic fetch failed:", isTimeout ? "timeout" : String(fetchErr));
+    throw new AnthropicCallError(
+      isTimeout ? "timeout" : "network",
+      isTimeout ? "Anthropic request timed out" : "Anthropic fetch failed",
+    );
+  }
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "Unknown error");
+    console.error("Anthropic API error:", res.status, errText);
+    throw new AnthropicCallError("api", "Anthropic API error", res.status, errText.slice(0, 500));
+  }
+
+  const aiData = await res.json();
+  const rawContent = aiData.content?.[0]?.text ?? "";
+  const combined = `${opts.prefill}${rawContent}`;
+  const cleaned = combined
+    .replace(/^```json\s*/i, "")
+    .replace(/```\s*$/, "")
+    .trim();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    // The model occasionally breaks out of the prefill and emits prose or a
+    // refusal wrapper instead of clean JSON. Transient — callers retry once.
+    console.error("Failed to parse AI response:", combined.slice(0, 500));
+    throw new AnthropicCallError("parse", "Failed to parse AI response", undefined, combined.slice(0, 200));
+  }
+
+  return {
+    data: parsed,
+    inputTokens: aiData.usage?.input_tokens ?? 0,
+    outputTokens: aiData.usage?.output_tokens ?? 0,
+  };
+}
+
+/**
+ * Translate an Anthropic call failure into an honest user-facing message and
+ * an HTTP status the client can act on. Pure (no Response building) so each
+ * function can wrap it with its own CORS-aware errorResponse helper.
+ *
+ * `noun` lets the message name what failed ("séance" / "programme").
+ */
+export function describeAnthropicError(err: unknown, noun = "contenu"): { message: string; status: number } {
+  if (err instanceof AnthropicCallError) {
+    if (err.kind === "timeout") {
+      return { message: "La génération a pris trop de temps. Réessaie dans un instant.", status: 504 };
+    }
+    if (err.kind === "parse") {
+      return { message: `L'IA n'a pas réussi à produire un ${noun} exploitable. Réessaie.`, status: 422 };
+    }
+    if (err.kind === "network") {
+      return { message: "Impossible de joindre le service IA. Vérifie ta connexion et réessaie.", status: 502 };
+    }
+    // kind === "api"
+    const s = err.status ?? 0;
+    if (s === 429) {
+      return { message: "Le service IA est momentanément surchargé. Réessaie dans quelques instants.", status: 429 };
+    }
+    if (s === 529 || s === 503) {
+      return { message: "Le service IA est temporairement indisponible. Réessaie dans un instant.", status: 503 };
+    }
+    if (s === 401 || s === 403) {
+      return {
+        message:
+          "Le service IA a refusé l'authentification. C'est un problème de configuration côté serveur — contacte le support.",
+        status: 502,
+      };
+    }
+    if (s === 400) {
+      return {
+        message:
+          "Le service IA a rejeté la requête (quota épuisé ou configuration). Si cela persiste, contacte le support.",
+        status: 502,
+      };
+    }
+    return {
+      message: `Le service IA a renvoyé une erreur (${s}). Réessaie ou contacte le support si cela persiste.`,
+      status: 502,
+    };
+  }
+  return { message: "Erreur inattendue lors de la communication avec l'IA. Réessaie.", status: 502 };
+}

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -10,10 +10,10 @@ const MAX_ACTIVE_PROGRAMS = 3;
 const MAX_DAILY_GENERATIONS = 3;
 const MODEL = "claude-sonnet-4-6";
 const MAX_TOKENS = 12288;
-// Defence-in-depth against prompt injection: prefilling the assistant turn
-// with `{"` forces the model to immediately start a JSON object and pre-empts
-// any "ignore previous instructions" jailbreak embedded in user freetext.
-const ASSISTANT_PREFILL = '{"';
+// NB: no assistant-message prefill here — claude-sonnet-4-6 rejects it with a
+// 400 ("This model does not support assistant message prefill"). Prompt-
+// injection defence + JSON-only output are enforced by the system prompt
+// instead (see prompt.ts and the callAnthropic comment below).
 // Sentinel raised by the enforce_user_active_programs_cap trigger
 // (migration 022). Kept as a constant so a future trigger message rename
 // surfaces as a TypeScript build break rather than a silent 500.
@@ -287,21 +287,28 @@ Deno.serve(async (req: Request) => {
 
   // Call Anthropic API. Sonnet with 12K tokens needs a more generous timeout
   // than the Haiku session generation. The fetch/parse/error-taxonomy lives in
-  // _shared/anthropic.ts; here we only assemble the prompt turns. The last
-  // message must be the assistant prefill so the model continues from the
-  // JSON-start token instead of free-form prose.
+  // _shared/anthropic.ts; here we only assemble the prompt turns.
+  //
+  // IMPORTANT: claude-sonnet-4-6 does NOT support assistant message prefill —
+  // ending the conversation with an `{ role: "assistant", content: '{"' }`
+  // turn returns `400 invalid_request_error: "This model does not support
+  // assistant message prefill"`, which is what broke every program generation
+  // in production. The conversation must end with a user message. We rely on
+  // the system prompt's "REGLE ABSOLUE : Reponds UNIQUEMENT avec du JSON
+  // valide" directive (+ the retry-on-parse + the ```json strip in the shared
+  // helper) to keep the output parseable. prefill is "" so nothing is
+  // prepended to the response.
   function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000) {
     return callAnthropicJson({
       apiKey: anthropicApiKey!,
       model: MODEL,
       maxTokens: MAX_TOKENS,
       systemPrompt,
-      prefill: ASSISTANT_PREFILL,
+      prefill: "",
       timeoutMs,
       messages: [
         { role: "user", content: userPrompt },
         ...extraMessages,
-        { role: "assistant", content: ASSISTANT_PREFILL },
       ],
     });
   }

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -4,6 +4,7 @@ import { getCorsHeaders } from "../_shared/cors.ts";
 import { buildSystemPrompt, buildUserPrompt, type Locale } from "./prompt.ts";
 import { sanitizeOnboardingForPersistence } from "./sanitize.ts";
 import { validateProgram } from "./validate.ts";
+import { AnthropicCallError, callAnthropicJson, describeAnthropicError } from "../_shared/anthropic.ts";
 
 const MAX_ACTIVE_PROGRAMS = 3;
 const MAX_DAILY_GENERATIONS = 3;
@@ -42,6 +43,14 @@ function jsonResponse(req: Request, data: unknown, status = 200) {
 
 function errorResponse(req: Request, message: string, status = 400) {
   return jsonResponse(req, { error: message }, status);
+}
+
+// Map a typed Anthropic failure to a CORS-aware error response. The taxonomy
+// + message/status mapping live in _shared/anthropic.ts so generate-session
+// and generate-program stay in lockstep.
+function mapAnthropicError(req: Request, err: unknown): Response {
+  const { message, status } = describeAnthropicError(err, "programme");
+  return errorResponse(req, message, status);
 }
 
 const VALID_BLESSURES = [
@@ -276,84 +285,54 @@ Deno.serve(async (req: Request) => {
   const userPrompt = buildUserPrompt({ ...body, locale });
   const systemPrompt = buildSystemPrompt(locale);
 
-  // Call Anthropic API
-  // Sonnet with 12K tokens needs more time than Haiku session generation
-  async function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000): Promise<{ data: unknown; inputTokens: number; outputTokens: number }> {
-    // Last message must be the assistant prefill so the model continues from
-    // the JSON-start token instead of free-form prose.
-    const messages = [
-      { role: "user", content: userPrompt },
-      ...extraMessages,
-      { role: "assistant", content: ASSISTANT_PREFILL },
-    ];
-
-    const aiResponse = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": anthropicApiKey!,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        // System prompt is stable across all calls (only varies by locale).
-        // Caching cuts input cost ~90% and shaves latency on the second-and-after
-        // call within the 5-minute TTL.
-        system: [
-          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
-        ],
-        messages,
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
+  // Call Anthropic API. Sonnet with 12K tokens needs a more generous timeout
+  // than the Haiku session generation. The fetch/parse/error-taxonomy lives in
+  // _shared/anthropic.ts; here we only assemble the prompt turns. The last
+  // message must be the assistant prefill so the model continues from the
+  // JSON-start token instead of free-form prose.
+  function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000) {
+    return callAnthropicJson({
+      apiKey: anthropicApiKey!,
+      model: MODEL,
+      maxTokens: MAX_TOKENS,
+      systemPrompt,
+      prefill: ASSISTANT_PREFILL,
+      timeoutMs,
+      messages: [
+        { role: "user", content: userPrompt },
+        ...extraMessages,
+        { role: "assistant", content: ASSISTANT_PREFILL },
+      ],
     });
-
-    if (!aiResponse.ok) {
-      const errText = await aiResponse.text().catch(() => "Unknown error");
-      console.error("Anthropic API error:", aiResponse.status, errText);
-      throw new Error("Erreur de generation");
-    }
-
-    const aiData = await aiResponse.json();
-    const rawContent = aiData.content?.[0]?.text ?? "";
-    // Anthropic returns only the continuation when the assistant turn is
-    // prefilled — prepend the prefill back before parsing.
-    const combined = `${ASSISTANT_PREFILL}${rawContent}`;
-
-    // Parse JSON (handle potential markdown wrapper, kept as belt-and-
-    // suspenders even though the prefill makes it unreachable in practice).
-    const cleaned = combined
-      .replace(/^```json\s*/i, "")
-      .replace(/```\s*$/, "")
-      .trim();
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(cleaned);
-    } catch {
-      console.error("Failed to parse AI response:", combined.slice(0, 500));
-      throw new Error("Réponse IA invalide");
-    }
-
-    return {
-      data: parsed,
-      inputTokens: aiData.usage?.input_tokens ?? 0,
-      outputTokens: aiData.usage?.output_tokens ?? 0,
-    };
   }
 
   let programJson: unknown;
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
 
-  // First attempt
+  // First attempt. A parse failure (the model breaking out of the forced-JSON
+  // format) is transient, so we retry it once with a fresh call before giving
+  // up — this is the single most common production failure and a clean retry
+  // almost always recovers. API/timeout/network errors are NOT retried here:
+  // a 429 needs backoff, a 401/quota error won't fix itself on an immediate
+  // re-call, and a timeout would just burn another timeout window.
   try {
-    const result = await callAnthropic();
+    let result;
+    try {
+      result = await callAnthropic();
+    } catch (err) {
+      if (err instanceof AnthropicCallError && err.kind === "parse") {
+        console.error("Parse failure on first attempt — retrying once");
+        result = await callAnthropic();
+      } else {
+        throw err;
+      }
+    }
     programJson = result.data;
     totalInputTokens = result.inputTokens;
     totalOutputTokens = result.outputTokens;
-  } catch {
-    return errorResponse(req, "Erreur de communication avec l'IA", 502);
+  } catch (err) {
+    return mapAnthropicError(req, err);
   }
 
   // Validate
@@ -372,13 +351,13 @@ Deno.serve(async (req: Request) => {
       totalInputTokens += retryResult.inputTokens;
       totalOutputTokens += retryResult.outputTokens;
       validation = validateProgram(programJson, body.duree_semaines, body.seances_par_semaine);
-    } catch {
-      return errorResponse(req, "La generation a echoue apres retry, reessayez", 502);
+    } catch (err) {
+      return mapAnthropicError(req, err);
     }
 
     if (!validation.valid) {
       console.error("Retry validation failed:", validation.error);
-      return errorResponse(req, "Le programme genere est invalide, reessayez", 502);
+      return errorResponse(req, "Le programme généré est invalide. Réessaie.", 422);
     }
   }
 

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "jsr:@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
 import { buildSystemPrompt, buildUserPrompt, type Locale } from "./prompt.ts";
 import { validateSession } from "./validate.ts";
+import { AnthropicCallError, callAnthropicJson, describeAnthropicError } from "../_shared/anthropic.ts";
 
 const MAX_DAILY_GENERATIONS = 10;
 const MODEL = "claude-haiku-4-5-20251001";
@@ -237,63 +238,49 @@ Deno.serve(async (req: Request) => {
   const userPrompt = buildUserPrompt({ ...body, locale } as Parameters<typeof buildUserPrompt>[0]);
   const systemPrompt = buildSystemPrompt(locale);
 
-  // Call Anthropic API
-  let aiResponse: Response;
-  try {
-    aiResponse = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": anthropicApiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        // System prompt is stable across all calls (only varies by locale).
-        // Marking it as cacheable cuts input cost ~90% and shaves latency.
-        system: [
-          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
-        ],
-        messages: [
-          { role: "user", content: userPrompt },
-          { role: "assistant", content: ASSISTANT_PREFILL },
-        ],
-      }),
-      signal: AbortSignal.timeout(30_000),
+  // Call Anthropic. The fetch/parse/error-taxonomy lives in
+  // _shared/anthropic.ts. A parse failure (the model breaking out of the
+  // forced-JSON prefill and emitting prose, which is the failure captured in
+  // production) is transient, so we retry once with a fresh call before giving
+  // up. API/timeout/network errors are not retried — they won't self-resolve
+  // on an immediate re-call. Every failure is mapped to an honest message +
+  // an actionable HTTP status instead of one opaque 502.
+  function callAi() {
+    return callAnthropicJson({
+      apiKey: anthropicApiKey,
+      model: MODEL,
+      maxTokens: MAX_TOKENS,
+      systemPrompt,
+      prefill: ASSISTANT_PREFILL,
+      timeoutMs: 30_000,
+      messages: [
+        { role: "user", content: userPrompt },
+        { role: "assistant", content: ASSISTANT_PREFILL },
+      ],
     });
-  } catch {
-    return errorResponse(req, "Erreur de communication avec l'IA", 502);
   }
 
-  if (!aiResponse.ok) {
-    const errText = await aiResponse.text().catch(() => "Unknown error");
-    console.error("Anthropic API error:", aiResponse.status, errText);
-    return errorResponse(req, "Erreur de génération", 502);
-  }
-
-  const aiData = await aiResponse.json();
-
-  // Extract token usage
-  const inputTokens = aiData.usage?.input_tokens ?? null;
-  const outputTokens = aiData.usage?.output_tokens ?? null;
-
-  // Parse content. The assistant prefill is included only as the prompt
-  // start — Anthropic returns just the continuation, so prepend it back.
-  const rawContent = aiData.content?.[0]?.text ?? "";
-  const combined = `${ASSISTANT_PREFILL}${rawContent}`;
   let sessionJson: unknown;
-
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
   try {
-    // Handle potential ```json wrapper
-    const cleaned = combined
-      .replace(/^```json\s*/i, "")
-      .replace(/```\s*$/, "")
-      .trim();
-    sessionJson = JSON.parse(cleaned);
-  } catch {
-    console.error("Failed to parse AI response:", combined.slice(0, 500));
-    return errorResponse(req, "Réponse IA invalide, réessayez", 502);
+    let result;
+    try {
+      result = await callAi();
+    } catch (err) {
+      if (err instanceof AnthropicCallError && err.kind === "parse") {
+        console.error("Parse failure on first attempt — retrying once");
+        result = await callAi();
+      } else {
+        throw err;
+      }
+    }
+    sessionJson = result.data;
+    inputTokens = result.inputTokens;
+    outputTokens = result.outputTokens;
+  } catch (err) {
+    const { message, status } = describeAnthropicError(err, "séance");
+    return errorResponse(req, message, status);
   }
 
   // Check for off-topic
@@ -313,7 +300,7 @@ Deno.serve(async (req: Request) => {
   const validation = validateSession(sessionJson, body.duration);
   if (!validation.valid) {
     console.error("Session validation failed:", validation.error);
-    return errorResponse(req, "La séance générée est invalide, réessayez", 502);
+    return errorResponse(req, "La séance générée est invalide. Réessaie.", 422);
   }
 
   // Set date to today (server-side)


### PR DESCRIPTION
Quatre fixes PROD remontés en test (web + iOS).

## 1. `generate-program` — 400 systématique masqué en 502 (déployé PROD)
Logs PROD : `400 invalid_request_error: "This model does not support assistant message prefill"`. `claude-sonnet-4-6` ne supporte plus le prefill assistant `{"` → 400 à chaque appel. `generate-session` épargnée (Haiku 4.5). **Fix** : retrait du prefill (JSON-only déjà imposé par le system prompt).

## 2. Robustesse appels IA (`_shared/anthropic.ts`)
Taxonomie d'erreur partagée + retry-on-parse + mapping vers messages/status réels (429/503/502/504/422) au lieu d'un 502 opaque.

## 3. Signup — vrai message au lieu de générique
422 GoTrue (email existant) → match sur `error.code` stable d'abord, needles enrichis, report Sentry des codes non mappés. Closes #229.

## 4. iOS natif (build TestFlight requis)
- **Zoom input** : iOS auto-zoome au focus d'un input <16px et restait coincé. Lock du viewport (`maximum-scale=1, user-scalable=no`) au runtime, **shell natif uniquement** (pas en dur dans index.html → préserve le pinch-zoom web / a11y).
- **Veille en séance** : `keepAwake()` ne tournait qu'au mount → l'écran pouvait se rendormir après une interruption (appel, control centre, retour de background). Ré-assertion sur `appStateChange` retour au premier plan.

## Déploiement
- Edge functions `generate-program` + `generate-session` : **DEV + PROD** ✅
- Frontend (signup + zoom + veille) : via develop → main → Vercel (web) + build TestFlight (natif)

## Validation
- lint ✅ · build ✅ · **500 tests** ✅ (useWakeLock : +2 tests resume/cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)