### PR TITLE
fix(iap): native paywall loads, purchases & unlocks premium on iOS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10109
-        versionName "1.1.9"
+        versionCode 10110
+        versionName "1.1.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10105
-        versionName "1.1.5"
+        versionCode 10108
+        versionName "1.1.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "fr.wansoft.wan2fit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10108
-        versionName "1.1.8"
+        versionCode 10109
+        versionName "1.1.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10109;
+				CURRENT_PROJECT_VERSION = 10110;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.9;
+				MARKETING_VERSION = 1.1.10;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10109;
+				CURRENT_PROJECT_VERSION = 10110;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.9;
+				MARKETING_VERSION = 1.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10108;
+				CURRENT_PROJECT_VERSION = 10109;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.8;
+				MARKETING_VERSION = 1.1.9;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10108;
+				CURRENT_PROJECT_VERSION = 10109;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.8;
+				MARKETING_VERSION = 1.1.9;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10105;
+				CURRENT_PROJECT_VERSION = 10108;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -315,7 +315,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.8;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10105;
+				CURRENT_PROJECT_VERSION = 10108;
 				DEVELOPMENT_TEAM = DL5537MH8T;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -339,7 +339,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.wansoft.wan2fit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,24 @@
       }
     },
     {
+      "identity" : "purchases-hybrid-common",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RevenueCat/purchases-hybrid-common.git",
+      "state" : {
+        "revision" : "a9d25f3d300cdb515b0cce464b59ebb29ad9ec14",
+        "version" : "18.10.0"
+      }
+    },
+    {
+      "identity" : "purchases-ios-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RevenueCat/purchases-ios-spm",
+      "state" : {
+        "revision" : "92e2804a6b84b3b7ce60bfe7e9ff63dc9524ef5b",
+        "version" : "5.76.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wan2fit",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wan2fit",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2fit",
   "private": true,
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/auth/NativePricingCards.tsx
+++ b/src/components/auth/NativePricingCards.tsx
@@ -125,10 +125,18 @@ export function NativePricingCards() {
         await sleep(2000);
       }
       setActivating(false);
+      // Only claim success once premium has actually landed. If the webhook is
+      // slow (> ~24s) the entitlement is still valid but the tier hasn't synced
+      // yet — tell the truth rather than a premature "Premium activé".
       setFeedback(
-        t('native_pricing.purchase_success', {
-          defaultValue: 'Premium activé ! Toutes les fonctionnalités sont débloquées.',
-        }),
+        premiumRef.current
+          ? t('native_pricing.purchase_success', {
+              defaultValue: 'Premium activé ! Toutes les fonctionnalités sont débloquées.',
+            })
+          : t('native_pricing.activation_delayed', {
+              defaultValue:
+                "Achat confirmé. L'activation Premium peut prendre un instant — relance l'app si rien ne change.",
+            }),
       );
     }
   };
@@ -251,7 +259,7 @@ export function NativePricingCards() {
         <button
           type="button"
           onClick={handleRestore}
-          disabled={restoring}
+          disabled={processing}
           className="text-sm text-link underline disabled:opacity-60"
         >
           {restoring

--- a/src/components/auth/NativePricingCards.tsx
+++ b/src/components/auth/NativePricingCards.tsx
@@ -1,8 +1,11 @@
 import { Check, Crown, Loader2, Sparkles } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext.tsx';
 import { usePurchases } from '../../hooks/usePurchases.ts';
 import { useSubscription } from '../../hooks/useSubscription.ts';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Native iOS / Android paywall — replaces the web Stripe paywall in
 // PricingCards / PremiumPromoPage when running inside the Capacitor shell.
@@ -16,9 +19,16 @@ import { useSubscription } from '../../hooks/useSubscription.ts';
 export function NativePricingCards() {
   const { t } = useTranslation('marketing');
   const { isPremium } = useSubscription();
+  const { refreshProfile } = useAuth();
   const { packages, loading, error, purchase, restore } = usePurchases();
+
+  // Latest premium flag readable inside async callbacks without re-subscribing.
+  const premiumRef = useRef(isPremium);
+  premiumRef.current = isPremium;
+
   const [purchasing, setPurchasing] = useState<string | null>(null);
   const [restoring, setRestoring] = useState(false);
+  const [activating, setActivating] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
 
   if (isPremium) {
@@ -104,6 +114,17 @@ export function NativePricingCards() {
     const ok = await purchase(pkg);
     setPurchasing(null);
     if (ok) {
+      // The StoreKit entitlement is active immediately, but the app's premium
+      // state is sourced from Supabase `profiles.subscription_tier`, which the
+      // revenuecat-webhook flips asynchronously (a few seconds). Poll the
+      // profile until it lands so the UI unlocks without an app restart.
+      setActivating(true);
+      for (let i = 0; i < 12 && !premiumRef.current; i++) {
+        await refreshProfile();
+        if (premiumRef.current) break;
+        await sleep(2000);
+      }
+      setActivating(false);
       setFeedback(
         t('native_pricing.purchase_success', {
           defaultValue: 'Premium activé ! Toutes les fonctionnalités sont débloquées.',
@@ -128,8 +149,22 @@ export function NativePricingCards() {
     );
   };
 
+  const processing = purchasing !== null || restoring || activating;
+
   return (
     <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
+      {processing && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-black/70 backdrop-blur-sm px-6 text-center">
+          <Loader2 className="w-8 h-8 text-white animate-spin" aria-hidden="true" />
+          <p className="text-sm font-medium text-white">
+            {activating
+              ? t('native_pricing.activating', { defaultValue: 'Activation de ton abonnement…' })
+              : restoring
+                ? t('native_pricing.restoring', { defaultValue: 'Restauration en cours…' })
+                : t('native_pricing.processing', { defaultValue: 'Traitement en cours…' })}
+          </p>
+        </div>
+      )}
       <header className="text-center space-y-2">
         <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-brand/10">
           <Sparkles className="w-7 h-7 text-brand" aria-hidden="true" />

--- a/src/components/auth/NativePricingCards.tsx
+++ b/src/components/auth/NativePricingCards.tsx
@@ -1,4 +1,4 @@
-import { Check, Crown, Sparkles } from 'lucide-react';
+import { Check, Crown, Loader2, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePurchases } from '../../hooks/usePurchases.ts';
@@ -42,7 +42,8 @@ export function NativePricingCards() {
 
   if (loading) {
     return (
-      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12">
+      <div className="min-h-[40vh] flex flex-col items-center justify-center gap-3 px-6 py-12">
+        <Loader2 className="w-6 h-6 text-brand animate-spin" aria-hidden="true" />
         <p className="text-sm text-subtle">
           {t('native_pricing.loading', { defaultValue: 'Chargement des abonnements…' })}
         </p>
@@ -69,13 +70,22 @@ export function NativePricingCards() {
 
   if (!packages || packages.length === 0) {
     return (
-      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12 text-center">
-        <p className="text-sm text-subtle max-w-md">
-          {t('native_pricing.unavailable', {
-            defaultValue:
-              "Les abonnements ne sont pas disponibles pour l'instant. Réessaie dans quelques minutes ou contacte le support.",
-          })}
-        </p>
+      <div className="min-h-[40vh] flex items-center justify-center px-6 py-12">
+        <div className="max-w-md w-full text-center space-y-3">
+          <p className="text-sm text-subtle">
+            {t('native_pricing.unavailable', {
+              defaultValue:
+                "Les abonnements ne sont pas disponibles pour l'instant. Réessaie dans quelques minutes ou contacte le support.",
+            })}
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="btn-secondary px-4 py-2 rounded-xl text-sm font-medium"
+          >
+            {t('native_pricing.retry', { defaultValue: 'Réessayer' })}
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/hooks/usePurchases.ts
+++ b/src/hooks/usePurchases.ts
@@ -1,12 +1,21 @@
+import { Purchases as RevenueCatPurchases } from '@revenuecat/purchases-capacitor';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { isNative } from '../lib/capacitor.ts';
+import { captureException } from '../lib/sentryReport.ts';
 
-// We dynamically import the RevenueCat SDK so the web bundle stays lean.
-// Loading the plugin on web would no-op (it ships native bridges only) but
-// even the JS wrapper adds ~30KB gzipped to the initial chunk. The native
-// shell pays the cost once at first use of the paywall.
+// IMPORTANT: this is a STATIC import, intentionally not a dynamic `import()`.
+// A previous version lazy-loaded the SDK with `import('@revenuecat/purchases-
+// capacitor')` to keep the web bundle lean. Inside the iOS Capacitor WKWebView
+// that dynamic import NEVER resolved — the on-screen diagnostic showed the load
+// pipeline frozen at `import-sdk` forever (then our 30s safety timeout fired).
+// Rollup had merged the plugin into a heavy shared chunk and the runtime
+// `import()` of that chunk hangs under the `capacitor://` scheme. A static
+// import is resolved by the native ESM loader when the (already-working)
+// usePurchases chunk loads, so the SDK is ready synchronously. The ~30KB it
+// adds to the bundle is the price of a paywall that actually loads.
+
 type PurchasesPackage = {
   identifier: string; // $rc_monthly | $rc_annual | custom
   packageType?: string;
@@ -32,23 +41,41 @@ type PurchasesSdk = {
   getOfferings: () => Promise<{ current: { availablePackages: PurchasesPackage[] } | null }>;
   purchasePackage: (opts: { aPackage: PurchasesPackage }) => Promise<{ customerInfo: CustomerInfo }>;
   restorePurchases: () => Promise<{ customerInfo: CustomerInfo }>;
-  logIn: (appUserID: string) => Promise<{ customerInfo: CustomerInfo }>;
+  // RevenueCat's Capacitor API takes an OPTIONS OBJECT, not a positional
+  // string: logIn({ appUserID }). Passing the bare string makes the plugin see
+  // `options.appUserID === undefined` → "Must provide appUserId parameter".
+  logIn: (options: { appUserID: string }) => Promise<{ customerInfo: CustomerInfo }>;
   logOut: () => Promise<{ customerInfo: CustomerInfo }>;
   getCustomerInfo: () => Promise<{ customerInfo: CustomerInfo }>;
 };
 
-// Cached module — survive Vite HMR by hanging onto window. Initialising
-// twice in the same JS context throws inside the native SDK.
-let sdkPromise: Promise<PurchasesSdk> | null = null;
+// The SDK is statically imported above; no async module loading needed.
+// `configured` guards the one-time configure() call within a JS context.
 let configured = false;
 
-// The RevenueCat / StoreKit product fetch can hang indefinitely when the
-// products aren't yet available on Apple's side (e.g. the Paid Apps Agreement
-// just went active, or the products are still propagating after reaching
-// "Ready to Submit"). Without a cap, `getOfferings()` never resolves and the
-// paywall is stuck on a static "loading" forever. Race it against a timeout so
-// the UI can fall back to an actionable error + retry instead.
-const OFFERINGS_TIMEOUT_MS = 12_000;
+// StoreKit's first product fetch on a cold device (the App Store review
+// machine, a freshly-installed TestFlight build, a sandbox tester's first
+// launch) is genuinely slow — Apple's own guidance and RevenueCat's
+// troubleshooting both note it can take 15-30s, occasionally more, before
+// StoreKit returns products. Our previous 12s hard cap fired *before* that
+// fetch completed and surfaced an error to the App Review reviewer, who
+// rejected the build under guideline 2.1(b) ("subscriptions couldn't be
+// loaded"). The fetch wasn't broken — we gave up too early.
+//
+// New strategy: a generous per-attempt timeout, retried a few times (StoreKit
+// warms its cache between attempts), and only after all attempts fail do we
+// show an actionable error. An empty offering is treated as a failure worth
+// retrying too — RevenueCat returns an empty `current` while StoreKit is still
+// resolving products rather than throwing.
+const OFFERINGS_TIMEOUT_MS = 30_000;
+const OFFERINGS_MAX_ATTEMPTS = 3;
+const OFFERINGS_RETRY_BACKOFF_MS = 2_000;
+
+// Records each milestone of the load pipeline (import-sdk → configure →
+// offerings-try-N → …). The accumulated trail is attached to the Sentry report
+// when loading fails, so an empty/stuck paywall is diagnosable from the
+// dashboard instead of guessed at.
+type StepFn = (step: string) => void;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return Promise.race([
@@ -57,28 +84,77 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   ]);
 }
 
-async function loadSdk(): Promise<PurchasesSdk> {
-  if (!sdkPromise) {
-    sdkPromise = import('@revenuecat/purchases-capacitor').then((m) => m.Purchases as unknown as PurchasesSdk);
-  }
-  return sdkPromise;
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function ensureConfigured(userId: string | null): Promise<PurchasesSdk> {
-  const sdk = await loadSdk();
+// Return the SDK SYNCHRONOUSLY. This must never be `await`ed nor returned from
+// an async function: the Capacitor `registerPlugin` proxy intercepts *every*
+// property access — including `.then` — and returns a function, which makes the
+// proxy a fake "thenable". Resolving any Promise with it (via `return proxy`
+// from an async fn, `await proxy`, or `.then(() => proxy)`) triggers the
+// runtime to call `proxy.then(resolve, reject)`; the proxy treats `then` as a
+// native method name, ignores the resolve/reject callbacks, and never settles
+// the Promise → an eternal hang (observed as the load pipeline frozen at
+// `import-sdk` until the 30s safety timeout). Calling *methods* on the proxy is
+// fine — those return real Promises. Only the proxy object itself is poison.
+function getSdk(): PurchasesSdk {
+  return RevenueCatPurchases as unknown as PurchasesSdk;
+}
+
+// Configure the SDK. Returns void on purpose — it must NOT return the proxy
+// (see getSdk): an async fn returning the proxy would adopt it as a thenable
+// and hang. Callers grab the SDK synchronously via getSdk() after this resolves.
+async function ensureConfigured(userId: string | null, onStep: StepFn = () => {}): Promise<void> {
+  onStep('import-sdk');
+  const sdk = getSdk();
+  onStep('sdk-loaded');
   const apiKey = import.meta.env.VITE_REVENUECAT_PUBLIC_API_KEY_IOS as string | undefined;
   if (!apiKey) {
-    throw new Error('VITE_REVENUECAT_PUBLIC_API_KEY_IOS missing — IAP cannot init');
+    throw new Error('apikey-missing');
   }
   if (!configured) {
+    onStep('configure');
     await sdk.configure({ apiKey, appUserID: userId });
     configured = true;
+    onStep('configured');
   } else if (userId) {
     // Already configured — bind/rebind the user. logIn is idempotent and
     // reuses the same customer if appUserID matches.
-    await sdk.logIn(userId);
+    onStep('login');
+    await sdk.logIn({ appUserID: userId });
+    onStep('logged-in');
   }
-  return sdk;
+}
+
+// Fetch offerings with bounded retries. Returns the available packages, or
+// throws the last error after exhausting attempts. Treats an empty offering as
+// a retryable miss (StoreKit still resolving) rather than a definitive answer.
+async function fetchOfferingsWithRetry(sdk: PurchasesSdk, onStep: StepFn = () => {}): Promise<PurchasesPackage[]> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= OFFERINGS_MAX_ATTEMPTS; attempt++) {
+    try {
+      onStep(`offerings-try-${attempt}`);
+      const offerings = await withTimeout(sdk.getOfferings(), OFFERINGS_TIMEOUT_MS, 'offerings');
+      const list = offerings.current?.availablePackages ?? [];
+      if (list.length > 0) {
+        onStep(`offerings-ok-${list.length}`);
+        return list;
+      }
+      // Empty — StoreKit likely still warming up. Retry unless this was the
+      // last attempt, in which case return empty (genuinely no products).
+      onStep(`offerings-empty-${attempt}`);
+      lastError = new Error('offerings_empty');
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      onStep(`offerings-err-${attempt}:${lastError.message}`);
+    }
+    if (attempt < OFFERINGS_MAX_ATTEMPTS) await delay(OFFERINGS_RETRY_BACKOFF_MS);
+  }
+  // All attempts produced an empty offering (no throw): surface empty so the
+  // UI shows the "unavailable" state rather than an error.
+  if (lastError?.message === 'offerings_empty') return [];
+  throw lastError ?? new Error('offerings_failed');
 }
 
 interface UsePurchasesResult {
@@ -120,24 +196,33 @@ export function usePurchases(): UsePurchasesResult {
     setLoading(true);
     setError(null);
 
-    withTimeout(ensureConfigured(user?.id ?? null), OFFERINGS_TIMEOUT_MS, 'configure')
-      .then((sdk) => withTimeout(sdk.getOfferings(), OFFERINGS_TIMEOUT_MS, 'offerings'))
-      .then((offerings) => {
+    // Accumulate the full step trail so a Sentry failure report carries the
+    // exact path taken (import-sdk → configure → offerings-try-1 → …), not just
+    // the final error.
+    const trail: string[] = [];
+    const step: StepFn = (s) => trail.push(s);
+
+    withTimeout(ensureConfigured(user?.id ?? null, step), OFFERINGS_TIMEOUT_MS, 'configure')
+      .then(() => fetchOfferingsWithRetry(getSdk(), step))
+      .then((list) => {
         if (cancelled) return;
-        const list = offerings.current?.availablePackages ?? [];
         setPackages(list);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         const raw = err instanceof Error ? err.message : String(err);
-        // A timeout almost always means the products aren't reachable from the
-        // App Store yet (propagation after "Ready to Submit", or a sandbox
-        // hiccup). Surface a clear, retryable message rather than the raw
-        // SDK string.
+        // Report the real failure reason + the step trail to Sentry so a future
+        // empty paywall (including one a reviewer hits) is diagnosable from the
+        // dashboard instead of guessed at.
+        captureException(err instanceof Error ? err : new Error(raw), {
+          contexts: { iap: { stage: 'load_offerings', raw, trail: trail.join(' → ') } },
+        });
+        // A timeout means StoreKit never returned products within our (now
+        // generous) window — usually a transient sandbox/App Store hiccup.
+        // Surface a clear, retryable message rather than the raw SDK string.
         const message = raw.endsWith('_timeout')
           ? t('hook_errors.offerings_timeout', {
-              defaultValue:
-                "Les abonnements n'ont pas pu être chargés (le service Apple peut mettre un moment à les rendre disponibles). Réessaie dans quelques minutes.",
+              defaultValue: 'Le chargement des abonnements a pris trop de temps. Vérifie ta connexion et réessaie.',
             })
           : raw;
         setError(message);
@@ -156,8 +241,8 @@ export function usePurchases(): UsePurchasesResult {
       if (!isNative()) return false;
       setError(null);
       try {
-        const sdk = await ensureConfigured(user?.id ?? null);
-        const result = await sdk.purchasePackage({ aPackage: pkg });
+        await ensureConfigured(user?.id ?? null);
+        const result = await getSdk().purchasePackage({ aPackage: pkg });
         const active = result.customerInfo.entitlements.active;
         return PREMIUM_ENTITLEMENT_ID in active;
       } catch (err: unknown) {
@@ -181,8 +266,8 @@ export function usePurchases(): UsePurchasesResult {
     if (!isNative()) return false;
     setError(null);
     try {
-      const sdk = await ensureConfigured(user?.id ?? null);
-      const result = await sdk.restorePurchases();
+      await ensureConfigured(user?.id ?? null);
+      const result = await getSdk().restorePurchases();
       const active = result.customerInfo.entitlements.active;
       return PREMIUM_ENTITLEMENT_ID in active;
     } catch (err: unknown) {

--- a/src/hooks/usePurchases.ts
+++ b/src/hooks/usePurchases.ts
@@ -42,6 +42,21 @@ type PurchasesSdk = {
 let sdkPromise: Promise<PurchasesSdk> | null = null;
 let configured = false;
 
+// The RevenueCat / StoreKit product fetch can hang indefinitely when the
+// products aren't yet available on Apple's side (e.g. the Paid Apps Agreement
+// just went active, or the products are still propagating after reaching
+// "Ready to Submit"). Without a cap, `getOfferings()` never resolves and the
+// paywall is stuck on a static "loading" forever. Race it against a timeout so
+// the UI can fall back to an actionable error + retry instead.
+const OFFERINGS_TIMEOUT_MS = 12_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${label}_timeout`)), ms)),
+  ]);
+}
+
 async function loadSdk(): Promise<PurchasesSdk> {
   if (!sdkPromise) {
     sdkPromise = import('@revenuecat/purchases-capacitor').then((m) => m.Purchases as unknown as PurchasesSdk);
@@ -105,8 +120,8 @@ export function usePurchases(): UsePurchasesResult {
     setLoading(true);
     setError(null);
 
-    ensureConfigured(user?.id ?? null)
-      .then((sdk) => sdk.getOfferings())
+    withTimeout(ensureConfigured(user?.id ?? null), OFFERINGS_TIMEOUT_MS, 'configure')
+      .then((sdk) => withTimeout(sdk.getOfferings(), OFFERINGS_TIMEOUT_MS, 'offerings'))
       .then((offerings) => {
         if (cancelled) return;
         const list = offerings.current?.availablePackages ?? [];
@@ -114,7 +129,17 @@ export function usePurchases(): UsePurchasesResult {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const raw = err instanceof Error ? err.message : String(err);
+        // A timeout almost always means the products aren't reachable from the
+        // App Store yet (propagation after "Ready to Submit", or a sandbox
+        // hiccup). Surface a clear, retryable message rather than the raw
+        // SDK string.
+        const message = raw.endsWith('_timeout')
+          ? t('hook_errors.offerings_timeout', {
+              defaultValue:
+                "Les abonnements n'ont pas pu être chargés (le service Apple peut mettre un moment à les rendre disponibles). Réessaie dans quelques minutes.",
+            })
+          : raw;
         setError(message);
       })
       .finally(() => {
@@ -124,7 +149,7 @@ export function usePurchases(): UsePurchasesResult {
     return () => {
       cancelled = true;
     };
-  }, [user?.id]);
+  }, [user?.id, t]);
 
   const purchase = useCallback(
     async (pkg: PurchasesPackage): Promise<boolean> => {

--- a/src/hooks/usePurchases.ts
+++ b/src/hooks/usePurchases.ts
@@ -70,6 +70,10 @@ let configured = false;
 const OFFERINGS_TIMEOUT_MS = 30_000;
 const OFFERINGS_MAX_ATTEMPTS = 3;
 const OFFERINGS_RETRY_BACKOFF_MS = 2_000;
+// configure() only inits the SDK + a single native bridge call — it's fast and,
+// unlike the StoreKit product fetch, doesn't warrant the generous offerings
+// window. A tighter cap keeps the worst-case spinner bounded.
+const CONFIGURE_TIMEOUT_MS = 15_000;
 
 // Records each milestone of the load pipeline (import-sdk → configure →
 // offerings-try-N → …). The accumulated trail is attached to the Sentry report
@@ -202,7 +206,7 @@ export function usePurchases(): UsePurchasesResult {
     const trail: string[] = [];
     const step: StepFn = (s) => trail.push(s);
 
-    withTimeout(ensureConfigured(user?.id ?? null, step), OFFERINGS_TIMEOUT_MS, 'configure')
+    withTimeout(ensureConfigured(user?.id ?? null, step), CONFIGURE_TIMEOUT_MS, 'configure')
       .then(() => fetchOfferingsWithRetry(getSdk(), step))
       .then((list) => {
         if (cancelled) return;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -69,6 +69,13 @@
     "profile_load_failed": "Failed to load profile",
     "meals_load_failed": "Failed to load meals",
     "generic_retry": "An error occurred. Please try again.",
-    "unexpected": "Unexpected error"
+    "unexpected": "Unexpected error",
+    "offerings_timeout": "Subscriptions couldn't be loaded (Apple's service may take a while to make them available). Try again in a few minutes."
+  },
+  "restore_purchases": {
+    "success": "Purchase restored. Premium reactivated.",
+    "empty": "No purchase to restore on this Apple/Google account.",
+    "working": "Restoring…",
+    "cta": "Restore my purchases"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -70,7 +70,7 @@
     "meals_load_failed": "Failed to load meals",
     "generic_retry": "An error occurred. Please try again.",
     "unexpected": "Unexpected error",
-    "offerings_timeout": "Subscriptions couldn't be loaded (Apple's service may take a while to make them available). Try again in a few minutes."
+    "offerings_timeout": "Loading subscriptions took too long. Check your connection and try again."
   },
   "restore_purchases": {
     "success": "Purchase restored. Premium reactivated.",

--- a/src/i18n/locales/en/marketing.json
+++ b/src/i18n/locales/en/marketing.json
@@ -78,6 +78,8 @@
     "feature_nutrition": "Full nutrition tracking + AI analysis",
     "feature_no_ads": "No ads, no commitment",
     "opening_store": "Opening the store…",
+    "processing": "Processing…",
+    "activating": "Activating your subscription…",
     "purchase_success": "Premium activated! All features are unlocked.",
     "restore_cta": "Restore my purchases",
     "restoring": "Restoring…",

--- a/src/i18n/locales/en/marketing.json
+++ b/src/i18n/locales/en/marketing.json
@@ -81,6 +81,7 @@
     "processing": "Processing…",
     "activating": "Activating your subscription…",
     "purchase_success": "Premium activated! All features are unlocked.",
+    "activation_delayed": "Purchase confirmed. Premium may take a moment to activate — restart the app if nothing changes.",
     "restore_cta": "Restore my purchases",
     "restoring": "Restoring…",
     "restore_success": "Purchase restored. Premium reactivated.",

--- a/src/i18n/locales/en/marketing.json
+++ b/src/i18n/locales/en/marketing.json
@@ -65,6 +65,27 @@
       "premium_4": "Progression adapted to your level"
     }
   },
+  "native_pricing": {
+    "title": "Go Premium",
+    "subtitle": "Unlimited AI programs, personalized workouts, full nutrition tracking.",
+    "loading": "Loading subscriptions…",
+    "retry": "Try again",
+    "unavailable": "Subscriptions aren't available right now. Try again in a few minutes or contact support.",
+    "plan_yearly": "Premium Yearly",
+    "plan_monthly": "Premium Monthly",
+    "yearly_savings": "Save ~17% vs monthly",
+    "feature_ai": "Unlimited AI programs & workouts",
+    "feature_nutrition": "Full nutrition tracking + AI analysis",
+    "feature_no_ads": "No ads, no commitment",
+    "opening_store": "Opening the store…",
+    "purchase_success": "Premium activated! All features are unlocked.",
+    "restore_cta": "Restore my purchases",
+    "restoring": "Restoring…",
+    "restore_success": "Purchase restored. Premium reactivated.",
+    "restore_empty": "No purchase to restore for this Apple/Google account.",
+    "legal_note": "Subscription renews automatically. You can cancel anytime from your iPhone Settings (Settings > Apple ID > Subscriptions) at least 24h before the end of the current period.",
+    "active_premium_body": "All Premium content is unlocked in the app. Manage your subscription from your iPhone Settings (Settings > Apple ID > Subscriptions)."
+  },
   "premium": {
     "page_title": "Premium",
     "page_description": "Go Premium: custom AI sessions and personalized programs to reach your goals.",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -69,6 +69,13 @@
     "profile_load_failed": "Erreur de chargement du profil",
     "meals_load_failed": "Erreur de chargement des repas",
     "generic_retry": "Une erreur est survenue. Réessayez.",
-    "unexpected": "Erreur inattendue"
+    "unexpected": "Erreur inattendue",
+    "offerings_timeout": "Les abonnements n'ont pas pu être chargés (le service Apple peut mettre un moment à les rendre disponibles). Réessaie dans quelques minutes."
+  },
+  "restore_purchases": {
+    "success": "Achat restauré. Premium réactivé.",
+    "empty": "Aucun achat à restaurer sur ce compte Apple/Google.",
+    "working": "Restauration en cours…",
+    "cta": "Restaurer mes achats"
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -70,7 +70,7 @@
     "meals_load_failed": "Erreur de chargement des repas",
     "generic_retry": "Une erreur est survenue. Réessayez.",
     "unexpected": "Erreur inattendue",
-    "offerings_timeout": "Les abonnements n'ont pas pu être chargés (le service Apple peut mettre un moment à les rendre disponibles). Réessaie dans quelques minutes."
+    "offerings_timeout": "Le chargement des abonnements a pris trop de temps. Vérifie ta connexion et réessaie."
   },
   "restore_purchases": {
     "success": "Achat restauré. Premium réactivé.",

--- a/src/i18n/locales/fr/marketing.json
+++ b/src/i18n/locales/fr/marketing.json
@@ -78,6 +78,8 @@
     "feature_nutrition": "Suivi nutrition complet + analyse IA",
     "feature_no_ads": "Sans publicité, sans engagement",
     "opening_store": "Ouverture de la boutique…",
+    "processing": "Traitement en cours…",
+    "activating": "Activation de ton abonnement…",
     "purchase_success": "Premium activé ! Toutes les fonctionnalités sont débloquées.",
     "restore_cta": "Restaurer mes achats",
     "restoring": "Restauration en cours…",

--- a/src/i18n/locales/fr/marketing.json
+++ b/src/i18n/locales/fr/marketing.json
@@ -81,6 +81,7 @@
     "processing": "Traitement en cours…",
     "activating": "Activation de ton abonnement…",
     "purchase_success": "Premium activé ! Toutes les fonctionnalités sont débloquées.",
+    "activation_delayed": "Achat confirmé. L'activation Premium peut prendre un instant — relance l'app si rien ne change.",
     "restore_cta": "Restaurer mes achats",
     "restoring": "Restauration en cours…",
     "restore_success": "Achat restauré. Premium réactivé.",

--- a/src/i18n/locales/fr/marketing.json
+++ b/src/i18n/locales/fr/marketing.json
@@ -65,6 +65,27 @@
       "premium_4": "Progression adaptée à ton niveau"
     }
   },
+  "native_pricing": {
+    "title": "Passe à Premium",
+    "subtitle": "Programmes IA illimités, séances personnalisées, suivi nutrition complet.",
+    "loading": "Chargement des abonnements…",
+    "retry": "Réessayer",
+    "unavailable": "Les abonnements ne sont pas disponibles pour l'instant. Réessaie dans quelques minutes ou contacte le support.",
+    "plan_yearly": "Premium Annuel",
+    "plan_monthly": "Premium Mensuel",
+    "yearly_savings": "Économise ~17% vs mensuel",
+    "feature_ai": "Programmes & séances IA illimités",
+    "feature_nutrition": "Suivi nutrition complet + analyse IA",
+    "feature_no_ads": "Sans publicité, sans engagement",
+    "opening_store": "Ouverture de la boutique…",
+    "purchase_success": "Premium activé ! Toutes les fonctionnalités sont débloquées.",
+    "restore_cta": "Restaurer mes achats",
+    "restoring": "Restauration en cours…",
+    "restore_success": "Achat restauré. Premium réactivé.",
+    "restore_empty": "Aucun achat à restaurer pour ce compte Apple/Google.",
+    "legal_note": "Abonnement renouvelé automatiquement. Tu peux annuler à tout moment depuis les Réglages de ton iPhone (Réglages > Apple ID > Abonnements) au moins 24h avant la fin de la période en cours.",
+    "active_premium_body": "Tout le contenu Premium est débloqué dans l'app. Gère ton abonnement depuis les Réglages de ton iPhone (Réglages > Apple ID > Abonnements)."
+  },
   "premium": {
     "page_title": "Premium",
     "page_description": "Passe à Premium : séances IA sur-mesure et programmes personnalisés pour atteindre tes objectifs.",

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -175,12 +175,17 @@ Deno.serve(async (req) => {
     .single();
 
   if (readError) {
-    // Most likely: user does not exist (e.g. someone with an Apple-ID-only
-    // account trying to subscribe before completing Wan2Fit signup, or a
-    // sandbox tester whose Supabase user was deleted). Log + 200 OK so
-    // RevenueCat stops retrying — we can investigate in logs.
-    console.warn(`[revenuecat-webhook] user not found id=${userId} event=${event.type}`);
-    return jsonResponse({ ok: true, skipped: "user_not_found" });
+    // Distinguish "profile genuinely missing" (PostgREST PGRST116 = no rows)
+    // from a schema/query error (e.g. the 026 subscription_provider migration
+    // not applied in this environment, code 42703 = undefined_column), which
+    // would otherwise masquerade as user_not_found for EVERY subscriber.
+    // The pg code is surfaced in the response body + logs so the failure mode
+    // is diagnosable from the RevenueCat dashboard instead of opaque.
+    const code = (readError as { code?: string }).code ?? "unknown";
+    console.warn(
+      `[revenuecat-webhook] read error id=${userId} event=${event.type} code=${code} msg=${readError.message}`,
+    );
+    return jsonResponse({ ok: true, skipped: "read_error", code, message: readError.message });
   }
 
   if (current.subscription_tier === action && current.subscription_provider === "revenuecat") {

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -175,12 +175,12 @@ Deno.serve(async (req) => {
     .single();
 
   if (readError) {
-    // Distinguish "profile genuinely missing" (PostgREST PGRST116 = no rows)
-    // from a schema/query error (e.g. the 026 subscription_provider migration
-    // not applied in this environment, code 42703 = undefined_column), which
-    // would otherwise masquerade as user_not_found for EVERY subscriber.
-    // The pg code is surfaced in the response body + logs so the failure mode
-    // is diagnosable from the RevenueCat dashboard instead of opaque.
+    // Surface the Postgres error code so a schema/query error (e.g. the 026
+    // subscription_provider migration not applied → code 42703 undefined_column,
+    // which masqueraded as user_not_found for EVERY subscriber) is told apart
+    // from a genuinely missing profile (PostgREST PGRST116 = no rows). Both
+    // still return 200 so RevenueCat stops retrying — the difference is purely
+    // diagnostic (the code lands in the response body + logs).
     const code = (readError as { code?: string }).code ?? "unknown";
     console.warn(
       `[revenuecat-webhook] read error id=${userId} event=${event.type} code=${code} msg=${readError.message}`,


### PR DESCRIPTION
## Contexte
Débogage de bout en bout du rejet Apple **2.1(b)** (« subscriptions couldn't be loaded ») + correctifs UX/sync découverts pendant les tests sandbox.

## Causes racines corrigées
1. **Proxy thenable Capacitor** — `registerPlugin` renvoie un Proxy dont `.then` est une fonction → faux thenable. `await proxy` / `return proxy` depuis une async **ne se résout jamais** (paywall figé sur « Chargement »). Fix : `getSdk()` synchrone, le proxy ne transite jamais par une résolution de promesse.
2. **`Package.resolved`** — le plugin SPM RevenueCat était déclaré mais **jamais résolu** → `PurchasesPlugin` non linké dans l'archive → « not implemented on ios ». Pin de `RevenueCat` / `PurchasesHybridCommon`.
3. **`logIn({ appUserID })`** — l'API Capacitor attend un objet (la string positionnelle → « Must provide appUserId parameter »).
4. **Webhook RevenueCat → Supabase** — la fonction `revenuecat-webhook` n'était **pas déployée en prod** (404) et la migration **026 `subscription_provider`** manquait → `select` en échec masqué en `user_not_found` → premium jamais accordé. (Fonction déployée + migration appliquée en prod ; la fonction remonte désormais le vrai code PG.)

## UX
- Fetch des offerings : 30s × 3 retries (StoreKit froid lent), `configure()` capé à 15s.
- Overlay spinner pendant achat/restore/activation.
- Poll du profil après achat → premium se débloque sans redémarrage ; message honnête si le webhook tarde.
- Capture Sentry de la vraie raison + trail en cas d'échec.

## Validation
- ✅ Produits chargés, achat StoreKit sandbox OK, premium débloqué sur device.
- ✅ lint, 500 tests, build verts.
- ✅ Review quality-engineer : WARNINGs traités.

🤖 Generated with [Claude Code](https://claude.com/claude-code)