### PR TITLE
feat(marketing): liens Instagram + Facebook dans le footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
+import { SocialLinks } from './SocialLinks.tsx';
 import { StoreBadges } from './StoreBadges.tsx';
 
 export function Footer() {
@@ -10,6 +11,9 @@ export function Footer() {
       <div className="mb-6 flex flex-col items-center gap-2">
         <p className="text-subtle text-xs">{t('store_badges.title')}</p>
         <StoreBadges />
+        <div className="mt-2">
+          <SocialLinks />
+        </div>
       </div>
       <p className="text-faint text-xs text-center">
         Wan2Fit {t('footer.by')}{' '}

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,0 +1,33 @@
+import { Facebook, Instagram } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+const INSTAGRAM_URL = 'https://www.instagram.com/wan.2.fit/';
+const FACEBOOK_URL = 'https://www.facebook.com/profile.php?id=61581314044112';
+
+// Links to the brand's social profiles. Rendered in the public web Footer.
+export function SocialLinks() {
+  const { t } = useTranslation('marketing');
+
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <a
+        href={INSTAGRAM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={t('social.instagram')}
+        className="text-faint hover:text-subtle transition-colors"
+      >
+        <Instagram className="h-5 w-5" />
+      </a>
+      <a
+        href={FACEBOOK_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={t('social.facebook')}
+        className="text-faint hover:text-subtle transition-colors"
+      >
+        <Facebook className="h-5 w-5" />
+      </a>
+    </div>
+  );
+}

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -5,17 +5,18 @@ const INSTAGRAM_URL = 'https://www.instagram.com/wan.2.fit/';
 const FACEBOOK_URL = 'https://www.facebook.com/profile.php?id=61581314044112';
 
 // Links to the brand's social profiles. Rendered in the public web Footer.
+// Circular icon buttons that adopt each network's brand colour on hover.
 export function SocialLinks() {
   const { t } = useTranslation('marketing');
 
   return (
-    <div className="flex items-center justify-center gap-4">
+    <div className="flex items-center justify-center gap-3">
       <a
         href={INSTAGRAM_URL}
         target="_blank"
         rel="noopener noreferrer"
         aria-label={t('social.instagram')}
-        className="text-faint hover:text-subtle transition-colors"
+        className="flex h-10 w-10 items-center justify-center rounded-full border border-divider text-subtle transition-colors hover:border-transparent hover:bg-gradient-to-tr hover:from-[#f58529] hover:via-[#dd2a7b] hover:to-[#8134af] hover:text-white"
       >
         <Instagram className="h-5 w-5" />
       </a>
@@ -24,7 +25,7 @@ export function SocialLinks() {
         target="_blank"
         rel="noopener noreferrer"
         aria-label={t('social.facebook')}
-        className="text-faint hover:text-subtle transition-colors"
+        className="flex h-10 w-10 items-center justify-center rounded-full border border-divider text-subtle transition-colors hover:border-transparent hover:bg-[#1877f2] hover:text-white"
       >
         <Facebook className="h-5 w-5" />
       </a>

--- a/src/i18n/locales/en/marketing.json
+++ b/src/i18n/locales/en/marketing.json
@@ -138,6 +138,10 @@
     "app_store": "Download on the App Store",
     "google_play": "Get it on Google Play"
   },
+  "social": {
+    "instagram": "Wan2Fit on Instagram",
+    "facebook": "Wan2Fit on Facebook"
+  },
   "carousel": {
     "slide_aria": "Go to slide {{current}} of {{total}}"
   }

--- a/src/i18n/locales/fr/marketing.json
+++ b/src/i18n/locales/fr/marketing.json
@@ -138,6 +138,10 @@
     "app_store": "Télécharger dans l'App Store",
     "google_play": "Disponible sur Google Play"
   },
+  "social": {
+    "instagram": "Wan2Fit sur Instagram",
+    "facebook": "Wan2Fit sur Facebook"
+  },
   "carousel": {
     "slide_aria": "Aller au slide {{current}} sur {{total}}"
   }


### PR DESCRIPTION
## Contexte
Closes #193 — partie « réseaux sociaux » de l'issue (les liens vers les apps iOS/Android étaient déjà livrés via `StoreBadges`).

## Changements
- Nouveau composant `SocialLinks.tsx` (icônes lucide `Instagram` / `Facebook`, aria-labels i18n), aligné sur le style de `StoreBadges`.
- Affiché dans le `Footer`, sous les badges stores.
- Clés i18n `social.{instagram,facebook}` ajoutées en FR + EN.

URLs :
- Instagram : https://www.instagram.com/wan.2.fit/
- Facebook : https://www.facebook.com/profile.php?id=61581314044112

## Validation
- `npm run build` ✅ (153 routes prerendues)
- `biome check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)