### PR TITLE
fix(auth): clear message for breached (pwned) passwords on signup

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,7 +39,12 @@ const SUPABASE_CODE_KEYS: Record<string, string> = {
   email_exists: 'user_already_registered',
   invalid_credentials: 'invalid_credentials',
   email_not_confirmed: 'email_not_confirmed',
-  weak_password: 'password_too_short',
+  // NB: `weak_password` is intentionally NOT mapped here. It is too coarse —
+  // GoTrue uses it for three very different reasons (too short, missing a
+  // character class, or "pwned" i.e. found in a breach database via HIBP).
+  // Mapping it to a single key produced the "password must be 8 characters"
+  // message for a perfectly long but breached password (e.g. "P@ssword01").
+  // The reason is disambiguated by the message needles below instead.
   email_address_invalid: 'invalid_email_format',
   validation_failed: 'invalid_email_format',
   over_email_send_rate_limit: 'email_rate_limited',
@@ -57,6 +62,14 @@ const SUPABASE_ERROR_KEYS: Record<string, string> = {
   'already been registered': 'user_already_registered',
   'already registered': 'user_already_registered',
   'already in use': 'user_already_registered',
+  // The three `weak_password` reasons, disambiguated by GoTrue's message.
+  // "pwned" (found in a breach via HaveIBeenPwned) is the common one and was
+  // previously mis-shown as "too short" — a long but breached password like
+  // "P@ssword01" passes the client strength check, reaches the server, and is
+  // rejected here.
+  'known to be weak': 'password_pwned',
+  'easy to guess': 'password_pwned',
+  'should contain at least one character': 'password_needs_chars',
   // Generic prefix that matches GoTrue's "Password should be at least N
   // characters" regardless of N. The client-side isPasswordStrong() catches
   // weak passwords first; this needle only fires if Supabase Cloud config

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -95,6 +95,8 @@
     "email_not_confirmed": "Please confirm your email address before signing in.",
     "user_already_registered": "An account already exists with this email.",
     "password_too_short": "Password must be at least 8 characters.",
+    "password_pwned": "This password is too common — it appears in known data breaches. Please choose a different one.",
+    "password_needs_chars": "Password must contain at least one uppercase letter, one lowercase letter and one digit.",
     "rate_limited_short": "Please wait before trying again.",
     "invalid_email_format": "Invalid email address.",
     "new_password_same": "Your new password must be different from the old one.",

--- a/src/i18n/locales/fr/auth.json
+++ b/src/i18n/locales/fr/auth.json
@@ -95,6 +95,8 @@
     "email_not_confirmed": "Confirme ton adresse email avant de te connecter.",
     "user_already_registered": "Un compte existe déjà avec cet email.",
     "password_too_short": "Le mot de passe doit contenir au moins 8 caractères.",
+    "password_pwned": "Ce mot de passe est trop courant : il figure dans des fuites de données connues. Choisis-en un autre.",
+    "password_needs_chars": "Le mot de passe doit contenir au moins une majuscule, une minuscule et un chiffre.",
     "rate_limited_short": "Patiente avant de réessayer.",
     "invalid_email_format": "Adresse email invalide.",
     "new_password_same": "Le nouveau mot de passe doit être différent de l'ancien.",


### PR DESCRIPTION
## Symptôme
Création de compte avec `P@ssword01` (10 caractères, fort) → « Le mot de passe doit contenir 8 caractères », message impossible/bouclant.

## Cause
La PROD a **HaveIBeenPwned activé** → GoTrue rejette les mots de passe présents dans des fuites avec `weak_password` / `reasons:["pwned"]`. Le code-map mappait `weak_password` → `password_too_short` en bloc, d'où le faux « trop court ».

Confirmé contre la PROD :
- `P@ssword01` → `422 weak_password reasons:["pwned"]`
- mot de passe unique → `200` ✅

## Fix
- Retrait du mapping grossier `weak_password`.
- Désambiguïsation par le message GoTrue : pwned (« known to be weak » / « easy to guess ») → nouveau `password_pwned` ; classes de caractères → `password_needs_chars`.
- Copy FR + EN.

## Validation
- lint ✅ · build ✅ · 500 tests ✅

## Note
Workaround immédiat utilisateur : utiliser un mot de passe unique (non compromis). Le signup fonctionne déjà.

## Follow-up
- Extraire `translateError` + maps dans un module pur testable (`src/lib/auth-errors.ts`) + tests unitaires sur les codes GoTrue courants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)