### PR TITLE
feat(programs): programmes IA périodisés (séances variables par phase)

### DIFF
--- a/src/components/CreateProgramPage.tsx
+++ b/src/components/CreateProgramPage.tsx
@@ -37,7 +37,7 @@ interface DraftState {
   duree_seance_minutes: number;
   materiel: (Equipment | 'salle')[];
   materiel_detail: string;
-  duree_semaines: 4 | 8 | 12;
+  duree_semaines: 4 | 6 | 8 | 12;
 }
 
 const DEFAULT_DRAFT: DraftState = {

--- a/src/components/create-program/StepPreferences.tsx
+++ b/src/components/create-program/StepPreferences.tsx
@@ -9,7 +9,7 @@ export interface StepPreferencesProps {
   dureeSeanceMinutes: number;
   materiel: (Equipment | 'salle')[];
   materielDetail: string;
-  dureeSemaines: 4 | 8 | 12;
+  dureeSemaines: 4 | 6 | 8 | 12;
   isValid: boolean;
   generating: boolean;
   generateError: string | null;
@@ -18,7 +18,7 @@ export interface StepPreferencesProps {
   onChangeDureeSeance: (value: number) => void;
   onToggleMateriel: (value: Equipment | 'salle') => void;
   onChangeMaterielDetail: (value: string) => void;
-  onChangeDureeSemaines: (value: 4 | 8 | 12) => void;
+  onChangeDureeSemaines: (value: 4 | 6 | 8 | 12) => void;
   onBack: () => void;
   onSubmit: () => void;
 }
@@ -136,7 +136,7 @@ export function StepPreferences({
         <legend className="text-sm font-semibold text-heading mb-3">
           {t('step_preferences.program_duration_legend')}
         </legend>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {DUREE_OPTIONS.map((d) => (
             <button
               key={d.value}

--- a/src/components/create-program/formOptions.ts
+++ b/src/components/create-program/formOptions.ts
@@ -51,8 +51,9 @@ export const MATERIEL_OPTIONS: { value: Equipment | 'salle' }[] = [
   { value: 'salle' },
 ];
 
-export const DUREE_OPTIONS: { value: 4 | 8 | 12; recommended?: boolean }[] = [
+export const DUREE_OPTIONS: { value: 4 | 6 | 8 | 12; recommended?: boolean }[] = [
   { value: 4 },
+  { value: 6 },
   { value: 8, recommended: true },
   { value: 12 },
 ];

--- a/src/i18n/locales/en/programs.json
+++ b/src/i18n/locales/en/programs.json
@@ -92,7 +92,7 @@
     "title": "What motivates you?",
     "legend": "Choose your goals",
     "detail_label": "Tell us more",
-    "detail_hint": "The more specific you are, the better your program will be.",
+    "detail_hint": "The more specific you are, the better your program will be. If you're preparing for a deadline (a competition, getting back into a sport, a holiday...), mention it: it changes how the program is structured.",
     "detail_placeholder": "E.g. lose 5kg before summer, pre-season football, program alongside basketball to perform on weekends...",
     "next": "Next"
   },
@@ -184,6 +184,7 @@
   },
   "duree": {
     "4": "4 weeks",
+    "6": "6 weeks",
     "8": "8 weeks",
     "12": "12 weeks"
   },

--- a/src/i18n/locales/fr/programs.json
+++ b/src/i18n/locales/fr/programs.json
@@ -92,7 +92,7 @@
     "title": "Qu'est-ce qui te motive ?",
     "legend": "Choisis tes objectifs",
     "detail_label": "Dis-nous en plus",
-    "detail_hint": "Plus tu précises, plus ton programme sera adapté.",
+    "detail_hint": "Plus tu précises, plus ton programme sera adapté. Si tu prépares une échéance (compétition, reprise d'un sport, vacances...), mentionne-la : ça change la structure du programme.",
     "detail_placeholder": "Ex : perdre 5kg avant l'été, pré-saison foot, programme en parallèle du basket pour performer le week-end...",
     "next": "Suivant"
   },
@@ -184,6 +184,7 @@
   },
   "duree": {
     "4": "4 semaines",
+    "6": "6 semaines",
     "8": "8 semaines",
     "12": "12 semaines"
   },

--- a/src/types/custom-program.ts
+++ b/src/types/custom-program.ts
@@ -21,7 +21,7 @@ export interface ProgramOnboardingInput {
   seances_par_semaine: number;
   duree_seance_minutes: number;
   materiel: Equipment[];
-  duree_semaines: 4 | 8 | 12;
+  duree_semaines: 4 | 6 | 8 | 12;
 }
 
 /**

--- a/supabase/functions/_shared/anthropic.ts
+++ b/supabase/functions/_shared/anthropic.ts
@@ -9,7 +9,7 @@
 // no actionable signal. We carry the kind + upstream HTTP status so callers
 // can (a) surface an honest message and (b) decide whether a retry can help.
 
-export type AnthropicErrorKind = "api" | "parse" | "timeout" | "network";
+export type AnthropicErrorKind = "api" | "parse" | "timeout" | "network" | "truncation";
 
 export class AnthropicCallError extends Error {
   kind: AnthropicErrorKind;
@@ -77,6 +77,16 @@ export async function callAnthropicJson(opts: {
   }
 
   const aiData = await res.json();
+
+  // Truncation guard: if the model hit the token ceiling, `content` is a
+  // syntactically broken JSON fragment. Detecting it here (via stop_reason)
+  // gives callers a distinct, honest signal instead of a misleading "parse"
+  // error that would trigger a same-shape retry doomed to truncate again.
+  if (aiData.stop_reason === "max_tokens") {
+    console.error("Anthropic response truncated: stop_reason=max_tokens");
+    throw new AnthropicCallError("truncation", "Anthropic response truncated (max_tokens)");
+  }
+
   const rawContent = aiData.content?.[0]?.text ?? "";
   const combined = `${opts.prefill}${rawContent}`;
   const cleaned = combined
@@ -115,6 +125,9 @@ export function describeAnthropicError(err: unknown, noun = "contenu"): { messag
     }
     if (err.kind === "parse") {
       return { message: `L'IA n'a pas réussi à produire un ${noun} exploitable. Réessaie.`, status: 422 };
+    }
+    if (err.kind === "truncation") {
+      return { message: `Le ${noun} généré était trop volumineux et a été coupé. Réessaie.`, status: 422 };
     }
     if (err.kind === "network") {
       return { message: "Impossible de joindre le service IA. Vérifie ta connexion et réessaie.", status: 502 };

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -9,7 +9,11 @@ import { AnthropicCallError, callAnthropicJson, describeAnthropicError } from ".
 const MAX_ACTIVE_PROGRAMS = 3;
 const MAX_DAILY_GENERATIONS = 3;
 const MODEL = "claude-sonnet-4-6";
-const MAX_TOKENS = 12288;
+// Raised from 12288 to absorb periodised ("phase") programs, which declare
+// distinct sessions per phase (worst realistic case ~15-20 unique sessions ≈
+// 14-16K output tokens + JSON overhead). Truncation is now detected via
+// stop_reason in _shared/anthropic.ts rather than surfacing as a parse error.
+const MAX_TOKENS = 20480;
 // NB: no assistant-message prefill here — claude-sonnet-4-6 rejects it with a
 // 400 ("This model does not support assistant message prefill"). Prompt-
 // injection defence + JSON-only output are enforced by the system prompt
@@ -31,7 +35,7 @@ const VALID_MATERIEL = [
   'corde_a_sauter', 'medecine_ball', 'swiss_ball', 'tapis',
   'step', 'foam_roller', 'anneaux',
 ];
-const VALID_DUREES = [4, 8, 12];
+const VALID_DUREES = [4, 6, 8, 12];
 const VALID_LOCALES: Locale[] = ["fr", "en"];
 
 function jsonResponse(req: Request, data: unknown, status = 200) {
@@ -133,6 +137,21 @@ function validateInput(body: RequestInput): string | null {
   }
 
   return null;
+}
+
+/**
+ * Deterministic structure decision for the high-stakes, high-confidence case:
+ * a sport-performance goal on a program long enough to periodise (≥ 6 weeks)
+ * is ALWAYS phased — we never leave that to the model, because the asymmetric
+ * failure (a sportif with a deadline getting a flat, repeated program) is the
+ * one that matters. Every other case returns undefined and falls through to
+ * the deduction rules in the system prompt (repeat is the safe default there).
+ */
+function classifyStructure(body: RequestInput): "phase" | undefined {
+  if (body.objectifs.includes("performance_sportive") && body.duree_semaines >= 6) {
+    return "phase";
+  }
+  return undefined;
 }
 
 function slugify(text: string): string {
@@ -282,7 +301,8 @@ Deno.serve(async (req: Request) => {
 
   // Build prompt
   const locale: Locale = (body.locale as Locale) ?? "fr";
-  const userPrompt = buildUserPrompt({ ...body, locale });
+  const imposedStructure = classifyStructure(body);
+  const userPrompt = buildUserPrompt({ ...body, locale }, imposedStructure);
   const systemPrompt = buildSystemPrompt(locale);
 
   // Call Anthropic API. Sonnet with 12K tokens needs a more generous timeout
@@ -353,7 +373,7 @@ Deno.serve(async (req: Request) => {
       const retryResult = await callAnthropic([
         { role: "assistant", content: truncatedPrev },
         { role: "user", content: `Ta reponse precedente etait invalide: ${validation.error}. Corrige et renvoie le JSON complet.` },
-      ], 30_000);
+      ], 90_000);
       programJson = retryResult.data;
       totalInputTokens += retryResult.inputTokens;
       totalOutputTokens += retryResult.outputTokens;
@@ -371,6 +391,19 @@ Deno.serve(async (req: Request) => {
   const pgm = programJson as Record<string, unknown>;
   const sessions = pgm.sessions as Record<string, Record<string, unknown>>;
   const calendrier = pgm.calendrier as CalendrierEntry[];
+
+  // Observability (non-fatal): surface two silent-waste / drift signals.
+  // 1) Orphan sessions — declared but never scheduled → wasted output tokens.
+  const referencedIds = new Set(calendrier.flatMap((e) => e.sequence));
+  const orphanIds = Object.keys(sessions).filter((id) => !referencedIds.has(id));
+  if (orphanIds.length > 0) {
+    console.warn(`Orphan sessions declared but never scheduled: ${orphanIds.join(", ")}`);
+  }
+  // 2) Structure conformance — when we imposed "phase" deterministically, log
+  //    any divergence so we can measure how often the model ignores the order.
+  if (imposedStructure === "phase" && pgm.structure !== "phase") {
+    console.warn(`Imposed structure "phase" but model returned "${String(pgm.structure)}"`);
+  }
 
   // Generate slug
   const baseSlug = slugify(pgm.titre as string) || 'programme';

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -318,7 +318,13 @@ Deno.serve(async (req: Request) => {
   // valide" directive (+ the retry-on-parse + the ```json strip in the shared
   // helper) to keep the output parseable. prefill is "" so nothing is
   // prepended to the response.
-  function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 120_000) {
+  // Default 145s: Supabase's gateway returns a hard 504 if the function does
+  // not respond within 150s (request idle timeout), so we abort at 145s to fail
+  // with our own honest "trop volumineux" message just under that ceiling. This
+  // is the real limit on a single blocking call — larger phased programs are
+  // kept generatable-in-window by the prompt bounding them (≤3 phases, strong
+  // session reuse). Programs too large for 145s still surface an honest 504.
+  function callAnthropic(extraMessages: { role: string; content: string }[] = [], timeoutMs = 145_000) {
     return callAnthropicJson({
       apiKey: anthropicApiKey!,
       model: MODEL,

--- a/supabase/functions/generate-program/index.ts
+++ b/supabase/functions/generate-program/index.ts
@@ -103,7 +103,7 @@ function validateInput(body: RequestInput): string | null {
     return "duree_seance_minutes doit etre entre 30 et 75";
 
   if (!VALID_DUREES.includes(body.duree_semaines))
-    return "duree_semaines doit etre 4, 8 ou 12";
+    return "duree_semaines doit etre 4, 6, 8 ou 12";
 
   if (body.blessures && !Array.isArray(body.blessures))
     return "blessures doit etre un tableau";
@@ -305,9 +305,9 @@ Deno.serve(async (req: Request) => {
   const userPrompt = buildUserPrompt({ ...body, locale }, imposedStructure);
   const systemPrompt = buildSystemPrompt(locale);
 
-  // Call Anthropic API. Sonnet with 12K tokens needs a more generous timeout
-  // than the Haiku session generation. The fetch/parse/error-taxonomy lives in
-  // _shared/anthropic.ts; here we only assemble the prompt turns.
+  // Call Anthropic API. Sonnet with a 20K-token budget needs a more generous
+  // timeout than the Haiku session generation. The fetch/parse/error-taxonomy
+  // lives in _shared/anthropic.ts; here we only assemble the prompt turns.
   //
   // IMPORTANT: claude-sonnet-4-6 does NOT support assistant message prefill —
   // ending the conversation with an `{ role: "assistant", content: '{"' }`
@@ -365,7 +365,9 @@ Deno.serve(async (req: Request) => {
   // Validate
   let validation = validateProgram(programJson, body.duree_semaines, body.seances_par_semaine);
 
-  // Retry once if invalid
+  // Retry once if invalid. Timeout is 90s (not 30s): the correction round must
+  // regenerate a full program under the same 20K-token budget, which at Sonnet
+  // speed can take 45-70s — a 30s cap would time out most phased retries.
   if (!validation.valid) {
     console.error("First attempt validation failed:", validation.error);
     try {

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -103,7 +103,7 @@ Choisis une structure et indique-la dans le champ "structure".
 
 - "repete" : les memes seances reviennent a l'identique toute la duree. La progression se fait uniquement en augmentant series/charges/repetitions, expliquee dans consignes_semaine. Mode par defaut, adapte a la prise de muscle, la force, le renforcement general. Nomme les seances A, B, C…
 
-- "phase" : le programme est decoupe en 2 a 4 phases successives, chacune avec ses PROPRES seances distinctes, pour orchestrer une montee en puissance (ex: reprise → developpement → pic → affutage). Chaque phase couvre une plage de semaines du calendrier. Nomme les seances avec le numero de phase en suffixe : A1/B1/C1 (phase 1), A2/B2/C2 (phase 2)… et donne un "nom" a chaque plage du calendrier.
+- "phase" : le programme est decoupe en 2 a 3 phases successives, chacune avec ses PROPRES seances distinctes, pour orchestrer une montee en puissance (ex: reprise → developpement → pic/affutage). Chaque phase couvre une plage de semaines du calendrier. Nomme les seances avec le numero de phase en suffixe : A1/B1/C1 (phase 1), A2/B2/C2 (phase 2)… et donne un "nom" a chaque plage du calendrier.
 
 QUAND CHOISIR "phase" :
 - Si "STRUCTURE IMPOSEE : phase" apparait dans la demande → respecte-la sans exception.
@@ -112,11 +112,11 @@ QUAND CHOISIR "phase" :
 - En cas de doute → "repete".
 
 REGLES DU MODE "phase" :
-- 2 a 4 phases. Chaque phase = une plage de semaines consecutives, SANS chevauchement, l'ensemble couvrant les semaines 1 a duree_semaines.
-- Les seances d'une phase doivent differer de celles des autres phases (intensite, format de bloc, volume) pour refleter la progression. Reutilise une seance identique d'une phase a l'autre UNIQUEMENT si la progression ne justifie pas de la changer.
+- 2 a 3 phases maximum. Chaque phase = une plage de semaines consecutives, SANS chevauchement, l'ensemble couvrant les semaines 1 a duree_semaines.
+- Les seances d'une phase doivent differer de celles des autres phases (intensite, format de bloc, volume) pour refleter la progression.
+- IMPORTANT (garde la sortie compacte) : vise un TOTAL de 6 seances uniques ou moins (maximum absolu 20). Reutilise une meme seance d'une phase a l'autre des que la progression le permet — ne cree une nouvelle version d'une seance QUE si son intensite ou son format change vraiment. Il vaut mieux 2 phases bien distinctes que 3 phases aux differences minimes.
 - La longueur de chaque "sequence" ne depasse jamais seances_par_semaine (plus court autorise pour une semaine d'affutage/recuperation).
 - consignes_semaine doit couvrir chaque plage de phase.
-- Total : 20 seances uniques maximum.
 
 REGLES DE PROGRAMMATION SPORTIVE :
 

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -48,6 +48,7 @@ SCHEMA JSON DE SORTIE :
   "titre": "string (nom court et motivant)",
   "description": "string (1-2 phrases)",
   "niveau": "debutant" | "intermediaire" | "avance",
+  "structure": "repete" | "phase" (voir section STRUCTURE ci-dessous),
   "note_coach": "string (3-5 phrases, tutoiement, personnalise selon le profil)",
   "progression": {
     "logique": "string (explication de la logique de progression)",
@@ -57,17 +58,21 @@ SCHEMA JSON DE SORTIE :
     "cible_semaine_12": "string (optionnel)"
   },
   "sessions": {
-    "A": Session,
-    "B": Session,
-    "C": Session (optionnel, max 5 sessions uniques A-E)
+    // Mode "repete" : nomme les seances A, B, C… (memes seances toute la duree).
+    // Mode "phase"  : suffixe le numero de phase — A1, B1, C1 (phase 1),
+    //                 A2, B2, C2 (phase 2), etc.
+    // Maximum 20 seances uniques au total.
+    "A1": Session,
+    "B1": Session,
+    "A2": Session
   },
   "calendrier": [
-    { "semaines": [1, 2], "sequence": ["A", "B"] },
-    { "semaines": [3, 4], "sequence": ["A", "B", "C"] }
+    { "semaines": [1, 2, 3], "sequence": ["A1", "B1"], "nom": "Reprise (optionnel)" },
+    { "semaines": [4, 5, 6], "sequence": ["A2", "B2"], "nom": "Developpement" }
   ],
   "consignes_semaine": {
-    "1-2": "string (consigne de progression pour ces semaines)",
-    "3-4": "string"
+    "1-3": "string (consigne de progression pour ces semaines)",
+    "4-6": "string"
   }
 }
 
@@ -93,6 +98,26 @@ TYPES DE BLOCS DISPONIBLES :
 9. superset — { "type": "superset", "name": "string", "sets": number, "restBetweenSets": number (sec), "restBetweenPairs?": number (sec), "pairs": [{ "exercises": [{ "name": "string", "reps": number, "instructions": "string" }] }] }
 10. pyramid — { "type": "pyramid", "name": "string", "pattern": [number], "restBetweenSets": number (sec), "restBetweenExercises?": number (sec), "exercises": [{ "name": "string", "instructions": "string" }] }
 
+STRUCTURE DU PROGRAMME — "repete" ou "phase" :
+Choisis une structure et indique-la dans le champ "structure".
+
+- "repete" : les memes seances reviennent a l'identique toute la duree. La progression se fait uniquement en augmentant series/charges/repetitions, expliquee dans consignes_semaine. Mode par defaut, adapte a la prise de muscle, la force, le renforcement general. Nomme les seances A, B, C…
+
+- "phase" : le programme est decoupe en 2 a 4 phases successives, chacune avec ses PROPRES seances distinctes, pour orchestrer une montee en puissance (ex: reprise → developpement → pic → affutage). Chaque phase couvre une plage de semaines du calendrier. Nomme les seances avec le numero de phase en suffixe : A1/B1/C1 (phase 1), A2/B2/C2 (phase 2)… et donne un "nom" a chaque plage du calendrier.
+
+QUAND CHOISIR "phase" :
+- Si "STRUCTURE IMPOSEE : phase" apparait dans la demande → respecte-la sans exception.
+- Sinon, deduis : objectif de performance sportive avec une echeance (competition, reprise de saison, match, course, date), ou toute mention d'un evenement a preparer dans le detail de l'objectif → "phase".
+- Prise de muscle, force, remise en forme sans echeance, bien-etre, souplesse → "repete".
+- En cas de doute → "repete".
+
+REGLES DU MODE "phase" :
+- 2 a 4 phases. Chaque phase = une plage de semaines consecutives, SANS chevauchement, l'ensemble couvrant les semaines 1 a duree_semaines.
+- Les seances d'une phase doivent differer de celles des autres phases (intensite, format de bloc, volume) pour refleter la progression. Reutilise une seance identique d'une phase a l'autre UNIQUEMENT si la progression ne justifie pas de la changer.
+- La longueur de chaque "sequence" ne depasse jamais seances_par_semaine (plus court autorise pour une semaine d'affutage/recuperation).
+- consignes_semaine doit couvrir chaque plage de phase.
+- Total : 20 seances uniques maximum.
+
 REGLES DE PROGRAMMATION SPORTIVE :
 
 Echauffement :
@@ -108,10 +133,11 @@ Cooldown :
 - Inclure 30-60s de respiration profonde en fin
 
 Progression :
-- Programme 4 sem : progression lineaire simple (volume ou intensite croissante)
+- Programme 4 sem : progression lineaire simple (volume ou intensite croissante), pas de deload
+- Programme 6 sem : progression lineaire, deload leger possible en semaine 4 si l'intensite est elevee
 - Programme 8 sem : deload semaine 4, reprise avec intensite plus elevee sem 5
 - Programme 12 sem : deload sem 4 et sem 8, 3 phases progressives (decouverte, montee en puissance, performance)
-- Deload = semaine de recuperation : reduire le nombre de series de 40% et l'effort de 20%, garder les memes exercices
+- Deload = semaine de recuperation : reduire le nombre de series de 40% et l'effort de 20%, garder les memes exercices (mode "repete"), ou une plage de calendrier a sequence plus courte (mode "phase")
 
 Logique par objectif :
 - Perte de poids : predominance circuits/HIIT, 2-3 blocs cardio par seance, repos courts (15-30s), inclure du renfo pour preserver la masse musculaire
@@ -163,13 +189,14 @@ INTERDICTIONS :
 - Pas de references a des poids specifiques en kg (utiliser "charge moderee" ou "charge lourde")
 - Pas de jargon technique (voir section LANGAGE)
 - Ne jamais depasser la duree demandee par seance (tolerance ±3 min)
-- Ne jamais proposer plus de sessions uniques que le nombre de seances/semaine demande
+- Ne jamais mettre plus de seances dans une meme semaine (longueur de "sequence") que seances_par_semaine
 
 EXEMPLE MINI-PROGRAMME (4 sem, 2 seances/sem, 30 min) :
 {
   "titre": "Debutant Full Body",
   "description": "Programme progressif pour reprendre le sport en douceur.",
   "niveau": "debutant",
+  "structure": "repete",
   "note_coach": "Bienvenue ! Ce programme est concu pour toi qui reprends le sport. On va y aller progressivement : les 2 premieres semaines servent a poser les bases et apprendre les mouvements. Semaines 3-4, on augmente un peu le volume. Ecoute ton corps et n'hesite pas a adapter.",
   "progression": {
     "logique": "Progression lineaire en volume : +1 serie par exercice toutes les 2 semaines.",
@@ -231,9 +258,30 @@ EXEMPLE MINI-PROGRAMME (4 sem, 2 seances/sem, 30 min) :
   }
 }
 
+EXEMPLE DE STRUCTURE "phase" (forme uniquement — chaque Session garde le meme format complet que ci-dessus, avec warmup + blocs + cooldown) :
+Cas : prepa physique 6 sem, 3 seances/sem, echeance sportive.
+{
+  "titre": "Prepa reprise",
+  "structure": "phase",
+  ...
+  "sessions": {
+    "A1": { ... }, "B1": { ... }, "C1": { ... },
+    "A2": { ... }, "B2": { ... }, "C2": { ... }
+  },
+  "calendrier": [
+    { "semaines": [1, 2, 3], "sequence": ["A1", "B1", "C1"], "nom": "Reprise" },
+    { "semaines": [4, 5, 6], "sequence": ["A2", "B2", "C2"], "nom": "Montee en puissance" }
+  ],
+  "consignes_semaine": {
+    "1-3": "Retrouver les sensations, mouvements propres, effort modere.",
+    "4-6": "Seances plus intenses et explosives pour preparer la reprise."
+  }
+}
+Les seances A2/B2/C2 sont DISTINCTES de A1/B1/C1 (plus intenses, formats de blocs differents), pas de simples copies.
+
 RAPPELS CRITIQUES :
 1. Chaque session DOIT commencer par warmup et finir par cooldown
-2. Le nombre de sessions uniques (A, B, C...) doit etre <= seances_par_semaine
+2. La longueur de chaque "sequence" du calendrier doit etre <= seances_par_semaine (plus court autorise pour l'affutage/deload). Le nombre TOTAL de seances uniques peut le depasser en mode "phase" (max 20)
 3. Le calendrier doit couvrir TOUTES les semaines du programme (1 a duree_semaines)
 4. Chaque ID dans les sequences du calendrier doit exister dans "sessions"
 5. consignes_semaine doit couvrir toutes les semaines avec des plages (ex: "1-2", "3-4")
@@ -295,7 +343,10 @@ const BLESSURE_LABELS: Record<string, string> = {
   'hanche': 'Hanche',
 };
 
-export function buildUserPrompt(input: ProgramInput): string {
+export function buildUserPrompt(
+  input: ProgramInput,
+  imposedStructure?: 'phase',
+): string {
   const parts: string[] = [];
 
   // Objectifs
@@ -372,6 +423,16 @@ export function buildUserPrompt(input: ProgramInput): string {
     for (const w of warnings) {
       parts.push(`- ${w}`);
     }
+  }
+
+  // Deterministic override decided server-side (see classifyStructure in
+  // index.ts): a sport-performance goal on a long-enough program is always
+  // periodised, we don't leave that high-stakes case to the model's judgement.
+  // Any other case falls through to the deduction rules in the system prompt.
+  if (imposedStructure === 'phase') {
+    parts.push('');
+    parts.push('STRUCTURE IMPOSEE : phase');
+    parts.push('→ Genere un programme PHASE : plusieurs phases successives avec des seances DISTINCTES par phase (montee en puissance vers l\'echeance). Indique "structure": "phase".');
   }
 
   parts.push('');

--- a/supabase/functions/generate-program/prompt.ts
+++ b/supabase/functions/generate-program/prompt.ts
@@ -430,6 +430,10 @@ export function buildUserPrompt(
   // periodised, we don't leave that high-stakes case to the model's judgement.
   // Any other case falls through to the deduction rules in the system prompt.
   if (imposedStructure === 'phase') {
+    // The sentinel stays in French for every locale on purpose: the system
+    // prompt is language-agnostic (French, with only an EN output directive
+    // prepended for locale 'en'), and it references this exact French string
+    // in its "QUAND CHOISIR phase" rules. Keep the two in lockstep.
     parts.push('');
     parts.push('STRUCTURE IMPOSEE : phase');
     parts.push('→ Genere un programme PHASE : plusieurs phases successives avec des seances DISTINCTES par phase (montee en puissance vers l\'echeance). Indique "structure": "phase".');

--- a/supabase/functions/generate-program/validate.test.ts
+++ b/supabase/functions/generate-program/validate.test.ts
@@ -85,27 +85,133 @@ describe('validateProgram — sessions count bounds', () => {
     const single = { A: embeddedSession() };
     const result = validateProgram(baseProgram({ sessions: single }), 4, 3);
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('sessions must have 2-5 entries');
+    expect(result.error).toContain('sessions must have 2-20 entries');
   });
 
-  it('rejects more than 5 sessions', () => {
-    const six = Object.fromEntries(
-      ['A', 'B', 'C', 'D', 'E', 'F'].map((k) => [k, embeddedSession({ title: `S ${k}` })]),
-    );
-    const result = validateProgram(baseProgram({ sessions: six }), 4, 6);
+  it('rejects more than 20 sessions', () => {
+    const keys = Array.from({ length: 21 }, (_, i) => `S${i}`);
+    const many = Object.fromEntries(keys.map((k) => [k, embeddedSession({ title: k })]));
+    const result = validateProgram(baseProgram({ sessions: many }), 4, 5);
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('sessions must have 2-5 entries');
+    expect(result.error).toContain('sessions must have 2-20 entries');
   });
 
-  it('rejects more sessions than maxSessionsPerWeek allows', () => {
-    const four = Object.fromEntries(['A', 'B', 'C', 'D'].map((k) => [k, embeddedSession({ title: `S ${k}` })]));
+  it('accepts more unique sessions than seances_par_semaine (phased programs)', () => {
+    // 6 unique sessions with only 3 sessions/week — the old cap rejected this,
+    // it is exactly what periodisation needs.
+    const six = Object.fromEntries(
+      ['A1', 'B1', 'C1', 'A2', 'B2', 'C2'].map((k) => [k, embeddedSession({ title: k })]),
+    );
     const result = validateProgram(
-      baseProgram({ sessions: four, calendrier: [{ semaines: [1, 2, 3, 4], sequence: ['A', 'B', 'C', 'D'] }] }),
+      baseProgram({
+        sessions: six,
+        calendrier: [
+          { semaines: [1, 2], sequence: ['A1', 'B1', 'C1'] },
+          { semaines: [3, 4], sequence: ['A2', 'B2', 'C2'] },
+        ],
+      }),
       4,
       3,
     );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateProgram — phased periodisation', () => {
+  function phasedProgram(overrides: Record<string, unknown> = {}) {
+    const sessions = Object.fromEntries(
+      ['A1', 'B1', 'C1', 'A2', 'B2', 'C2'].map((k) => [k, embeddedSession({ title: k })]),
+    );
+    return baseProgram({
+      structure: 'phase',
+      sessions,
+      calendrier: [
+        { semaines: [1, 2, 3, 4], sequence: ['A1', 'B1', 'C1'], nom: 'Base' },
+        { semaines: [5, 6, 7, 8], sequence: ['A2', 'B2', 'C2'], nom: 'Développement' },
+      ],
+      consignes_semaine: { '1-4': 'Phase de base', '5-8': 'Montée en intensité' },
+      ...overrides,
+    });
+  }
+
+  it('accepts an 8-week, 2-phase program', () => {
+    expect(validateProgram(phasedProgram(), 8, 3).valid).toBe(true);
+  });
+
+  it('accepts a deload week with a shorter sequence than seances_par_semaine', () => {
+    const result = validateProgram(
+      phasedProgram({
+        calendrier: [
+          { semaines: [1, 2, 3], sequence: ['A1', 'B1', 'C1'] },
+          { semaines: [4], sequence: ['A1'], nom: 'Récupération' },
+          { semaines: [5, 6, 7, 8], sequence: ['A2', 'B2', 'C2'] },
+        ],
+      }),
+      8,
+      3,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a sequence longer than seances_par_semaine', () => {
+    const result = validateProgram(baseProgram(), 4, 1); // baseProgram sequence = ['A','B']
     expect(result.valid).toBe(false);
     expect(result.error).toContain('exceeds seances_par_semaine');
+  });
+
+  it('rejects overlapping week ranges between two entries', () => {
+    const result = validateProgram(
+      phasedProgram({
+        calendrier: [
+          { semaines: [1, 2, 3, 4], sequence: ['A1', 'B1', 'C1'] },
+          { semaines: [4, 5, 6, 7, 8], sequence: ['A2', 'B2', 'C2'] }, // week 4 twice
+        ],
+      }),
+      8,
+      3,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('week 4 covered by multiple entries');
+  });
+
+  it('rejects consignes that miss a phase', () => {
+    const result = validateProgram(
+      phasedProgram({ consignes_semaine: { '1-4': 'Phase de base' } }), // 5-8 missing
+      8,
+      3,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('week 5 not covered');
+  });
+
+  it('sanitizes phase labels (nom) on calendrier entries', () => {
+    const program = phasedProgram({
+      calendrier: [
+        { semaines: [1, 2, 3, 4], sequence: ['A1', 'B1', 'C1'], nom: 'Base <script>x</script>' },
+        { semaines: [5, 6, 7, 8], sequence: ['A2', 'B2', 'C2'], nom: 'Pic https://x.y' },
+      ],
+    });
+    const result = validateProgram(program, 8, 3);
+    expect(result.valid).toBe(true);
+    const cal = (program as Record<string, unknown>).calendrier as { nom: string }[];
+    expect(cal[0].nom).toBe('Base x');
+    expect(cal[1].nom).toBe('Pic ');
+  });
+});
+
+describe('validateProgram — structure tag', () => {
+  it('accepts a valid structure value', () => {
+    expect(validateProgram(baseProgram({ structure: 'repete' }), 4, 3).valid).toBe(true);
+  });
+
+  it('accepts an absent structure (backward compat)', () => {
+    expect(validateProgram(baseProgram(), 4, 3).valid).toBe(true);
+  });
+
+  it('rejects an invalid structure value', () => {
+    const result = validateProgram(baseProgram({ structure: 'linear' }), 4, 3);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('structure must be');
   });
 });
 
@@ -194,14 +300,14 @@ describe('validateProgram — sanitization', () => {
   it('sanitizes progression.logique and consignes_semaine values', () => {
     const program = baseProgram({
       progression: { logique: 'On augmente <b>lourd</b> via https://x.y' },
-      consignes_semaine: { '1': 'Attention <script>x</script>' },
+      consignes_semaine: { '1-4': 'Attention <script>x</script>' },
     });
     const result = validateProgram(program, 4, 3);
     expect(result.valid).toBe(true);
     const progression = (program as Record<string, unknown>).progression as Record<string, unknown>;
     expect(progression.logique).toBe('On augmente lourd via ');
     const consignes = (program as Record<string, unknown>).consignes_semaine as Record<string, string>;
-    expect(consignes['1']).toBe('Attention x');
+    expect(consignes['1-4']).toBe('Attention x');
   });
 
   it('sanitizes the optional progression.cible_semaine_X fields', () => {

--- a/supabase/functions/generate-program/validate.test.ts
+++ b/supabase/functions/generate-program/validate.test.ts
@@ -199,6 +199,36 @@ describe('validateProgram — phased periodisation', () => {
   });
 });
 
+describe('validateProgram — consigne key parsing', () => {
+  it('accepts a comma-list consigne key ("1,2,3,4")', () => {
+    const result = validateProgram(
+      baseProgram({ consignes_semaine: { '1,2,3,4': 'Tout au long' } }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a mix of range and single-week keys', () => {
+    const result = validateProgram(
+      baseProgram({ consignes_semaine: { '1-2': 'Debut', '3': 'Milieu', '4': 'Fin' } }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('treats an inverted range ("4-1") as covering nothing', () => {
+    const result = validateProgram(
+      baseProgram({ consignes_semaine: { '4-1': 'Range inverse' } }),
+      4,
+      3,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('week 1 not covered');
+  });
+});
+
 describe('validateProgram — structure tag', () => {
   it('accepts a valid structure value', () => {
     expect(validateProgram(baseProgram({ structure: 'repete' }), 4, 3).valid).toBe(true);

--- a/supabase/functions/generate-program/validate.ts
+++ b/supabase/functions/generate-program/validate.ts
@@ -232,6 +232,32 @@ export function validateSession(data: unknown): ValidationResult {
 interface CalendrierEntry {
   semaines: number[];
   sequence: string[];
+  /** Optional phase label (e.g. "Reprise", "Pic") — UI only, sanitized. */
+  nom?: string;
+}
+
+/**
+ * Expand a consigne key into the week numbers it covers. Handles the formats
+ * the model is instructed to emit: "3" (single), "1-4" (range), "1,2,3" (list),
+ * and combinations. Unparseable fragments are skipped (they simply don't
+ * contribute coverage, which surfaces as a "week N not covered" error rather
+ * than a false pass).
+ */
+function weeksFromConsigneKey(key: string): number[] {
+  const weeks: number[] = [];
+  for (const part of key.split(',')) {
+    const bounds = part.trim().split('-');
+    if (bounds.length === 2) {
+      const start = Number.parseInt(bounds[0], 10);
+      const end = Number.parseInt(bounds[1], 10);
+      if (Number.isNaN(start) || Number.isNaN(end)) continue;
+      for (let w = start; w <= end; w++) weeks.push(w);
+    } else {
+      const n = Number.parseInt(part.trim(), 10);
+      if (!Number.isNaN(n)) weeks.push(n);
+    }
+  }
+  return weeks;
 }
 
 export function validateProgram(
@@ -270,10 +296,16 @@ export function validateProgram(
   const sessions = program.sessions as Record<string, unknown>;
   const sessionKeys = Object.keys(sessions);
 
-  if (sessionKeys.length < 2 || sessionKeys.length > 5)
-    return { valid: false, error: `sessions must have 2-5 entries, got ${sessionKeys.length}` };
-  if (sessionKeys.length > maxSessionsPerWeek)
-    return { valid: false, error: `sessions count (${sessionKeys.length}) exceeds seances_par_semaine (${maxSessionsPerWeek})` };
+  // Upper bound raised from 5 to 20 to allow periodised programs: a phased
+  // program declares distinct sessions per phase (A1/B1 phase 1, A2/B2 phase
+  // 2…), so the total unique-session count legitimately exceeds a single
+  // week's session count. Worst realistic case = 4 phases × 5 sessions = 20.
+  // The old `sessionKeys.length > maxSessionsPerWeek` cap is INTENTIONALLY
+  // dropped — it was the exact constraint that forced every week to be
+  // identical. The real per-week limit is enforced on each calendrier
+  // sequence below (sequence.length <= maxSessionsPerWeek).
+  if (sessionKeys.length < 2 || sessionKeys.length > 20)
+    return { valid: false, error: `sessions must have 2-20 entries, got ${sessionKeys.length}` };
 
   // Validate each session
   for (const key of sessionKeys) {
@@ -293,8 +325,21 @@ export function validateProgram(
     if (!isArray(entry.sequence) || entry.sequence.length === 0)
       return { valid: false, error: 'calendrier entry: sequence required' };
 
+    // A week can hold at most `seances_par_semaine` sessions. Fewer is allowed
+    // (deload / taper weeks legitimately run a shorter sequence).
+    if (entry.sequence.length > maxSessionsPerWeek)
+      return {
+        valid: false,
+        error: `calendrier: sequence length (${entry.sequence.length}) exceeds seances_par_semaine (${maxSessionsPerWeek})`,
+      };
+
     for (const week of entry.semaines) {
       if (!isNumber(week)) return { valid: false, error: 'calendrier: semaine must be a number' };
+      // Overlap guard: a week assigned by two entries would insert duplicate
+      // program_sessions rows (index.ts unrolls semaines × sequence), leaving
+      // the player with an undefined week. A Set silently deduped this before.
+      if (coveredWeeks.has(week))
+        return { valid: false, error: `calendrier: week ${week} covered by multiple entries` };
       coveredWeeks.add(week);
     }
 
@@ -326,6 +371,19 @@ export function validateProgram(
       return { valid: false, error: `consignes_semaine["${key}"] must be a string` };
   }
 
+  // Verify the consigne ranges cover every week 1..expectedWeeks. Previously
+  // the keys were opaque strings, so the model could silently skip a phase
+  // (e.g. emit "1-4"/"5-8" for a 12-week program and forget "9-12"), leaving
+  // those weeks without guidance in the UI. More failure-prone with phasing.
+  const consigneWeeks = new Set<number>();
+  for (const key of consigneKeys) {
+    for (const w of weeksFromConsigneKey(key)) consigneWeeks.add(w);
+  }
+  for (let w = 1; w <= expectedWeeks; w++) {
+    if (!consigneWeeks.has(w))
+      return { valid: false, error: `consignes_semaine: week ${w} not covered` };
+  }
+
   // Sanitize top-level strings
   program.titre = sanitizeString(program.titre as string);
   program.description = sanitizeString(program.description as string);
@@ -344,6 +402,19 @@ export function validateProgram(
   // Sanitize consignes_semaine values
   for (const key of consigneKeys) {
     consignes[key] = sanitizeString(consignes[key] as string);
+  }
+
+  // Optional `structure` tag ("repete" | "phase"). Advisory (analytics + UI),
+  // never drives ingestion, but if present it must be one of the two values so
+  // the stored signal stays trustworthy. Absent is fine (older/repeat outputs).
+  if (program.structure !== undefined) {
+    if (program.structure !== 'repete' && program.structure !== 'phase')
+      return { valid: false, error: 'structure must be "repete" or "phase"' };
+  }
+
+  // Sanitize optional phase labels on calendrier entries (UI-facing text).
+  for (const entry of program.calendrier as CalendrierEntry[]) {
+    if (isString(entry.nom)) entry.nom = sanitizeString(entry.nom);
   }
 
   return { valid: true };

--- a/supabase/functions/generate-program/validate.ts
+++ b/supabase/functions/generate-program/validate.ts
@@ -250,7 +250,7 @@ function weeksFromConsigneKey(key: string): number[] {
     if (bounds.length === 2) {
       const start = Number.parseInt(bounds[0], 10);
       const end = Number.parseInt(bounds[1], 10);
-      if (Number.isNaN(start) || Number.isNaN(end)) continue;
+      if (Number.isNaN(start) || Number.isNaN(end) || start > end) continue;
       for (let w = start; w <= end; w++) weeks.push(w);
     } else {
       const n = Number.parseInt(part.trim(), 10);
@@ -280,6 +280,13 @@ export function validateProgram(
   if (!isString(program.niveau)) return { valid: false, error: 'niveau is required' };
   if (!['debutant', 'intermediaire', 'avance'].includes(program.niveau as string))
     return { valid: false, error: 'niveau must be debutant, intermediaire or avance' };
+  // Optional `structure` tag ("repete" | "phase"). Advisory (analytics + UI),
+  // never drives ingestion, but if present it must be one of the two values so
+  // the stored signal stays trustworthy. Absent is fine (older/repeat outputs).
+  // Checked here, before any sanitization mutation, so an invalid value never
+  // leaves the input object half-transformed.
+  if (program.structure !== undefined && program.structure !== 'repete' && program.structure !== 'phase')
+    return { valid: false, error: 'structure must be "repete" or "phase"' };
   if (!isString(program.note_coach) || (program.note_coach as string).length === 0)
     return { valid: false, error: 'note_coach is required' };
 
@@ -404,15 +411,8 @@ export function validateProgram(
     consignes[key] = sanitizeString(consignes[key] as string);
   }
 
-  // Optional `structure` tag ("repete" | "phase"). Advisory (analytics + UI),
-  // never drives ingestion, but if present it must be one of the two values so
-  // the stored signal stays trustworthy. Absent is fine (older/repeat outputs).
-  if (program.structure !== undefined) {
-    if (program.structure !== 'repete' && program.structure !== 'phase')
-      return { valid: false, error: 'structure must be "repete" or "phase"' };
-  }
-
   // Sanitize optional phase labels on calendrier entries (UI-facing text).
+  // (`structure` validity is checked earlier, before sanitization.)
   for (const entry of program.calendrier as CalendrierEntry[]) {
     if (isString(entry.nom)) entry.nom = sanitizeString(entry.nom);
   }

--- a/supabase/functions/generate-session/index.ts
+++ b/supabase/functions/generate-session/index.ts
@@ -272,6 +272,9 @@ Deno.serve(async (req: Request) => {
         console.error("Parse failure on first attempt — retrying once");
         result = await callAi();
       } else {
+        // Note: a "truncation" error (stop_reason=max_tokens, added to the
+        // shared helper) intentionally does NOT retry here — a re-run under the
+        // same token budget would just truncate again. It surfaces directly.
         throw err;
       }
     }


### PR DESCRIPTION
## Contexte

Le générateur de programmes IA était bridé : il produisait 2-5 séances *templates* répétées à l'identique toutes les semaines. Adapté à la muscu (surcharge progressive), mais incapable de produire une vraie prépa physique avec montée en puissance (reprise → développement → pic → affûtage) — alors que le modèle sait très bien le faire en texte libre.

La cause n'était **pas** le modèle : c'était un verrou de format (`séances uniques ≤ séances/semaine`) présent à 3 endroits (prompt ×2 + validateur). Le stockage, lui, savait déjà gérer des semaines toutes différentes.

## Ce que fait cette PR

Permet des séances **distinctes par phase** (périodisation), sans toucher au stockage/ingestion.

- **prompt** : section STRUCTURE (`repete` vs `phase`), nomenclature `A1/B1` par phase, exemple phasé, champ `structure` en sortie + `nom` de phase. Les 2 règles de bridage supprimées.
- **validate** : plafond séances 5→20, verrou par-semaine retiré, contrainte réelle `sequence ≤ séances/semaine` par phase, + garde-fous **chevauchement de semaines** et **couverture des consignes** (trous silencieux comblés).
- **index** : `classifyStructure` déterministe (`performance_sportive` + `≥ 6 sem` → phasé, sinon déduction LLM), `MAX_TOKENS` 12288→20480, timeout retry 30s→90s, logs orphelines/conformité.
- **anthropic** : détection de troncature via `stop_reason` (nouveau kind `truncation`, non-retry aveugle) — bénéficie aussi à `generate-session`.
- **6 semaines** ajoutées à l'enum de durée (type, edge, UI 2×2, i18n).
- Hint `objectif_detail` (FR+EN) incitant à mentionner une échéance.

## Décisions de conception

- **Déduction hybride, pas de coche technique** : le cas sport à enjeu est forcé côté backend (déterministe, haute confiance) ; le reste est déduit par le LLM. « Répété vs phasé » n'est jamais exposé à l'utilisateur (choix d'expert).
- `structure` émis en sortie : vérifié si imposé, logué sinon → mesure de dérive.

## Validation

- ✅ 509 tests (dont 32 sur `validate.ts`, +11 nouveaux : phasé, deload, chevauchement, couverture consignes, parsing clés, structure)
- ✅ lint biome, i18n (3490 clés alignées), build (`tsc -b` + vite + prerender 153 routes)
- ⚠️ L'edge Deno n'est pas type-checkable localement (pas de `deno`) → vérifié par la CI
- ⚠️ Recette end-to-end du mode phasé = fonction déployée + compte premium + clé Anthropic requis (pas faisable en local)

## Relecture

Conçu et durci via plusieurs agents de relecture indépendants (backend/intégrité, fiabilité LLM, validation/edge, review qualité). Findings CRITICAL/WARNING adressés dans le 2ᵉ commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)